### PR TITLE
fix(build): restore [project] section in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,53 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "sweep-solver"
+version = "0.0.0"
+description = "Seismic Wave Equation Exploration Platform — equations, propagators, operators."
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+authors = [
+    {name = "Shaowen Wang", email = "shaowen.wang@kaust.edu.sa"},
+]
+keywords = ["fwi", "geophysics", "seismic", "wave-equation", "propagator", "cuda", "pytorch", "jax"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Physics",
+]
+dependencies = [
+    "numpy>=1.20",
+    "scipy>=1.7",
+]
+
+[project.optional-dependencies]
+cuda  = ["torch"]
+torch = ["torch"]
+jax   = ["jax", "jaxlib"]
+all   = ["torch", "jax", "jaxlib"]
+
+[project.urls]
+Homepage = "https://github.com/DeepWave-KAUST/sweep"
+Issues   = "https://github.com/DeepWave-KAUST/sweep/issues"
+
+[project.scripts]
+sweep = "sweep.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["sweep*", "geophyai*"]
+exclude = ["sweep.csrc*"]


### PR DESCRIPTION
## Summary

- `3f94a52` (2026-05-21 "docs: notebook gallery + ...") refactored `build_config.py`: dropped the inline `name` / `version` / `extras_require` (`cuda`/`torch`/`jax`/`all`) from `build_setup_kwargs`, with a comment saying these now come from `pyproject.toml`'s `[project]` section — but that section was never added.
- Net effect since `0887476` (2026-05-22, the import-error fix that re-enabled installs): every `pip install .` produced a wheel named `UNKNOWN 0.0.0` and emitted `WARNING: unknown 0.0.0 does not provide the extra 'cuda'`.
- This PR adds the missing `[project]` block (PEP 621). Distribution name is **`sweep-solver`** to align with the sweep-stack naming used in `PUBLISHING.md`. Import name stays `sweep` (controlled by `[tool.setuptools.packages.find]`), so `import sweep` and the `sweep` CLI command are unchanged. Version pinned to `0.0.0` — no PyPI release yet.

Closes #12.

## Test plan

- [x] \`prepare_metadata_for_build_wheel\` produces \`sweep_solver-0.0.0.dist-info\` with \`Name: sweep-solver\`, \`Version: 0.0.0\`, \`Provides-Extra: cuda\` (+ \`torch\` / \`jax\` / \`all\`) on KW60443
- [x] Reporter from #12 confirms \`SWEEP_BUILD_CUDA=1 pip install -v \".[cuda]\" --no-build-isolation\` produces \`sweep-solver 0.0.0\` in \`pip list\` (no \`UNKNOWN\`, no \`does not provide the extra 'cuda'\` warning)
- [x] \`python -c \"import sweep; print(sweep.__file__)\"\` works after install
- [x] \`sweep --help\` (CLI entry-point) works after install

## Notes for users with an older \`sweep\` install

The distribution name change (\`sweep\` → \`sweep-solver\`) means pip treats them as two independent packages. To avoid leftover metadata pointing at the old name:

\`\`\`bash
pip uninstall -y sweep sweep-solver UNKNOWN 2>/dev/null
SWEEP_BUILD_CUDA=1 pip install -v \".[cuda]\" --no-build-isolation
\`\`\`

The import name (\`import sweep\`) and the CLI command (\`sweep\`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)