### PR TITLE
fix: tuple-wrap subscript star-unpacking for Python 3.10 compatibility

### DIFF
--- a/src/sweep/receivers/base.py
+++ b/src/sweep/receivers/base.py
@@ -3,4 +3,4 @@ class ReceiverBase:
         pass
 
     def forward(self, wavefield):
-        return wavefield[self.bidx, :, *self.coords_r]
+        return wavefield[(self.bidx, slice(None), *self.coords_r)]

--- a/src/sweep/sources/jax.py
+++ b/src/sweep/sources/jax.py
@@ -23,7 +23,7 @@ class SourceJax(SourceBase):
         #     self.mask = self.mask.at[index, 0,  *jax.numpy.flip(coords, [-1])[i]].set(1.)
     
     def forward_source_encoding(self, wavefield, wavelet):
-        wavefield = wavefield.at[..., *self.coords_r].add(wavelet)
+        wavefield = wavefield.at[(..., *self.coords_r)].add(wavelet)
         return wavefield
     
     def forward_adjoint_modeling(self, wavefield, wavelet):
@@ -39,7 +39,7 @@ class SourceJax(SourceBase):
         if self.adj:
             shots = jnp.repeat(shots, self.coords.shape[1])
             wavelet = wavelet.reshape(-1)
-        wavefield = wavefield.at[shots, 0, *self.coords_r].add(wavelet)
+        wavefield = wavefield.at[(shots, 0, *self.coords_r)].add(wavelet)
         return wavefield
 
     def __call__(self, *args):


### PR DESCRIPTION
PEP 646's `arr[a, :, *b]` syntax requires Python 3.11+, causing a SyntaxError on import under Python 3.10. Wrap the subscript explicitly as `arr[(a, slice(None), *b)]` so it parses as a PEP 448 tuple-display; semantics are unchanged since CPython already constructs a tuple for comma-separated subscripts.

Same fix applied to two starred-subscript uses in sweep.sources.jax. Mirrors the form already used in sweep.receivers.torch.

Fixes #1