### PR TITLE
fix(boundary-saving): widen kernel idx to int64 to avoid byte-offset …

### DIFF
--- a/src/sweep/csrc/cuda/common/boundarysaver.cu
+++ b/src/sweep/csrc/cuda/common/boundarysaver.cu
@@ -1,5 +1,6 @@
 #include "context.h"
 #include "boundary/kernels.cuh"
+#include <cstdint>
 #include <cuda_runtime.h>
 
 __global__ void boundary_kernel2d(
@@ -84,8 +85,8 @@ __global__ void boundary_kernel2d(
         int zloc = iz - top_start;
         int xloc = ix - x_t0;
 
-        int idx =
-            ((it * ctx.B + b) * width + zloc) * nx_boundary + xloc;
+        int64_t idx =
+            ((static_cast<int64_t>(it) * ctx.B + b) * width + zloc) * nx_boundary + xloc;
 
         if (mode == BOUNDARY_SAVE) top[idx] = val;
         else u_b[iz * ctx.nx + ix] = top[idx];
@@ -97,8 +98,8 @@ __global__ void boundary_kernel2d(
         int zloc = iz - bot_start;
         int xloc = ix - x_t0;
 
-        int idx =
-            ((it * ctx.B + b) * width + zloc) * nx_boundary + xloc;
+        int64_t idx =
+            ((static_cast<int64_t>(it) * ctx.B + b) * width + zloc) * nx_boundary + xloc;
 
         if (mode == BOUNDARY_SAVE) bottom[idx] = val;
         else u_b[iz * ctx.nx + ix] = bottom[idx];
@@ -110,8 +111,8 @@ __global__ void boundary_kernel2d(
         int xloc = ix - left_start;
         int zloc = iz - z_t0;
 
-        int idx =
-            ((it * ctx.B + b) * nz_boundary + zloc) * width + xloc;
+        int64_t idx =
+            ((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc) * width + xloc;
 
         if (mode == BOUNDARY_SAVE) left[idx] = val;
         else u_b[iz * ctx.nx + ix] = left[idx];
@@ -123,8 +124,8 @@ __global__ void boundary_kernel2d(
         int xloc = ix - right_start;
         int zloc = iz - z_t0;
 
-        int idx =
-            ((it * ctx.B + b) * nz_boundary + zloc) * width + xloc;
+        int64_t idx =
+            ((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc) * width + xloc;
 
         if (mode == BOUNDARY_SAVE) right[idx] = val;
         else u_b[iz * ctx.nx + ix] = right[idx];
@@ -262,8 +263,8 @@ __global__ void boundary_kernel3d(
         int yloc = iy - y_t0;
         int xloc = ix - x_t0;
 
-        int idx =
-            ((((it * ctx.B + b) * width + zloc)
+        int64_t idx =
+            ((((static_cast<int64_t>(it) * ctx.B + b) * width + zloc)
               * ny_boundary + yloc)
               * nx_boundary + xloc);
 
@@ -283,8 +284,8 @@ __global__ void boundary_kernel3d(
         int yloc = iy - y_t0;
         int xloc = ix - x_t0;
 
-        int idx =
-            ((((it * ctx.B + b) * width + zloc)
+        int64_t idx =
+            ((((static_cast<int64_t>(it) * ctx.B + b) * width + zloc)
               * ny_boundary + yloc)
               * nx_boundary + xloc);
 
@@ -304,8 +305,8 @@ __global__ void boundary_kernel3d(
         int zloc = iz - z_t0;
         int xloc = ix - x_t0;
 
-        int idx =
-            ((((it * ctx.B + b) * nz_boundary + zloc)
+        int64_t idx =
+            ((((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc)
               * width + yloc)
               * nx_boundary + xloc);
 
@@ -325,8 +326,8 @@ __global__ void boundary_kernel3d(
         int zloc = iz - z_t0;
         int xloc = ix - x_t0;
 
-        int idx =
-            ((((it * ctx.B + b) * nz_boundary + zloc)
+        int64_t idx =
+            ((((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc)
               * width + yloc)
               * nx_boundary + xloc);
 
@@ -346,8 +347,8 @@ __global__ void boundary_kernel3d(
         int zloc = iz - z_t0;
         int yloc = iy - y_t0;
 
-        int idx =
-            ((((it * ctx.B + b) * nz_boundary + zloc)
+        int64_t idx =
+            ((((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc)
               * ny_boundary + yloc)
               * width + xloc);
 
@@ -367,8 +368,8 @@ __global__ void boundary_kernel3d(
         int zloc = iz - z_t0;
         int yloc = iy - y_t0;
 
-        int idx =
-            ((((it * ctx.B + b) * nz_boundary + zloc)
+        int64_t idx =
+            ((((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc)
               * ny_boundary + yloc)
               * width + xloc);
 
@@ -442,7 +443,7 @@ __global__ void boundary_kernel3d_compact(
     int ix = 0;
     int iy = 0;
     int iz = 0;
-    int idx = 0;
+    int64_t idx = 0;
     float* boundary = nullptr;
 
     if (local < top_count) {
@@ -454,7 +455,7 @@ __global__ void boundary_kernel3d_compact(
         iz = top_start + zloc;
         iy = y_t0 + yloc;
         ix = x_t0 + xloc;
-        idx = ((((it * ctx.B + b) * width + zloc) * ny_boundary + yloc) * nx_boundary + xloc);
+        idx = ((((static_cast<int64_t>(it) * ctx.B + b) * width + zloc) * ny_boundary + yloc) * nx_boundary + xloc);
         boundary = top;
     } else if (local < 2 * top_count) {
         local -= top_count;
@@ -466,7 +467,7 @@ __global__ void boundary_kernel3d_compact(
         iz = bot_start + zloc;
         iy = y_t0 + yloc;
         ix = x_t0 + xloc;
-        idx = ((((it * ctx.B + b) * width + zloc) * ny_boundary + yloc) * nx_boundary + xloc);
+        idx = ((((static_cast<int64_t>(it) * ctx.B + b) * width + zloc) * ny_boundary + yloc) * nx_boundary + xloc);
         boundary = bottom;
     } else if (local < 2 * top_count + front_count) {
         local -= 2 * top_count;
@@ -478,7 +479,7 @@ __global__ void boundary_kernel3d_compact(
         iz = z_t0 + zloc;
         iy = front_start + yloc;
         ix = x_t0 + xloc;
-        idx = ((((it * ctx.B + b) * nz_boundary + zloc) * width + yloc) * nx_boundary + xloc);
+        idx = ((((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc) * width + yloc) * nx_boundary + xloc);
         boundary = front;
     } else if (local < 2 * top_count + 2 * front_count) {
         local -= 2 * top_count + front_count;
@@ -490,7 +491,7 @@ __global__ void boundary_kernel3d_compact(
         iz = z_t0 + zloc;
         iy = back_start + yloc;
         ix = x_t0 + xloc;
-        idx = ((((it * ctx.B + b) * nz_boundary + zloc) * width + yloc) * nx_boundary + xloc);
+        idx = ((((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc) * width + yloc) * nx_boundary + xloc);
         boundary = back;
     } else if (local < 2 * top_count + 2 * front_count + left_count) {
         local -= 2 * top_count + 2 * front_count;
@@ -502,7 +503,7 @@ __global__ void boundary_kernel3d_compact(
         iz = z_t0 + zloc;
         iy = y_t0 + yloc;
         ix = left_start + xloc;
-        idx = ((((it * ctx.B + b) * nz_boundary + zloc) * ny_boundary + yloc) * width + xloc);
+        idx = ((((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc) * ny_boundary + yloc) * width + xloc);
         boundary = left;
     } else {
         local -= 2 * top_count + 2 * front_count + left_count;
@@ -514,7 +515,7 @@ __global__ void boundary_kernel3d_compact(
         iz = z_t0 + zloc;
         iy = y_t0 + yloc;
         ix = right_start + xloc;
-        idx = ((((it * ctx.B + b) * nz_boundary + zloc) * ny_boundary + yloc) * width + xloc);
+        idx = ((((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc) * ny_boundary + yloc) * width + xloc);
         boundary = right;
     }
 

--- a/test/test_boundary_int_idx_overflow.py
+++ b/test/test_boundary_int_idx_overflow.py
@@ -1,0 +1,95 @@
+"""Regression test for the boundary-saving int idx overflow bug.
+
+Before the fix in bug/boundary-kernel-int-idx-overflow,
+``boundary_kernel3d_compact`` (and ``boundary_kernel3d``) computed the
+boundary-buffer index as ``int``. With ``spatial_order=8`` plus a large enough
+combination of ``nz``/``ny``/``nt``, the byte offset that nvcc emits for
+``boundary[idx]`` (``idx * sizeof(float)``) overflowed int32 and wrapped to a
+large negative value. The kernel then wrote to memory far outside the LEFT /
+RIGHT boundary tensor, surfacing as ``CUDA error: an illegal memory access``
+during the forward pass.
+
+The fix widens ``idx`` to ``int64_t`` and forces 64-bit promotion of the
+``it * ctx.B`` factor that drives the expression, so both intermediate
+arithmetic and the pointer offset stay safe.
+
+This test runs the minimum config that reliably triggered the bug on an A100:
+``(nz=401, ny=383, nx=64), nt=2800, spatial_order=8`` with
+``strategy='boundary'`` and GPU storage. Peak GPU memory is ~23 GiB, so the
+test is skipped on GPUs with less than 32 GiB total.
+"""
+
+import pytest
+import torch
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="requires CUDA",
+)
+
+
+def _device0_total_gib() -> float:
+    return torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or _device0_total_gib() < 32.0,
+    reason="requires >=32 GiB GPU memory",
+)
+def test_boundary_kernel_order8_no_illegal_memory_access():
+    """Forward + backward must complete and produce a finite, non-zero gradient.
+
+    Before the fix, this configuration crashed with
+    ``CUDA error: an illegal memory access was encountered`` during the very
+    first forward time step on order=8.
+    """
+    import numpy as np
+
+    from sweep.equations import Acoustic3D
+    from sweep.propagator.options import BoundaryOptions, CUDAOptions, MemoryOptions
+    from sweep.propagator.torch import PropTorch
+    from sweep.signal import ricker
+
+    dev = torch.device("cuda")
+    nz, ny, nx, nt = 401, 383, 64, 2800
+    dh, dt, freq, delay = 10.0, 1.0e-3, 8.0, 0.12
+
+    vp = torch.full((nz, ny, nx), 2000.0, device=dev).requires_grad_(True)
+    t = np.arange(nt, dtype=np.float32) * dt
+    wavelet = ricker(t - delay, f=freq).astype(np.float32)
+    sources = np.array([[nx // 2, ny // 2, 4]], dtype=np.int64)
+    rec_x = np.linspace(20, nx - 20, 64, dtype=np.int64)
+    rec_y = np.full_like(rec_x, ny // 2)
+    rec_z = np.full_like(rec_x, 6)
+    receivers = np.stack([rec_x, rec_y, rec_z], axis=1)[None, ...]
+
+    equation = Acoustic3D(spatial_order=8, device=dev, backend="torch")
+    solver = PropTorch(
+        equation,
+        shape=(nz, ny, nx),
+        dev=dev,
+        dh=dh,
+        dt=dt,
+        nt=nt,
+        source_type=["h1"],
+        receiver_type=["h1"],
+        abcn=20,
+        free_surface=True,
+        pml_type="cpmlr",
+        backend="cuda",
+        cuda_options=CUDAOptions(
+            memory=MemoryOptions(
+                strategy="boundary",
+                boundary=BoundaryOptions(storage="gpu"),
+            )
+        ),
+    )
+
+    syn = solver(wavelet, sources, receivers, models=[vp])
+    loss = syn.pow(2).mean()
+    loss.backward()
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(vp.grad).all(), "gradient has NaN/inf"
+    assert vp.grad.abs().max().item() > 0.0, "gradient is identically zero"


### PR DESCRIPTION
Fixes #7.

## Summary

`boundary_kernel3d_compact` (and `boundary_kernel3d` / `boundary_kernel2d` in `src/sweep/csrc/cuda/common/boundarysaver.cu`) computed the boundary-buffer index as `int`. With `spatial_order > 4` and a sufficiently large `(nz × ny × nt × save_width)` product, the emitted byte offset (`idx * sizeof(float)`) wrapped past int32, and the kernel wrote ~7 GiB before the LEFT/RIGHT boundary tensor base — surfacing as `CUDA error: an illegal memory access` during the forward pass.

The fix widens `idx` to `int64_t` and forces 64-bit promotion of the `it * ctx.B` factor that drives the expression, so both intermediate arithmetic and pointer-offset multiplication stay safe.

## Root cause

Minimal repro on an A100 (80 GB):

```
spatial_order=8, abcn=20, (nz, ny, nx) = (401, 383, 64), nt=2800,
strategy='boundary', storage='gpu'
→ CUDA error: an illegal memory access
```

`compute-sanitizer` pinpoints writes from `boundary_kernel3d_compact` landing **~7.5 GiB before** the nearest CUDA allocation. The plain index magnitude at the failing config is ~1.75 × 10⁹ (still under int32 max), but `idx * sizeof(float)` overflows int32, wraps to a large negative value, and the pointer addition jumps backward far outside the buffer.

Empirical threshold scan at the minimal-repro config:

| dim | last passing | first failing |
| --- | ------------ | ------------- |
| `nt` | 2795 | 2800 |
| `ny` | 382 | 383 |
| `nz` | 400 | 401 |

`spatial_order ∈ {2, 4, 6}` all pass at the same configuration; `strategy='ckpt'` also passes (different code path, not affected by the index width).

## Fix

`src/sweep/csrc/cuda/common/boundarysaver.cu` (+28 / −27):

- Added `#include <cstdint>`.
- In all three boundary kernels (2D, 3D, 3D-compact): every `int idx` declaration → `int64_t idx`; every `(it * ctx.B + b)` → `(static_cast<int64_t>(it) * ctx.B + b)` so the whole expression promotes to 64-bit.

## Verification

| Test | Result |
| ---- | ------ |
| (401, 383, 64) nt=2800 spatial_order=8 (minimal repro) | ✅ finite grad, peak 23 GiB |
| (401, 383, 64) nt=4001 spatial_order=8 | ✅ peak 32 GiB |
| (401, 383, 383) nt=4001 spatial_order=8 (issue config) | ✅ peak 75 GiB |
| Gradient consistency (boundary vs ckpt) at minimal repro | manual cos = 0.99999897, rel_l2 = 3.7e-3 |
| Sanity at spatial_order=4 (no-regression, bs vs ckpt) | bit-identical, cos = 1.0 |
| `test/solver_gradient_mode_suite.py --modes full,bs_gpu,bs_disk,bs_disk_async,ckpt_chunk,ckpt_recursive` | All 9 fails verified pre-existing on `dev` HEAD (6 × `vrz3d bs_*` + 3 × `vrz2d free_surface full/ckpt`) — none introduced by this fix |
| New regression test `test/test_boundary_int_idx_overflow.py` | ✅ |

## Test plan

- [x] Forward + backward completes on (401, 383, 64) nt=2800 spatial_order=8 with `strategy='boundary'`
- [x] Gradient bit-identical to `strategy='ckpt'` at spatial_order=4 (no regression)
- [x] Gradient consistent with `strategy='ckpt'` at spatial_order=8 (cosine > 0.9999)
- [x] `solver_gradient_mode_suite` no new failures vs. `dev` HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)