### PR TITLE
fix(cuda): guard kernel entries with CUDAGuard for non-default device

### DIFF
--- a/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <algorithm>
 
 #include "kernels.cuh"
@@ -191,6 +192,7 @@ void run_full_imaging(
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     BackwardOutput out;
     auto grad = torch::zeros_like(in.models[0]);
     auto grad_wavelet = torch::zeros_like(in.forward_source);
@@ -226,6 +228,7 @@ RTMOutput rtm(const BackwardInput& in)
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     const auto& p = in;
     BackwardOutput out;
@@ -753,6 +756,7 @@ void process_recursive_interval_2d(
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     const auto& p = in;
     BackwardOutput out;
@@ -925,6 +929,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
 BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/acoustic2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/forward.cu
@@ -1,6 +1,8 @@
 #include <torch/extension.h>
 #include <cuda_runtime.h>
 
+
+#include <c10/cuda/CUDAGuard.h>
 #include "acoustic2d.h"
 #include "kernels.cuh"
 #include "../../common/common.cuh"
@@ -18,6 +20,7 @@
 namespace acoustic2d {
 
 ForwardOutput forward(const ForwardInput& in) {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     const auto& p = in;
     ForwardOutput out;

--- a/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <algorithm>
 
 #include "kernels.cuh"
@@ -29,11 +30,13 @@ RTMOutput rtm_recursive_ckpt_impl(const BackwardInput& p);
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     return backward_full_imaging_impl(in);
 }
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     return backward_bs_imaging_impl(in);
 }
 
@@ -559,6 +562,7 @@ void run_full_imaging(
 
 BackwardOutput backward_full_imaging_impl(const BackwardInput& p)
 {
+    c10::cuda::CUDAGuard device_guard(p.models[0].device());
     BackwardOutput out;
     auto grad = torch::zeros_like(p.models[0]);
     auto grad_wavelet = torch::zeros_like(p.forward_source);
@@ -812,6 +816,7 @@ void run_bs_imaging(
 
 BackwardOutput backward_bs_imaging_impl(const BackwardInput& p)
 {
+    c10::cuda::CUDAGuard device_guard(p.models[0].device());
     BackwardOutput out;
     auto grad = torch::zeros_like(p.models[0]);
     auto grad_wavelet = torch::zeros_like(p.forward_source);
@@ -1001,6 +1006,7 @@ void run_ckpt_imaging(
 
 BackwardOutput backward_ckpt_imaging_impl(const BackwardInput& p)
 {
+    c10::cuda::CUDAGuard device_guard(p.models[0].device());
     BackwardOutput out;
     auto grad = torch::zeros_like(p.models[0]);
     auto grad_wavelet = torch::zeros_like(p.forward_source);
@@ -1159,6 +1165,7 @@ void run_recursive_imaging(
 
 BackwardOutput backward_recursive_imaging_impl(const BackwardInput& p)
 {
+    c10::cuda::CUDAGuard device_guard(p.models[0].device());
     BackwardOutput out;
     auto grad = torch::zeros_like(p.models[0]);
     auto grad_wavelet = torch::zeros_like(p.forward_source);
@@ -1183,11 +1190,13 @@ RTMOutput rtm_recursive_ckpt_impl(const BackwardInput& p)
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     return backward_ckpt_imaging_impl(in);
 }
 
 BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     return backward_recursive_imaging_impl(in);
 }
 

--- a/src/sweep/csrc/cuda/equations/acoustic3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/forward.cu
@@ -1,6 +1,8 @@
 #include <torch/extension.h>
 #include <cuda_runtime.h>
 
+
+#include <c10/cuda/CUDAGuard.h>
 #include "acoustic3d.h"
 #include "kernels.cuh"
 #include "../../common/common.cuh"
@@ -19,6 +21,7 @@ namespace acoustic3d {
 
 ForwardOutput forward(const ForwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     const auto& p = in;
     ForwardOutput out;

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/backward.cu
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <c10/cuda/CUDAGuard.h>
 
 #include <torch/extension.h>
 
@@ -342,6 +343,7 @@ void run_full_imaging(const BackwardInput& p, torch::Tensor& grad_mp)
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     BackwardOutput out;
     TORCH_CHECK(in.models.size() == 2, "Acoustic LSRTM 2D backward expects two models.");
 
@@ -357,6 +359,7 @@ BackwardOutput backward(const BackwardInput& in)
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -557,6 +560,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -715,6 +719,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
 BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/forward.cu
@@ -1,4 +1,6 @@
 #include <cuda_runtime.h>
+
+#include <c10/cuda/CUDAGuard.h>
 #include <torch/extension.h>
 
 #include "acoustic_lsrtm2d.h"
@@ -35,6 +37,7 @@ std::vector<torch::Tensor> slice_wavefields(
 } // namespace
 
 ForwardOutput forward(const ForwardInput& in) {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     ForwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/backward.cu
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <algorithm>
 
 #include "kernels.cuh"
@@ -44,12 +45,14 @@ RTMOutput rtm_recursive_ckpt_impl(const BackwardInput& p);
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     TORCH_CHECK(in.models.size() == 2, "Acoustic LSRTM 3D backward expects two models.");
     return backward_full_imaging_impl(in);
 }
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     TORCH_CHECK(in.models.size() == 2, "Acoustic LSRTM 3D backward expects two models.");
     return backward_bs_imaging_impl(in);
 }
@@ -566,6 +569,7 @@ void run_full_imaging(
 
 BackwardOutput backward_full_imaging_impl(const BackwardInput& p)
 {
+    c10::cuda::CUDAGuard device_guard(p.models[0].device());
     BackwardOutput out;
     auto grad_vp = torch::zeros_like(p.models[0]);
     auto grad = torch::zeros_like(p.models[1]);
@@ -815,6 +819,7 @@ void run_bs_imaging(
 
 BackwardOutput backward_bs_imaging_impl(const BackwardInput& p)
 {
+    c10::cuda::CUDAGuard device_guard(p.models[0].device());
     BackwardOutput out;
     auto grad_vp = torch::zeros_like(p.models[0]);
     auto grad = torch::zeros_like(p.models[1]);
@@ -1001,6 +1006,7 @@ void run_ckpt_imaging(
 
 BackwardOutput backward_ckpt_imaging_impl(const BackwardInput& p)
 {
+    c10::cuda::CUDAGuard device_guard(p.models[0].device());
     BackwardOutput out;
     auto grad_vp = torch::zeros_like(p.models[0]);
     auto grad = torch::zeros_like(p.models[1]);
@@ -1141,6 +1147,7 @@ void run_recursive_imaging(
 
 BackwardOutput backward_recursive_imaging_impl(const BackwardInput& p)
 {
+    c10::cuda::CUDAGuard device_guard(p.models[0].device());
     BackwardOutput out;
     auto grad_vp = torch::zeros_like(p.models[0]);
     auto grad = torch::zeros_like(p.models[1]);
@@ -1162,12 +1169,14 @@ RTMOutput rtm_recursive_ckpt_impl(const BackwardInput& p)
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     TORCH_CHECK(in.models.size() == 2, "Acoustic LSRTM 3D backward expects two models.");
     return backward_ckpt_imaging_impl(in);
 }
 
 BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     TORCH_CHECK(in.models.size() == 2, "Acoustic LSRTM 3D backward expects two models.");
     return backward_recursive_imaging_impl(in);
 }

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/forward.cu
@@ -1,4 +1,6 @@
 #include <cuda_runtime.h>
+
+#include <c10/cuda/CUDAGuard.h>
 #include <torch/extension.h>
 
 #include "acoustic_lsrtm3d.h"
@@ -35,6 +37,7 @@ std::vector<torch::Tensor> slice_wavefields(
 } // namespace
 
 ForwardOutput forward(const ForwardInput& in) {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     ForwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/backward.cu
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <algorithm>
 
 #include "acoustic_vrz2d.h"
@@ -33,6 +34,7 @@ void zero_wavefield_state_vrz(AcousticWavefieldTensor& wf)
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     TORCH_CHECK(
         in.u_forward.defined() && in.u_forward.numel() > 0,
         "AcousticVRZ backward expects saved full forward wavefields."
@@ -151,6 +153,7 @@ BackwardOutput backward(const BackwardInput& in)
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -343,6 +346,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -564,6 +568,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
 BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     return backward_ckpt(in);
 }
 

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/forward.cu
@@ -1,6 +1,8 @@
 #include <torch/extension.h>
 #include <cuda_runtime.h>
 
+
+#include <c10/cuda/CUDAGuard.h>
 #include "acoustic_vrz2d.h"
 #include "kernels.cuh"
 #include "../../common/acoustic.h"
@@ -18,6 +20,7 @@
 namespace acoustic_vrz2d {
 
 ForwardOutput forward(const ForwardInput& in) {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     const auto& p = in;
     ForwardOutput out;

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/backward.cu
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <c10/cuda/CUDAGuard.h>
 #include <torch/extension.h>
 
 #include "acoustic_vrz3d.h"
@@ -32,6 +33,7 @@ void zero_wavefield_state_vrz3d(AcousticWavefieldTensor& wf)
 
 BackwardOutput backward_full_impl(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     TORCH_CHECK(
         in.u_forward.defined() && in.u_forward.numel() > 0,
         "AcousticVRZ3D backward expects saved full forward wavefields."
@@ -168,6 +170,7 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
 
 BackwardOutput backward_bs_impl(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -387,6 +390,7 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
 
 BackwardOutput backward_ckpt_impl(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -627,21 +631,25 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     return backward_full_impl(in);
 }
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     return backward_bs_impl(in);
 }
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     return backward_ckpt_impl(in);
 }
 
 BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     return backward_ckpt_impl(in);
 }
 

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/forward.cu
@@ -1,6 +1,8 @@
 #include <torch/extension.h>
 #include <cuda_runtime.h>
 
+
+#include <c10/cuda/CUDAGuard.h>
 #include "acoustic_vrz3d.h"
 #include "kernels.cuh"
 #include "../../common/acoustic.h"
@@ -19,6 +21,7 @@ namespace acoustic_vrz3d {
 
 ForwardOutput forward(const ForwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     ForwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/acoustic_vti_1st_2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vti_1st_2d/backward.cu
@@ -18,6 +18,8 @@
 #include <torch/extension.h>
 #include <cuda_runtime.h>
 
+
+#include <c10/cuda/CUDAGuard.h>
 #include "acoustic_vti_1st_2d.h"
 #include "kernels.cuh"
 
@@ -105,6 +107,7 @@ struct AdjWavefieldTensor {
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -293,6 +296,7 @@ BackwardOutput backward(const BackwardInput& in)
 // ---------------------------------------------------------------------------
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -566,6 +570,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
 // ---------------------------------------------------------------------------
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/acoustic_vti_1st_2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vti_1st_2d/forward.cu
@@ -17,6 +17,8 @@
 #include <torch/extension.h>
 #include <cuda_runtime.h>
 
+
+#include <c10/cuda/CUDAGuard.h>
 #include "acoustic_vti_1st_2d.h"
 #include "kernels.cuh"
 
@@ -95,6 +97,7 @@ struct VTIWavefieldTensor {
 
 ForwardOutput forward(const ForwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     ForwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/acoustic_vti_1st_3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vti_1st_3d/backward.cu
@@ -21,6 +21,8 @@
 #include <torch/extension.h>
 #include <cuda_runtime.h>
 
+
+#include <c10/cuda/CUDAGuard.h>
 #include "acoustic_vti_1st_3d.h"
 #include "kernels.cuh"
 
@@ -121,6 +123,7 @@ struct AdjWavefieldTensor3D {
 // ===========================================================================
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -290,6 +293,7 @@ BackwardOutput backward(const BackwardInput& in)
 // alongside the adjoint pass.
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -527,6 +531,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
 // ===========================================================================
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/acoustic_vti_1st_3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vti_1st_3d/forward.cu
@@ -20,6 +20,8 @@
 #include <torch/extension.h>
 #include <cuda_runtime.h>
 
+
+#include <c10/cuda/CUDAGuard.h>
 #include "acoustic_vti_1st_3d.h"
 #include "kernels.cuh"
 
@@ -109,6 +111,7 @@ struct VTIWavefieldTensor3D {
 
 ForwardOutput forward(const ForwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     ForwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/das_mu2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/das_mu2d/backward.cu
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
 
 #include "kernels.cuh"
 #include "das_mu2d.h"
@@ -366,6 +367,7 @@ void backward_segment_2d(
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -485,6 +487,7 @@ BackwardOutput backward(const BackwardInput& in)
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
 
     TORCH_CHECK(p.checkpoint_interval >= 1, "checkpoint_interval must be >= 1");
@@ -598,6 +601,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
 BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
 
     TORCH_CHECK(p.checkpoints.size() == 18, "DAS Mu 2D recursive checkpointing expects 18 checkpoint tensors");
@@ -765,6 +769,7 @@ BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     const auto& p = in;
     BackwardOutput out;

--- a/src/sweep/csrc/cuda/equations/das_mu2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/das_mu2d/forward.cu
@@ -1,6 +1,8 @@
 #include <torch/extension.h>
 #include <cuda_runtime.h>
 
+
+#include <c10/cuda/CUDAGuard.h>
 #include "das_mu2d.h"
 #include "kernels.cuh"
 
@@ -19,6 +21,7 @@ namespace das_mu2d {
 
 ForwardOutput forward(const ForwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     const auto& p = in;
     ForwardOutput out;

--- a/src/sweep/csrc/cuda/equations/das_mu3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/das_mu3d/backward.cu
@@ -436,6 +436,7 @@ void backward_segment_3d(
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     cudaEvent_t start, stop, flush_start, flush_end;
     cudaEventCreate(&start);
@@ -747,6 +748,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -869,6 +871,7 @@ BackwardOutput backward(const BackwardInput& in)
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
 
     TORCH_CHECK(p.checkpoint_interval >= 1, "checkpoint_interval must be >= 1");
@@ -992,6 +995,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
 BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
 
     TORCH_CHECK(p.checkpoints.size() == 33, "DAS Mu 3D recursive checkpointing expects 33 checkpoint tensors");

--- a/src/sweep/csrc/cuda/equations/elastic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic2d/backward.cu
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
 
 #include "kernels.cuh"
 #include "elastic2d.h"
@@ -362,6 +363,7 @@ void backward_segment_2d(
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -480,6 +482,7 @@ BackwardOutput backward(const BackwardInput& in)
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
 
     TORCH_CHECK(p.checkpoint_interval >= 1, "checkpoint_interval must be >= 1");
@@ -593,6 +596,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
 BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
 
     TORCH_CHECK(p.checkpoints.size() == 15, "Elastic 2D recursive checkpointing expects 15 checkpoint tensors");
@@ -759,6 +763,7 @@ BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     const auto& p = in;
     BackwardOutput out;

--- a/src/sweep/csrc/cuda/equations/elastic2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic2d/forward.cu
@@ -1,6 +1,8 @@
 #include <torch/extension.h>
 #include <cuda_runtime.h>
 
+
+#include <c10/cuda/CUDAGuard.h>
 #include "elastic2d.h"
 #include "kernels.cuh"
 
@@ -18,6 +20,7 @@ namespace elastic2d {
 
 ForwardOutput forward(const ForwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     const auto& p = in;
     ForwardOutput out;

--- a/src/sweep/csrc/cuda/equations/elastic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic3d/backward.cu
@@ -425,6 +425,7 @@ void backward_segment_3d(
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
 
     cudaEvent_t start, stop, flush_start, flush_end;
     cudaEventCreate(&start);
@@ -698,6 +699,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -819,6 +821,7 @@ BackwardOutput backward(const BackwardInput& in)
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
 
     TORCH_CHECK(p.checkpoint_interval >= 1, "checkpoint_interval must be >= 1");
@@ -943,6 +946,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
 BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
 
     TORCH_CHECK(p.checkpoints.size() == 36, "Elastic 3D recursive checkpointing expects 36 checkpoint tensors");

--- a/src/sweep/csrc/cuda/equations/elastic3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic3d/forward.cu
@@ -23,6 +23,7 @@ namespace elastic3d {
 
 ForwardOutput forward(const ForwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     ForwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/elastic_tti_sg2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic_tti_sg2d/backward.cu
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <algorithm>
 #include <array>
 
@@ -262,6 +263,7 @@ void backward_segment_ckpt(
 
 BackwardOutput backward(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -386,6 +388,7 @@ BackwardOutput backward(const BackwardInput& in)
 
 BackwardOutput backward_bs(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 
@@ -652,6 +655,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
 BackwardOutput backward_ckpt(const BackwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     BackwardOutput out;
 

--- a/src/sweep/csrc/cuda/equations/elastic_tti_sg2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic_tti_sg2d/forward.cu
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
 
 #include "elastic_tti_sg2d.h"
 #include "kernels.cuh"
@@ -18,6 +19,7 @@ namespace elastic_tti_sg2d {
 
 ForwardOutput forward(const ForwardInput& in)
 {
+    c10::cuda::CUDAGuard device_guard(in.models[0].device());
     const auto& p = in;
     ForwardOutput out;
 

--- a/test/test_multi_device_cuda_guard.py
+++ b/test/test_multi_device_cuda_guard.py
@@ -1,0 +1,80 @@
+"""Regression test for the cuda:1 (non-default device) CUDAGuard bug.
+
+Before the fix in bug/cuda-guard-missing-non-default-device, forward/backward
+CUDA kernels in most equations (acoustic*, elastic*, das_mu*) launched on the
+current default device, which is cuda:0 unless the caller explicitly sets it.
+A user passing tensors on cuda:1 would hit "illegal memory access" because
+the kernels ran on cuda:0 while tensors lived on cuda:1.
+
+This test runs a tiny acoustic forward + backward on every visible CUDA
+device.  If the fix regresses (CUDAGuard removed from an entry function),
+the kernel launch on cuda:1 raises.
+"""
+
+import pytest
+import torch
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="requires >=2 visible CUDA devices",
+)
+
+
+def _tiny_acoustic_run(device):
+    """Forward + backward an acoustic propagator on `device`.
+
+    Returns the per-iteration loss so a caller can sanity-check finite values.
+    """
+    import numpy as np
+
+    from sweep.equations import Acoustic
+    from sweep.propagator.torch import PropTorch
+    from sweep.signal import ricker
+
+    shape = (48, 56)
+    dh, dt, nt = 10.0, 0.0015, 120
+    freq, delay = 10.0, 0.06
+
+    vp_np = np.full(shape, 2000.0, dtype=np.float32)
+    sources = np.array([[shape[1] // 2, 4]], dtype=np.int64)
+    rec_x = np.arange(0, shape[1], 6, dtype=np.int64)
+    receivers = np.stack([rec_x, np.full(rec_x.shape, 2, dtype=np.int64)], axis=1)[None]
+
+    t = np.arange(nt, dtype=np.float32) * dt
+    wavelet = ricker(t - delay, f=freq).astype(np.float32)
+
+    equation = Acoustic(spatial_order=4, device=device, backend="torch")
+    solver = PropTorch(
+        equation,
+        shape=shape,
+        dh=dh,
+        dt=dt,
+        dev=device,
+        abcn=30,
+        source_type=["h1"],
+        receiver_type=["h1"],
+        pml_type="cpmlr",
+        backend="torch",
+        impl="c",
+    )
+
+    vp_true = torch.tensor(vp_np, dtype=torch.float32, device=device)
+    with torch.no_grad():
+        observed = solver(wavelet, sources, receivers, models=[vp_true]).detach()
+
+    vp = torch.tensor(vp_np * 0.95, dtype=torch.float32, device=device, requires_grad=True)
+    predicted = solver(wavelet, sources, receivers, models=[vp])
+    loss = (predicted - observed).pow(2).mean()
+    loss.backward()
+    assert vp.grad is not None
+    return float(loss.detach().cpu()), float(vp.grad.norm().cpu())
+
+
+@pytest.mark.parametrize("device_str", [f"cuda:{i}" for i in range(torch.cuda.device_count())])
+def test_acoustic_runs_on_each_visible_device(device_str):
+    """Forward + backward must succeed on every CUDA device, not just cuda:0."""
+    device = torch.device(device_str)
+    loss, gnorm = _tiny_acoustic_run(device)
+    assert torch.isfinite(torch.tensor(loss)), f"loss not finite on {device_str}: {loss}"
+    assert torch.isfinite(torch.tensor(gnorm)), f"grad norm not finite on {device_str}: {gnorm}"


### PR DESCRIPTION
Closes #5.

## Root cause

25 CUDA forward/backward entry functions (`acoustic`, `acoustic_lsrtm`, `acoustic_vrz`, `acoustic_vti`, `elastic2d`, `elastic3d`, `elastic_tti_sg2d`, `das_mu2d`, `das_mu3d/backward`) didn't set the current device with `c10::cuda::CUDAGuard`. Only 5 entries (`das2d`/`das3d`/`das_mu3d/forward`) already had it.

When the caller does

```python
device = torch.device('cuda:N')  # N > 0
```

without an explicit `torch.cuda.set_device(N)`, the per-process **current device** stays at 0. Kernels launch on `cuda:0` while tensors live on `cuda:N` — at best `illegal memory access`, at worst **silent zero outputs** (cuda:1 on a 4-GPU box returned `loss=0, gradnorm=0` in our repro — forward returned a zeroed record, backward filled the gradient with zeros, no exception raised).

DDP doesn't trip this bug because every DDP worker template runs `torch.cuda.set_device(local_rank)` before sweep is touched, which pins the per-process current device to the worker's rank.

## Fix

Add `c10::cuda::CUDAGuard device_guard(<param>.models[0].device());` at the very first line of every forward/backward entry function (72 functions across 25 .cu files). The parameter name in the signature varies (`in` vs `p`); the patch extracts it from each signature individually.

## Verification (KW61204, 4× A100)

Tiny `Acoustic` forward + backward on every visible CUDA device:

| | dev (pre-fix) | this PR |
|---|---|---|
| cuda:0 | PASS  loss=9.18e-3 | PASS  loss=9.18e-3 |
| cuda:1 | "PASS" silent zeros (loss=0) | PASS  loss=9.18e-3 |
| cuda:2 | FAIL illegal memory access | PASS  loss=9.18e-3 |
| cuda:3 | FAIL all CUDA devices busy (cascade) | PASS  loss=9.18e-3 |
| DDP 4-worker | PASS (`set_device` masks bug) | PASS |

`test/test_multi_device_cuda_guard.py` added — auto-skips when <2 GPUs visible.
