### PR TITLE
fix(acoustic): proper adjoint for FWI vp gradient

### DIFF
--- a/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
@@ -33,7 +33,8 @@ void accumulate_imaging_2d(
     torch::Tensor* grad,
     RTMOutput* rtm_out,
     int nx,
-    int nz
+    int nz,
+    float dt
 )
 {
     if (grad != nullptr) {
@@ -42,7 +43,7 @@ void accumulate_imaging_2d(
             adjoint_ptr,
             vp.data_ptr<float>(),
             grad->data_ptr<float>(),
-            nx, nz
+            nx, nz, dt
         );
     }
 
@@ -114,6 +115,15 @@ void run_full_imaging(
 
     float* u_thist = nullptr;
 
+    // Buffer for pre-computed v^2 * lambda_now (proper-adjoint kernel input).
+    // Python-side (PropTorch) manages the buffer via adjoint_workspace[0] so
+    // it can be reused across backward calls; fall back to a local alloc when
+    // the caller has not bound one.  compute_v2_lambda_2d overwrites the
+    // full grid every step, so the buffer's initial values do not matter.
+    auto v2_lambda = !p.adjoint_workspace.empty()
+        ? p.adjoint_workspace[0]
+        : torch::empty_like(vp);
+
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 2);
     auto cpml = cpml_tensor.view();
@@ -137,13 +147,21 @@ void run_full_imaging(
 
         auto adj_view = adjoint.view();
 
-        ACOUSTIC2D(
+        // Pre-compute v^2 * lambda_now into the buffer that the adjoint
+        // kernel reads via the laplace stencil.
+        compute_v2_lambda_2d<<<launch_config.grid, launch_config.block>>>(
+            vp.data_ptr<float>(),
+            adj_view.u_now,
+            v2_lambda.data_ptr<float>(),
+            nx, nz, B
+        );
+
+        ACOUSTIC2D_ADJOINT(
             order,
             launch_config.grid,
             launch_config.block,
             adj_view,
-            false,
-            u_thist,
+            v2_lambda.data_ptr<float>(),
             vp.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
@@ -184,7 +202,8 @@ void run_full_imaging(
             grad,
             rtm_out,
             nx,
-            nz
+            nz,
+            dt
         );
     }
 }
@@ -274,6 +293,12 @@ BackwardOutput backward_bs(const BackwardInput& in)
     RTMOutput illumination;
     init_rtm_output_2d(illumination, vp);
 
+    // Buffer for pre-computed v^2 * lambda_now (proper-adjoint kernel input);
+    // Python-managed via adjoint_workspace[0] for reuse across calls.
+    auto v2_lambda = !p.adjoint_workspace.empty()
+        ? p.adjoint_workspace[0]
+        : torch::empty_like(vp);
+
     // For checking wavefields
     // torch::Tensor u_allt = torch::zeros({nt, B, 1, nz, nx}, vp.options());
 
@@ -331,13 +356,19 @@ BackwardOutput backward_bs(const BackwardInput& in)
         // u_allt[it].copy_(forward.u_now_t);
 
         // adjoint modeling
-        ACOUSTIC2D(
+        compute_v2_lambda_2d<<<launch_config.grid, launch_config.block>>>(
+            vp.data_ptr<float>(),
+            adj_view.u_now,
+            v2_lambda.data_ptr<float>(),
+            nx, nz, B
+        );
+
+        ACOUSTIC2D_ADJOINT(
             order,
             launch_config.grid,
             launch_config.block,
             adj_view,
-            false,
-            nullptr,
+            v2_lambda.data_ptr<float>(),
             vp.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
@@ -346,7 +377,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
             cpml,
             ctx
         );
-        
+
         add_source<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
             p.adjoint_source.data_ptr<float>(),
@@ -427,13 +458,19 @@ BackwardOutput backward_bs(const BackwardInput& in)
     if (p.nt > 0) {
         auto adj_view = adjoint.view();
 
-        ACOUSTIC2D(
+        compute_v2_lambda_2d<<<launch_config.grid, launch_config.block>>>(
+            vp.data_ptr<float>(),
+            adj_view.u_now,
+            v2_lambda.data_ptr<float>(),
+            nx, nz, B
+        );
+
+        ACOUSTIC2D_ADJOINT(
             order,
             launch_config.grid,
             launch_config.block,
             adj_view,
-            false,
-            nullptr,
+            v2_lambda.data_ptr<float>(),
             vp.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
@@ -566,6 +603,7 @@ void process_recursive_interval_2d(
     std::vector<AcousticWavefieldTensor>& scratch_states,
     int scratch_depth,
     torch::Tensor& u_this_scratch,
+    torch::Tensor& v2_lambda_scratch,
     int nx,
     int nz
 )
@@ -607,13 +645,19 @@ void process_recursive_interval_2d(
 
         auto adj_view = adjoint.view();
 
-        ACOUSTIC2D(
+        compute_v2_lambda_2d<<<wave_grid, wave_block>>>(
+            vp.data_ptr<float>(),
+            adj_view.u_now,
+            v2_lambda_scratch.data_ptr<float>(),
+            nx, nz, ctx.B
+        );
+
+        ACOUSTIC2D_ADJOINT(
             order,
             wave_grid,
             wave_block,
             adj_view,
-            false,
-            nullptr,
+            v2_lambda_scratch.data_ptr<float>(),
             vp.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
@@ -654,7 +698,8 @@ void process_recursive_interval_2d(
             grad,
             rtm_out,
             nx,
-            nz
+            nz,
+            ctx.dt
         );
         return;
     }
@@ -716,6 +761,7 @@ void process_recursive_interval_2d(
         scratch_states,
         scratch_depth + 1,
         u_this_scratch,
+        v2_lambda_scratch,
         nx,
         nz
     );
@@ -749,6 +795,7 @@ void process_recursive_interval_2d(
         scratch_states,
         scratch_depth + 1,
         u_this_scratch,
+        v2_lambda_scratch,
         nx,
         nz
     );
@@ -814,6 +861,11 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
     RTMOutput illumination;
     init_rtm_output_2d(illumination, vp);
 
+    // Buffer for v^2 * lambda_now; Python-managed via adjoint_workspace[0].
+    auto v2_lambda = !p.adjoint_workspace.empty()
+        ? p.adjoint_workspace[0]
+        : torch::empty_like(vp);
+
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 2);
     auto cpml = cpml_tensor.view();
@@ -872,13 +924,19 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
         for (int it = end - 1; it >= start; --it) {
             auto adj_view = adjoint.view();
 
-            ACOUSTIC2D(
+            compute_v2_lambda_2d<<<launch_config.grid, launch_config.block>>>(
+                vp.data_ptr<float>(),
+                adj_view.u_now,
+                v2_lambda.data_ptr<float>(),
+                nx, nz, B
+            );
+
+            ACOUSTIC2D_ADJOINT(
                 order,
                 launch_config.grid,
                 launch_config.block,
                 adj_view,
-                false,
-                nullptr,
+                v2_lambda.data_ptr<float>(),
                 vp.data_ptr<float>(),
                 lap_ctx,
                 grad_ctx,
@@ -919,7 +977,8 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
                 &grad,
                 &illumination,
                 nx,
-                nz
+                nz,
+                dt
             );
         }
     }
@@ -1025,6 +1084,10 @@ BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
     for (auto& scratch_state : scratch_states)
         scratch_state.allocate(vp, 2, true);
     auto u_this_scratch = torch::empty_like(vp);
+    // Scratch buffer for v^2 * lambda_now; Python-managed via adjoint_workspace[0].
+    auto v2_lambda_scratch = !p.adjoint_workspace.empty()
+        ? p.adjoint_workspace[0]
+        : torch::empty_like(vp);
 
     AcousticWavefieldTensor start_state;
     start_state.allocate(vp, 2, true);
@@ -1067,6 +1130,7 @@ BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
             scratch_states,
             0,
             u_this_scratch,
+            v2_lambda_scratch,
             nx,
             nz
         );

--- a/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cu
@@ -1,11 +1,11 @@
 #include "kernels.cuh"
 
 __global__ void calculate_grad(
-    const float* __restrict__ u_forward,  // (nt, B, nz, nx)
+    const float* __restrict__ u_forward,  // (nt, B, nz, nx); stored as vp^2 * Lap(u)
     const float* __restrict__ u_backward, // (nt, B, nz, nx)
     const float* __restrict__ vp,        // (B, nz, nx)
     float* __restrict__ grad,             // (B, nz, nx)
-    int nx, int nz
+    int nx, int nz, float dt
 ) {
 
     int ix = blockIdx.x * blockDim.x + threadIdx.x;
@@ -23,9 +23,10 @@ __global__ void calculate_grad(
     float*       grad_b       = grad       + b * spatial_size;
     const float* vp_b         = vp         + b * spatial_size;
 
-    float vp3 = vp_b[idx] * vp_b[idx] * vp_b[idx];
-
-    grad_b[idx] += 8*u_forward_b[idx] * u_backward_b[idx]/vp3;
+    // Discrete adjoint of u_next = 2 u_now - u_prev + dt^2 vp^2 Lap(u_now):
+    //   dL/dvp = 2 dt^2 vp * sum_t Lap(u) * u_adj
+    //          = (2 dt^2 / vp) * sum_t u_forward_saved * u_adj
+    grad_b[idx] += 2.f * dt * dt * u_forward_b[idx] * u_backward_b[idx] / vp_b[idx];
 
 }
 
@@ -56,11 +57,14 @@ __global__ void calculate_grad_utt(
     float*       grad_b       = grad       + b * spatial_size;
     const float* vp_b         = vp         + b * spatial_size;
 
+    // After the forward.swap() in backward_bs the buffer roles are rotated so
+    // that this expression evaluates to the centered second time derivative
+    // (u(t-1) - 2 u(t) + u(t+1)) / dt^2 at the physical middle time.
     float u_tt = (u_now_b[idx] - 2*u_prev_b[idx] + u_next_b[idx]) / (dt*dt);
 
-    float vp3 = vp_b[idx] * vp_b[idx] * vp_b[idx];
-
-    grad_b[idx] += 8*u_tt * u_backward_b[idx]/vp3;
+    // u_tt = vp^2 * Lap(u) in the interior, same form as calculate_grad:
+    //   dL/dvp += (2 dt^2 / vp) * u_tt * u_adj
+    grad_b[idx] += 2.f * dt * dt * u_tt * u_backward_b[idx] / vp_b[idx];
 
 }
 

--- a/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cuh
@@ -15,6 +15,21 @@
         else                   acoustic2nd<-1><<<grid, block>>>(__VA_ARGS__);\
     } while (0)
 
+// Proper adjoint of `L u = v^2 · ∇²u`:  L^* λ = ∇²(v^2 · λ)
+// Used in adjoint propagation. Differs from forward kernel only in the
+// non-PML branch (interior): computes ∇²(v²·λ) on a pre-computed `v2_lambda`
+// buffer instead of v²·∇²λ. PML branch left identical to forward (slight
+// residual error in PML zone; sufficient to clean up the interior box
+// anomaly).
+#define ACOUSTIC2D_ADJOINT(order, grid, block, ...)                                  \
+    do {                                                        \
+        if      ((order) == 2) acoustic2nd_adjoint<2><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 4) acoustic2nd_adjoint<4><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 6) acoustic2nd_adjoint<6><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 8) acoustic2nd_adjoint<8><<<grid, block>>>(__VA_ARGS__); \
+        else                   acoustic2nd_adjoint<-1><<<grid, block>>>(__VA_ARGS__);\
+    } while (0)
+
 // Pre-pass: clear air cells (above per-column topo surface).  Launched
 // BEFORE acoustic2nd so the main kernel can early-return on air cells
 // without writing any aux field — eliminating intra-launch RAW races
@@ -162,6 +177,118 @@ __global__ void acoustic2nd(
         u_this_b[idx] = (v * v) * (lap_x + lap_z);
 }
 
+// Helper: pre-compute v2_lambda[idx] = vp[idx]^2 * lambda[idx]
+// Used by the adjoint kernel which then computes ∇²(v²·λ) on this buffer.
+// `static` so each translation unit has its own copy (header-defined).
+static __global__ void compute_v2_lambda_2d(
+    const float* __restrict__ vp,
+    const float* __restrict__ lambda,
+    float* __restrict__ v2_lambda,
+    int nx, int nz, int B
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iz = blockIdx.y * blockDim.y + threadIdx.y;
+    int b  = blockIdx.z;
+    if (ix >= nx || iz >= nz || b >= B) return;
+    int spatial_size = nx * nz;
+    int idx = b * spatial_size + iz * nx + ix;
+    float v = vp[idx];
+    v2_lambda[idx] = v * v * lambda[idx];
+}
+
+// Proper-adjoint kernel for the acoustic wave equation.
+// Computes  λ_next = 2 λ_now - λ_pre + dt² · ∇²(v² · λ_now)
+// in the non-PML branch.  PML branch retains forward formulation for now.
+template<int Order>
+__global__ void acoustic2nd_adjoint(
+    AcousticWavefieldPointer wf,
+    const float* __restrict__ v2_lambda,  // pre-computed v^2 · λ_now
+    const float* __restrict__ vp,
+    LaplaceParam lap_ctx,
+    GradParam grad_ctx,
+    GradParam grad_ctx_x,
+    GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml,
+    SolverContext solver
+){
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iz = blockIdx.y * blockDim.y + threadIdx.y;
+    int b  = blockIdx.z;
+
+    if (ix >= solver.nx || iz >= solver.nz) return;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int  M_static  = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : M_static;
+
+    if (ix < halo || ix >= solver.nx - halo ||
+        iz < halo || iz >= solver.nz - halo)
+        return;
+
+    int spatial_size = solver.nx * solver.nz;
+    int idx = iz * solver.nx + ix;
+
+    auto f = wf.offset(b, spatial_size);
+    const float* vp_b = vp + b * spatial_size;
+    const float* v2l_b = v2_lambda + b * spatial_size;
+
+    if (solver.has_topo && iz < solver.topo_rows[ix]) {
+        return;
+    }
+
+    bool in_pml = (ix < solver.abcn + halo) || (ix >= solver.nx - solver.abcn - halo) ||
+                  (iz < (solver.free_surface ? halo : solver.abcn + halo)) ||
+                  (iz >= solver.nz - solver.abcn - halo);
+
+    if (!in_pml) {
+        // Non-PML: proper adjoint. Compute ∇²(v² · λ_now) on the pre-computed
+        // v2_lambda buffer.  This is the transpose of `v² · ∇²λ` from the
+        // forward kernel.
+        float lap_x = laplace<2, Order, X>(v2l_b, ix, 0, iz, lap_ctx);
+        float lap_z = laplace<2, Order, Z>(v2l_b, ix, 0, iz, lap_ctx);
+        float dt2 = solver.dt * solver.dt;
+        f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] +
+                        dt2 * (lap_x + lap_z);
+        return;
+    }
+
+    // PML branch: keep forward formulation for now (residual error in PML
+    // zone but main bug — box anomaly in non-PML interior — is addressed).
+    float v  = vp_b[idx];
+    float v2_dt2 = (v * v) * solver.dt * solver.dt;
+    float lap_x = laplace<2, Order, X>(f.u_now, ix, 0, iz, lap_ctx);
+    float lap_z = laplace<2, Order, Z>(f.u_now, ix, 0, iz, lap_ctx);
+
+    float ax_ = cpml.ax[ix];
+    float az_ = cpml.az[iz];
+    float bx_ = cpml.bx[ix];
+    float bz_ = cpml.bz[iz];
+    float dbxdx_ = cpml.dbxdx[ix];
+    float dbzdz_ = cpml.dbzdz[iz];
+
+    float w_sum = 0.0f;
+    float dudz     = gradient<2, Order, Z>(f.u_now, ix, 0, iz, grad_ctx);
+    float dudx     = gradient<2, Order, X>(f.u_now, ix, 0, iz, grad_ctx);
+    float dpsizdz  = gradient<2, Order, Z>(f.psiz, ix, 0, iz, grad_ctx);
+    float dpsixdx  = gradient<2, Order, X>(f.psix, ix, 0, iz, grad_ctx);
+    float daxdx    = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
+    float dazdz    = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
+    float daipsiz_dz = az_ * dpsizdz + dazdz * f.psiz[idx];
+    float daipxix_dx = ax_ * dpsixdx + daxdx * f.psix[idx];
+
+    float tmpx = ((1.0f+bx_)*lap_x + dbxdx_*dudx) + daipxix_dx;
+    w_sum += (1.0f+bx_) * tmpx + ax_ * f.zetax[idx];
+    f.psix[idx]  = bx_ * dudx + ax_ * f.psix[idx];
+    f.zetax[idx] = bx_ * tmpx + ax_ * f.zetax[idx];
+
+    float tmpz = ((1.0f+bz_)*lap_z + dbzdz_*dudz) + daipsiz_dz;
+    w_sum += (1.0f+bz_) * tmpz + az_ * f.zetaz[idx];
+    f.psiz[idx]  = bz_ * dudz + az_ * f.psiz[idx];
+    f.zetaz[idx] = bz_ * tmpz + az_ * f.zetaz[idx];
+
+    f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + v2_dt2 * w_sum;
+}
+
 template<int Order>
 __global__ void acoustic2nd_nopml(
     AcousticWavefieldPointer wf,
@@ -218,7 +345,7 @@ __global__ void calculate_grad(
     const float* __restrict__ u_backward, // (nt, B, nz, nx)
     const float* __restrict__ vp,        // (B, nz, nx)
     float* __restrict__ grad,             // (B, nz, nx)
-    int nx, int nz
+    int nx, int nz, float dt
 );
 
 __global__ void calculate_grad_utt(

--- a/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
@@ -82,7 +82,8 @@ void accumulate_imaging_3d(
     int B,
     int nx,
     int ny,
-    int nz
+    int nz,
+    float dt
 )
 {
     if (grad != nullptr) {
@@ -91,7 +92,7 @@ void accumulate_imaging_3d(
             adjoint_ptr,
             vp.data_ptr<float>(),
             grad->data_ptr<float>(),
-            B, nx, ny, nz
+            B, nx, ny, nz, dt
         );
     }
 
@@ -253,6 +254,7 @@ void process_recursive_interval_3d(
     std::vector<AcousticWavefieldTensor>& scratch_states,
     int scratch_depth,
     torch::Tensor& u_this_scratch,
+    torch::Tensor& v2_lambda_scratch,
     int B,
     int nx,
     int ny,
@@ -297,13 +299,19 @@ void process_recursive_interval_3d(
 
         auto adj_view = adjoint.view();
 
-        ACOUSTIC3D(
+        compute_v2_lambda_3d<<<wave_grid, wave_block>>>(
+            vp.data_ptr<float>(),
+            adj_view.u_now,
+            v2_lambda_scratch.data_ptr<float>(),
+            nx, ny, nz, ctx.B
+        );
+
+        ACOUSTIC3D_ADJOINT(
             order,
             wave_grid,
             wave_block,
             adj_view,
-            false,
-            nullptr,
+            v2_lambda_scratch.data_ptr<float>(),
             vp.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
@@ -347,7 +355,8 @@ void process_recursive_interval_3d(
             B,
             nx,
             ny,
-            nz
+            nz,
+            ctx.dt
         );
         return;
     }
@@ -411,6 +420,7 @@ void process_recursive_interval_3d(
         scratch_states,
         scratch_depth + 1,
         u_this_scratch,
+        v2_lambda_scratch,
         B,
         nx,
         ny,
@@ -447,6 +457,7 @@ void process_recursive_interval_3d(
         scratch_states,
         scratch_depth + 1,
         u_this_scratch,
+        v2_lambda_scratch,
         B,
         nx,
         ny,
@@ -482,6 +493,13 @@ void run_full_imaging(
 
     float* u_thist = nullptr;
 
+    // Buffer for pre-computed v^2 * lambda_now (proper-adjoint kernel input).
+    // Python-side (PropTorch) manages the buffer via adjoint_workspace[0] so
+    // it can be reused across backward calls.
+    auto v2_lambda = !p.adjoint_workspace.empty()
+        ? p.adjoint_workspace[0]
+        : torch::empty_like(vp);
+
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 3);
     auto cpml = cpml_tensor.view();
@@ -506,13 +524,19 @@ void run_full_imaging(
     for (int it = p.nt - 1; it >= 0; --it) {
         auto adj_view = adjoint.view();
 
-        ACOUSTIC3D(
+        compute_v2_lambda_3d<<<launch_config.grid, launch_config.block>>>(
+            vp.data_ptr<float>(),
+            adj_view.u_now,
+            v2_lambda.data_ptr<float>(),
+            nx, ny, nz, B
+        );
+
+        ACOUSTIC3D_ADJOINT(
             order,
             launch_config.grid,
             launch_config.block,
             adj_view,
-            false,
-            u_thist,
+            v2_lambda.data_ptr<float>(),
             vp.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
@@ -556,7 +580,8 @@ void run_full_imaging(
             B,
             nx,
             ny,
-            nz
+            nz,
+            ctx.dt
         );
     }
 }
@@ -627,6 +652,11 @@ void run_bs_imaging(
 
     auto f_this = torch::zeros_like(vp);
 
+    // Buffer for v^2 * lambda_now; Python-managed via adjoint_workspace[0].
+    auto v2_lambda = !p.adjoint_workspace.empty()
+        ? p.adjoint_workspace[0]
+        : torch::empty_like(vp);
+
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 3);
     auto cpml = cpml_tensor.view();
@@ -680,13 +710,19 @@ void run_bs_imaging(
         auto adj_view = adjoint.view();
         auto for_view = forward.view();
 
-        ACOUSTIC3D(
+        compute_v2_lambda_3d<<<launch_config.grid, launch_config.block>>>(
+            vp.data_ptr<float>(),
+            adj_view.u_now,
+            v2_lambda.data_ptr<float>(),
+            nx, ny, nz, B
+        );
+
+        ACOUSTIC3D_ADJOINT(
             order,
             launch_config.grid,
             launch_config.block,
             adj_view,
-            false,
-            nullptr,
+            v2_lambda.data_ptr<float>(),
             vp.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
@@ -775,13 +811,19 @@ void run_bs_imaging(
     if (p.nt > 0) {
         auto adj_view = adjoint.view();
 
-        ACOUSTIC3D(
+        compute_v2_lambda_3d<<<launch_config.grid, launch_config.block>>>(
+            vp.data_ptr<float>(),
+            adj_view.u_now,
+            v2_lambda.data_ptr<float>(),
+            nx, ny, nz, B
+        );
+
+        ACOUSTIC3D_ADJOINT(
             order,
             launch_config.grid,
             launch_config.block,
             adj_view,
-            false,
-            nullptr,
+            v2_lambda.data_ptr<float>(),
             vp.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
@@ -892,6 +934,11 @@ void run_ckpt_imaging(
 
     auto chunk_forward = torch::zeros({p.checkpoint_interval, B, nz, ny, nx}, vp.options());
 
+    // Buffer for v^2 * lambda_now; Python-managed via adjoint_workspace[0].
+    auto v2_lambda = !p.adjoint_workspace.empty()
+        ? p.adjoint_workspace[0]
+        : torch::empty_like(vp);
+
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 3);
     auto cpml = cpml_tensor.view();
@@ -951,13 +998,19 @@ void run_ckpt_imaging(
         for (int it = end - 1; it >= start; --it) {
             auto adj_view = adjoint.view();
 
-            ACOUSTIC3D(
+            compute_v2_lambda_3d<<<launch_config.grid, launch_config.block>>>(
+                vp.data_ptr<float>(),
+                adj_view.u_now,
+                v2_lambda.data_ptr<float>(),
+                nx, ny, nz, B
+            );
+
+            ACOUSTIC3D_ADJOINT(
                 order,
                 launch_config.grid,
                 launch_config.block,
                 adj_view,
-                false,
-                nullptr,
+                v2_lambda.data_ptr<float>(),
                 vp.data_ptr<float>(),
                 lap_ctx,
                 grad_ctx,
@@ -1001,7 +1054,8 @@ void run_ckpt_imaging(
                 B,
                 nx,
                 ny,
-                nz
+                nz,
+                ctx.dt
             );
         }
     }
@@ -1115,6 +1169,10 @@ void run_recursive_imaging(
     for (auto& scratch_state : scratch_states)
         scratch_state.allocate(vp, 3, true);
     auto u_this_scratch = torch::empty_like(vp);
+    // Scratch buffer for v^2 * lambda_now; Python-managed via adjoint_workspace[0].
+    auto v2_lambda_scratch = !p.adjoint_workspace.empty()
+        ? p.adjoint_workspace[0]
+        : torch::empty_like(vp);
 
     AcousticWavefieldTensor start_state;
     start_state.allocate(vp, 3, true);
@@ -1158,6 +1216,7 @@ void run_recursive_imaging(
             scratch_states,
             0,
             u_this_scratch,
+            v2_lambda_scratch,
             B,
             nx,
             ny,

--- a/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cu
@@ -1,11 +1,11 @@
 #include "kernels.cuh"
 
 __global__ void calculate_grad_3d(
-    const float* __restrict__ u_forward,  // (nt, B, nz, nx)
+    const float* __restrict__ u_forward,  // (nt, B, nz, nx); stored as vp^2 * Lap(u)
     const float* __restrict__ u_backward, // (nt, B, nz, nx)
     const float* __restrict__ vp,        // (B, nz, nx)
     float* __restrict__ grad,             // (B, nz, nx)
-    int B, int nx, int ny, int nz
+    int B, int nx, int ny, int nz, float dt
 ) {
 
     int ix = blockIdx.x * blockDim.x + threadIdx.x;
@@ -29,9 +29,9 @@ __global__ void calculate_grad_3d(
     float*       grad_b       = grad       + b * spatial_size;
     const float* vp_b         = vp         + b * spatial_size;
 
-    float vp3 = vp_b[idx] * vp_b[idx] * vp_b[idx];
-
-    grad_b[idx] += 16*u_forward_b[idx] * u_backward_b[idx]/vp3;
+    // Discrete adjoint of u_next = 2 u_now - u_prev + dt^2 vp^2 Lap(u_now):
+    //   dL/dvp = (2 dt^2 / vp) * sum_t u_forward_saved * u_adj
+    grad_b[idx] += 2.f * dt * dt * u_forward_b[idx] * u_backward_b[idx] / vp_b[idx];
 
 }
 
@@ -68,11 +68,14 @@ __global__ void calculate_grad_utt_3d(
     float*       grad_b       = grad       + b * spatial_size;
     const float* vp_b         = vp         + b * spatial_size;
 
-    float u_tt = (u_now_b[idx] - 2*u_prev_b[idx] + u_next_b[idx])/ (dt*dt); //
+    // After the forward.swap() in backward_bs the buffer roles are rotated so
+    // that this expression evaluates to the centered second time derivative
+    // (u(t-1) - 2 u(t) + u(t+1)) / dt^2 at the physical middle time.
+    float u_tt = (u_now_b[idx] - 2*u_prev_b[idx] + u_next_b[idx]) / (dt*dt);
 
-    float vp3 = vp_b[idx] * vp_b[idx] * vp_b[idx];
-
-    grad_b[idx] += 16*u_tt * u_backward_b[idx]/vp3;
+    // u_tt = vp^2 * Lap(u) in the interior, same form as calculate_grad_3d:
+    //   dL/dvp += (2 dt^2 / vp) * u_tt * u_adj
+    grad_b[idx] += 2.f * dt * dt * u_tt * u_backward_b[idx] / vp_b[idx];
 
 }
 

--- a/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cuh
@@ -24,6 +24,19 @@
         else                   acoustic_nopml_3d<-1><<<grid, block>>>(__VA_ARGS__);\
     } while (0)
 
+// Proper adjoint of `L u = v^2 · ∇²u`:  L^* λ = ∇²(v^2 · λ).
+// Same structure as the 2D version.  Non-PML branch uses a pre-computed
+// `v2_lambda` buffer; PML branch keeps the forward formulation (residual
+// error in PML zone but fixes the interior box-anomaly bug).
+#define ACOUSTIC3D_ADJOINT(order, grid, block, ...)                                  \
+    do {                                                                                    \
+        if      ((order) == 2) acoustic_adjoint_kernel_3d<2><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 4) acoustic_adjoint_kernel_3d<4><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 6) acoustic_adjoint_kernel_3d<6><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 8) acoustic_adjoint_kernel_3d<8><<<grid, block>>>(__VA_ARGS__); \
+        else                   acoustic_adjoint_kernel_3d<-1><<<grid, block>>>(__VA_ARGS__);\
+    } while (0)
+
 // Pre-pass: clear air cells (above per-(iy,ix) surface row).  Launched
 // BEFORE acoustic_forward_kernel_3d so the main kernel only reads (never
 // writes) air cells in the same launch — eliminates intra-launch RAW
@@ -236,6 +249,174 @@ __global__ void acoustic_forward_kernel_3d(
 }
 
 
+// Helper: pre-compute v2_lambda[idx] = vp[idx]^2 * lambda[idx]  for 3D.
+// `static` so each .cu including this header gets its own copy.
+static __global__ void compute_v2_lambda_3d(
+    const float* __restrict__ vp,
+    const float* __restrict__ lambda,
+    float* __restrict__ v2_lambda,
+    int nx, int ny, int nz, int B
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iy = blockIdx.y * blockDim.y + threadIdx.y;
+    int iz_global = blockIdx.z * blockDim.z + threadIdx.z;
+    int b  = iz_global / nz;
+    int iz = iz_global % nz;
+    if (b >= B || ix >= nx || iy >= ny || iz >= nz) return;
+    int spatial_size = nx * ny * nz;
+    int stride_y = nx;
+    int stride_z = nx * ny;
+    int idx = b * spatial_size + iz * stride_z + iy * stride_y + ix;
+    float v = vp[idx];
+    v2_lambda[idx] = v * v * lambda[idx];
+}
+
+// Proper adjoint kernel for the 3D acoustic wave equation.
+// Non-PML branch:  λ_next = 2 λ_now - λ_pre + dt² · ∇²(v² · λ_now)
+// using a pre-computed `v2_lambda` buffer.  PML branch retains forward
+// formulation (acceptable since the PML interior is sponge-zone anyway).
+template<int Order>
+__global__ void acoustic_adjoint_kernel_3d(
+    AcousticWavefieldPointer wf,
+    const float* __restrict__ v2_lambda,
+    const float* __restrict__ vp,
+    LaplaceParam lap_ctx,
+    GradParam grad_ctx,
+    GradParam grad_ctx_x,
+    GradParam grad_ctx_y,
+    GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml,
+    SolverContext solver
+)
+{
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iy = blockIdx.y * blockDim.y + threadIdx.y;
+    int iz_global = blockIdx.z * blockDim.z + threadIdx.z;
+
+    int b  = iz_global / solver.nz;
+    int iz = iz_global % solver.nz;
+
+    if (b >= solver.B || ix >= solver.nx || iy >= solver.ny || iz >= solver.nz)
+        return;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int  M_static   = is_runtime ? 0 : (Order / 2);
+
+    int halo = is_runtime ? solver.M : M_static;
+
+    if (ix < halo || ix >= solver.nx - halo ||
+        iy < halo || iy >= solver.ny - halo ||
+        iz < halo || iz >= solver.nz - halo)
+        return;
+
+    int stride_y = solver.nx;
+    int stride_z = solver.nx * solver.ny;
+    int spatial_size = solver.nx * solver.ny * solver.nz;
+
+    int idx = iz * stride_z + iy * stride_y + ix;
+
+    auto f = wf.offset(b, spatial_size);
+
+    if (solver.has_topo && iz < solver.topo_rows[iy * solver.nx + ix]) {
+        return;
+    }
+
+    const float* vp_b   = vp        + spatial_size * b;
+    const float* v2l_b  = v2_lambda + spatial_size * b;
+
+    int x0 = solver.phys_x0();
+    int x1 = solver.phys_x1();
+    int y0 = solver.phys_y0();
+    int y1 = solver.phys_y1();
+    int z0 = solver.phys_z0();
+    int z1 = solver.phys_z1();
+
+    bool in_pml_x = (ix < x0) || (ix >= x1);
+    bool in_pml_y = (iy < y0) || (iy >= y1);
+    bool in_pml_z = (iz < z0) || (iz >= z1);
+
+    if (!(in_pml_x || in_pml_y || in_pml_z)) {
+        // Proper adjoint in the non-PML interior:  ∇²(v² · λ_now)
+        float lap_x = laplace<3, Order, X>(v2l_b, ix, iy, iz, lap_ctx);
+        float lap_y = laplace<3, Order, Y>(v2l_b, ix, iy, iz, lap_ctx);
+        float lap_z = laplace<3, Order, Z>(v2l_b, ix, iy, iz, lap_ctx);
+        float dt2 = solver.dt * solver.dt;
+        f.u_next[idx] = 2.f * f.u_now[idx] - f.u_prev[idx] + dt2 * (lap_x + lap_y + lap_z);
+        return;
+    }
+
+    // PML branch: retain forward formulation.
+    float lap_x = laplace<3, Order, X>(f.u_now, ix, iy, iz, lap_ctx);
+    float lap_y = laplace<3, Order, Y>(f.u_now, ix, iy, iz, lap_ctx);
+    float lap_z = laplace<3, Order, Z>(f.u_now, ix, iy, iz, lap_ctx);
+
+    float w_sum = 0.f;
+
+    if (in_pml_x) {
+        float dudx = gradient<3, Order, X>(f.u_now, ix, iy, iz, grad_ctx);
+        float dpsixdx = gradient<3, Order, X>(f.psix, ix, iy, iz, grad_ctx);
+        float ax_ = cpml.ax[ix];
+        float bx_ = cpml.bx[ix];
+        float dbxdx_ = cpml.dbxdx[ix];
+        float daxdx = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
+
+        float tmpx = ((1.f + bx_) * lap_x + dbxdx_ * dudx)
+                     + ax_ * dpsixdx + daxdx * f.psix[idx];
+
+        w_sum += (1.f + bx_) * tmpx + ax_ * f.zetax[idx];
+
+        f.psix[idx]  = bx_ * dudx + ax_ * f.psix[idx];
+        f.zetax[idx] = bx_ * tmpx + ax_ * f.zetax[idx];
+    } else {
+        w_sum += lap_x;
+    }
+
+    if (in_pml_y) {
+        float dudy = gradient<3, Order, Y>(f.u_now, ix, iy, iz, grad_ctx);
+        float dpsiydy = gradient<3, Order, Y>(f.psiy, ix, iy, iz, grad_ctx);
+        float ay_ = cpml.ay[iy];
+        float by_ = cpml.by[iy];
+        float dbydy_ = cpml.dbydy[iy];
+        float daydy = gradient<2, Order, X>(cpml.ay, iy, 0, 0, grad_ctx_y);
+
+        float tmpy = ((1.f + by_) * lap_y + dbydy_ * dudy)
+                     + ay_ * dpsiydy + daydy * f.psiy[idx];
+
+        w_sum += (1.f + by_) * tmpy + ay_ * f.zetay[idx];
+
+        f.psiy[idx]  = by_ * dudy + ay_ * f.psiy[idx];
+        f.zetay[idx] = by_ * tmpy + ay_ * f.zetay[idx];
+    } else {
+        w_sum += lap_y;
+    }
+
+    if (in_pml_z) {
+        float dudz = gradient<3, Order, Z>(f.u_now, ix, iy, iz, grad_ctx);
+        float dpsizdz = gradient<3, Order, Z>(f.psiz, ix, iy, iz, grad_ctx);
+        float az_ = cpml.az[iz];
+        float bz_ = cpml.bz[iz];
+        float dbzdz_ = cpml.dbzdz[iz];
+        float dazdz = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
+
+        float tmpz = ((1.f + bz_) * lap_z + dbzdz_ * dudz)
+                     + az_ * dpsizdz + dazdz * f.psiz[idx];
+
+        w_sum += (1.f + bz_) * tmpz + az_ * f.zetaz[idx];
+
+        f.psiz[idx]  = bz_ * dudz + az_ * f.psiz[idx];
+        f.zetaz[idx] = bz_ * tmpz + az_ * f.zetaz[idx];
+    } else {
+        w_sum += lap_z;
+    }
+
+    float v  = vp_b[idx];
+    f.u_next[idx] =
+        2.f * f.u_now[idx] -
+        f.u_prev[idx] +
+        (v * v) * solver.dt * solver.dt * w_sum;
+}
+
+
 template<int Order>
 __global__ void acoustic_nopml_3d(
     AcousticWavefieldPointer wf,
@@ -310,7 +491,7 @@ __global__ void calculate_grad_3d(
     const float* __restrict__ u_backward, // (nt, B, nz, nx)
     const float* __restrict__ vp,        // (B, nz, nx)
     float* __restrict__ grad,             // (B, nz, nx)
-    int B, int nx, int ny, int nz
+    int B, int nx, int ny, int nz, float dt
 );
 
 __global__ void calculate_grad_utt_3d(

--- a/src/sweep/equations/acoustic.py
+++ b/src/sweep/equations/acoustic.py
@@ -187,4 +187,5 @@ class Acoustic(SecondOrderEquation):
             last_two_storage_nvar=1,
             checkpoint_nvar=6,
             boundary_save_nvar=1,
+            backward_workspace_nvar=1,
         )

--- a/src/sweep/equations/acoustic3d.py
+++ b/src/sweep/equations/acoustic3d.py
@@ -191,4 +191,5 @@ class Acoustic3D(SecondOrderEquation):
             last_two_storage_nvar=1,
             checkpoint_nvar=8,
             boundary_save_nvar=1,
+            backward_workspace_nvar=1,
         )

--- a/src/sweep/propagator/_c.py
+++ b/src/sweep/propagator/_c.py
@@ -1461,7 +1461,7 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         bwd.checkpoint_steps = checkpoint_steps.contiguous() if use_ckpt else torch.empty(0, dtype=torch.int32)
         bwd.adjoint_wavefields = [a.zero_() for a in adjoint_wavefields]
         bwd.forward_wavefields = []
-        bwd.adjoint_workspace = []
+        bwd.adjoint_workspace = list(adjoint_workspace)
         bwd.boundary_cpu = list(boundary_cpu) if boundary_on_cpu and use_boundary_saving else []
         bwd.boundary_gpu = list(boundary_gpu) if use_boundary_saving else []
         bwd.boundary_disk_files = list(self._boundary_disk_files) if boundary_on_disk and use_boundary_saving else []


### PR DESCRIPTION
## Summary

The acoustic forward operator `L u = v^2 . laplacian(u)` is non-self-adjoint
when `v` varies in space, so the discrete adjoint sweep needs
`L* lambda = laplacian(v^2 . lambda)`, not `L lambda` itself.

Before this PR, the CUDA backward applied `L` (i.e. propagated lambda as
if it were a forward field), which is exact only for constant `v`. With
realistic velocity contrasts, gradients inside velocity anomalies disagreed
with eager autograd / FD reference by up to ~18%.

## What changes

- **kernels.cuh** (2D/3D): new `acoustic2nd_adjoint` / `acoustic_adjoint_kernel_3d`
  + `compute_v2_lambda_{2,3}d` helper. Non-PML branch implements proper
  adjoint; PML branch keeps the forward formulation (sponge zone — small
  residual, doesn't affect physically meaningful interior).
- **backward.cu** (2D/3D): all four backward paths (full / boundary-saving /
  ckpt-chunk / recursive-ckpt) route their adjoint propagation through the
  new kernel.
- **calculate_grad**: the `8|16 / vp^3` factor was wrong by `(dt . vp / 2)^2`
  for any non-unit step; replaced with the discrete-adjoint expression
  `2 . dt^2 . vp . u_fwd . u_adj`.
- **Workspace**: declared `backward_workspace_nvar=1` in Acoustic /
  Acoustic3D `cuda_layout`, so PropTorch owns the `v^2 . lambda` scratch
  buffer via the existing `adjoint_workspace[]` mechanism (same path
  used by Elastic / DAS). The buffer is allocated once per propagator
  and reused across backward calls — no per-call `cudaMalloc`.
- **_c.py**: the RTM standalone-backward path was setting
  `bwd.adjoint_workspace = []`, silently dropping the slice. Fixed.

## Verification

All 8 cases PASS (`cos > 0.999`, `|ratio - 1| < 0.05`):

```
Acoustic2D uniform vp + box anomaly
  [full       ] cos=1.000000  ratio=1.0001
  [bs_gpu     ] cos=0.999999  ratio=1.0000
  [ckpt_chunk ] cos=1.000000  ratio=1.0001
  [ckpt_rec   ] cos=0.999999  ratio=1.0001
Acoustic3D uniform vp + box anomaly
  [full       ] cos=1.000000  ratio=0.9998
  [bs_gpu     ] cos=1.000000  ratio=0.9998
  [ckpt_chunk ] cos=1.000000  ratio=0.9997
  [ckpt_rec   ] cos=1.000000  ratio=0.9998
```

PML-thickness probe (box error vs eager autograd, abcn = PML width):

| abcn | pre-fix | post-fix |
|------|---------|----------|
| 50   | 18.82%  | 0.00%    |
| 30   | 18.82%  | 0.01%    |
| 20   | 18.82%  | 0.06%    |
| 10   | 18.82%  | 0.86%    |
| 5    | 18.94%  | 27%*     |
| 2    | 38%     | 112%*    |

*At very thin PML the box anomaly sits inside the PML zone, where this
PR keeps the forward formulation; with the standard `abcn=30` default
the box is fully in the interior and the error is essentially zero.

## Test plan

- [x] `test_acoustic_grad_scale.py` (2D, full + bs)
- [x] `test_acoustic3d_grad_scale.py` (3D, full + bs)
- [x] `test_ckpt_uniform.py` (4 modes x 2D + 3D)
- [x] `probe_box_abcn.py` (box error vs PML thickness)
- [ ] CI on this PR

## Risk / scope

- Only touches Acoustic 2D / Acoustic3D. Elastic / DAS / VTI unchanged.
- No public Python API change (the only Python edits are internal
  `cuda_layout` metadata + an `_c.py` bugfix).
- No docs update needed (no user-facing behavior change beyond
  gradients now being correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)