### PR TITLE
fix(build): align setup.py/setup_cuda.py with renamed build_ext_kwargs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from build_config import build_setup_kwargs, patch_packaging_compat
+from build_config import build_ext_kwargs, patch_packaging_compat
 
 
 patch_packaging_compat()
 
-setup(**build_setup_kwargs(distribution_name="sweep"))
+setup(**build_ext_kwargs())

--- a/setup_cuda.py
+++ b/setup_cuda.py
@@ -7,10 +7,10 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from build_config import build_setup_kwargs, patch_packaging_compat
+from build_config import build_ext_kwargs, patch_packaging_compat
 
 
 patch_packaging_compat()
 os.environ["SWEEP_BUILD_CUDA"] = "1"
 
-setup(**build_setup_kwargs(distribution_name="sweep-cuda"))
+setup(**build_ext_kwargs(build_cuda=True))


### PR DESCRIPTION
## Summary

- `3f94a52` renamed `build_setup_kwargs(distribution_name=...)` → `build_ext_kwargs(build_cuda=...)` in `build_config.py` but missed the two shim scripts (`setup.py`, `setup_cuda.py`) that import it.
- Every `pip install .` (and `pip install -e .`) since 2026-05-21 dies in the `Getting requirements to build wheel` stage with:
  ```
  ImportError: cannot import name 'build_setup_kwargs' from 'build_config'
  ```
- This PR is a 4-line symmetric fix: `build_setup_kwargs(distribution_name="sweep")` → `build_ext_kwargs()` in `setup.py`; `build_setup_kwargs(distribution_name="sweep-cuda")` → `build_ext_kwargs(build_cuda=True)` in `setup_cuda.py`.

## Test plan

Verified on KW60443 (RTX 6000 Ada sm_89, ifwitorch env: Py 3.12.5 / torch 2.9.1+cu128):

- [x] `pip install .` in a fresh venv (no CUDA): wheel built, `import sweep` works.
- [x] `SWEEP_BUILD_CUDA=1 pip install -v ".[cuda]" --no-build-isolation`: walks past the previously-failing metadata stage and proceeds to actual C++/CUDA compilation.
- [x] Import smoke: `from build_config import build_ext_kwargs; build_ext_kwargs(build_cuda=True)` returns the `sweep._C` `CUDAExtension` with 55 sources.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)