### PR TITLE
fix(acoustic_vrz): exact c adjoint for gradient (2D+3D)

### DIFF
--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/backward.cu
@@ -78,7 +78,13 @@ BackwardOutput backward(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto kappa_lambda = torch::zeros_like(vp);
+    auto c_x = torch::zeros_like(vp);
+    auto c_z = torch::zeros_like(vp);
+    auto e_x = torch::zeros_like(vp);
+    auto e_z = torch::zeros_like(vp);
+    auto aq0 = torch::zeros_like(vp);   // b·κ·λ   (adjoint transpose buffer)
+    auto aqx = torch::zeros_like(vp);   // (∂ₓb·κ)·λ
+    auto aqz = torch::zeros_like(vp);   // (∂_z b·κ)·λ
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(in.pml_vals, 2);
@@ -94,6 +100,21 @@ BackwardOutput backward(const BackwardInput& in)
 
     for (int it = in.nt - 1; it >= 0; --it) {
         auto adj_view = adjoint.view();
+        BUILD_VRZ_ADJOINT_FIELDS(
+            order,
+            launch_config.grid,
+            launch_config.block,
+            adj_view.u_now,
+            vp.data_ptr<float>(),
+            z.data_ptr<float>(),
+            inv_z.data_ptr<float>(),
+            aq0.data_ptr<float>(),
+            aqx.data_ptr<float>(),
+            aqz.data_ptr<float>(),
+            grad_ctx,
+            ctx
+        );
+
         ACOUSTIC_VRZ2D_ADJOINT(
             order,
             launch_config.grid,
@@ -102,6 +123,9 @@ BackwardOutput backward(const BackwardInput& in)
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
+            aq0.data_ptr<float>(),
+            aqx.data_ptr<float>(),
+            aqz.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
             grad_ctx_x,
@@ -121,11 +145,19 @@ BackwardOutput backward(const BackwardInput& in)
 
         adjoint.swap();
 
-        build_kappa_lambda_vrz2d<<<launch_config.grid, launch_config.block>>>(
+        BUILD_VRZ_GRAD_FIELDS(
+            order,
+            launch_config.grid,
+            launch_config.block,
+            in.u_forward.select(0, it).select(0, 0).data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
-            kappa_lambda.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_z.data_ptr<float>(),
+            grad_ctx,
             ctx
         );
 
@@ -135,7 +167,10 @@ BackwardOutput backward(const BackwardInput& in)
             launch_config.block,
             in.u_forward.select(0, it).select(0, 0).data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
-            kappa_lambda.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_z.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
@@ -199,7 +234,13 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto kappa_lambda = torch::zeros_like(vp);
+    auto c_x = torch::zeros_like(vp);
+    auto c_z = torch::zeros_like(vp);
+    auto e_x = torch::zeros_like(vp);
+    auto e_z = torch::zeros_like(vp);
+    auto aq0 = torch::zeros_like(vp);   // b·κ·λ   (adjoint transpose buffer)
+    auto aqx = torch::zeros_like(vp);   // (∂ₓb·κ)·λ
+    auto aqz = torch::zeros_like(vp);   // (∂_z b·κ)·λ
     auto neg_adjoint_source = -p.adjoint_source;
 
     AcousticCPMLTensor cpml_tensor;
@@ -250,6 +291,21 @@ BackwardOutput backward_bs(const BackwardInput& in)
         auto adj_view = adjoint.view();
         auto for_view = forward.view();
 
+        BUILD_VRZ_ADJOINT_FIELDS(
+            order,
+            launch_config.grid,
+            launch_config.block,
+            adj_view.u_now,
+            vp.data_ptr<float>(),
+            z.data_ptr<float>(),
+            inv_z.data_ptr<float>(),
+            aq0.data_ptr<float>(),
+            aqx.data_ptr<float>(),
+            aqz.data_ptr<float>(),
+            grad_ctx,
+            ctx
+        );
+
         ACOUSTIC_VRZ2D_ADJOINT(
             order,
             launch_config.grid,
@@ -258,6 +314,9 @@ BackwardOutput backward_bs(const BackwardInput& in)
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
+            aq0.data_ptr<float>(),
+            aqx.data_ptr<float>(),
+            aqz.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
             grad_ctx_x,
@@ -312,11 +371,19 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
         forward.swap();
 
-        build_kappa_lambda_vrz2d<<<launch_config.grid, launch_config.block>>>(
+        BUILD_VRZ_GRAD_FIELDS(
+            order,
+            launch_config.grid,
+            launch_config.block,
+            forward.u_now_t.data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
-            kappa_lambda.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_z.data_ptr<float>(),
+            grad_ctx,
             ctx
         );
 
@@ -326,7 +393,10 @@ BackwardOutput backward_bs(const BackwardInput& in)
             launch_config.block,
             forward.u_now_t.data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
-            kappa_lambda.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_z.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
@@ -392,7 +462,13 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto kappa_lambda = torch::zeros_like(vp);
+    auto c_x = torch::zeros_like(vp);
+    auto c_z = torch::zeros_like(vp);
+    auto e_x = torch::zeros_like(vp);
+    auto e_z = torch::zeros_like(vp);
+    auto aq0 = torch::zeros_like(vp);   // b·κ·λ   (adjoint transpose buffer)
+    auto aqx = torch::zeros_like(vp);   // (∂ₓb·κ)·λ
+    auto aqz = torch::zeros_like(vp);   // (∂_z b·κ)·λ
     auto checkpoint_steps_cpu = p.checkpoint_steps.defined()
         ? p.checkpoint_steps.to(torch::kCPU).to(torch::kInt32).contiguous()
         : torch::empty({0}, torch::TensorOptions().dtype(torch::kInt32));
@@ -508,6 +584,21 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
         for (int it = end - 1; it >= start; --it) {
             auto adj_view = adjoint.view();
 
+            BUILD_VRZ_ADJOINT_FIELDS(
+                order,
+                launch_config.grid,
+                launch_config.block,
+                adj_view.u_now,
+                vp.data_ptr<float>(),
+                z.data_ptr<float>(),
+                inv_z.data_ptr<float>(),
+                aq0.data_ptr<float>(),
+                aqx.data_ptr<float>(),
+                aqz.data_ptr<float>(),
+                grad_ctx,
+                ctx
+            );
+
             ACOUSTIC_VRZ2D_ADJOINT(
                 order,
                 launch_config.grid,
@@ -516,6 +607,9 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
                 vp.data_ptr<float>(),
                 z.data_ptr<float>(),
                 inv_z.data_ptr<float>(),
+                aq0.data_ptr<float>(),
+                aqx.data_ptr<float>(),
+                aqz.data_ptr<float>(),
                 lap_ctx,
                 grad_ctx,
                 grad_ctx_x,
@@ -535,11 +629,19 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
             adjoint.swap();
 
-            build_kappa_lambda_vrz2d<<<launch_config.grid, launch_config.block>>>(
+            BUILD_VRZ_GRAD_FIELDS(
+                order,
+                launch_config.grid,
+                launch_config.block,
+                chunk_forward[it - start].data_ptr<float>(),
                 adjoint.u_now_t.data_ptr<float>(),
                 vp.data_ptr<float>(),
                 z.data_ptr<float>(),
-                kappa_lambda.data_ptr<float>(),
+                c_x.data_ptr<float>(),
+                c_z.data_ptr<float>(),
+                e_x.data_ptr<float>(),
+                e_z.data_ptr<float>(),
+                grad_ctx,
                 ctx
             );
 
@@ -549,7 +651,10 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
                 launch_config.block,
                 chunk_forward[it - start].data_ptr<float>(),
                 adjoint.u_now_t.data_ptr<float>(),
-                kappa_lambda.data_ptr<float>(),
+                c_x.data_ptr<float>(),
+                c_z.data_ptr<float>(),
+                e_x.data_ptr<float>(),
+                e_z.data_ptr<float>(),
                 vp.data_ptr<float>(),
                 z.data_ptr<float>(),
                 inv_z.data_ptr<float>(),

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/kernels.cuh
@@ -35,11 +35,27 @@ __global__ void acoustic_vrz2nd_nopml(
 );
 
 template<int Order>
+__global__ void build_vrz_adjoint_fields(
+    const float* __restrict__ lambda_now,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    float* __restrict__ aq0,
+    float* __restrict__ aqx,
+    float* __restrict__ aqz,
+    GradParam grad_ctx,
+    SolverContext solver
+);
+
+template<int Order>
 __global__ void acoustic_vrz2nd_adjoint(
     AcousticWavefieldPointer wf,
     const float* __restrict__ vp,
     const float* __restrict__ z,
     const float* __restrict__ inv_z,
+    const float* __restrict__ aq0,   // b·κ·λ      (= vp²·λ)
+    const float* __restrict__ aqx,   // (∂ₓb·κ)·λ
+    const float* __restrict__ aqz,   // (∂_z b·κ)·λ
     LaplaceParam lap_ctx,
     GradParam grad_ctx,
     GradParam grad_ctx_x,
@@ -56,11 +72,30 @@ static __global__ void build_kappa_lambda_vrz2d(
     SolverContext solver
 );
 
+// Pre-compute the reverse-mode buffers for the exact discrete-adjoint gradient:
+//   c_d = λ·vp·∂_d p ,   e_d = λ·vp²·z·∂_d p   (d = x, z)
+template<int Order>
+__global__ void build_vrz_grad_fields(
+    const float* __restrict__ f_u_now,
+    const float* __restrict__ lambda_now,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    float* __restrict__ c_x,
+    float* __restrict__ c_z,
+    float* __restrict__ e_x,
+    float* __restrict__ e_z,
+    GradParam grad_ctx,
+    SolverContext solver
+);
+
 template<int Order>
 __global__ void calculate_grad_vrz2d(
     const float* __restrict__ f_u_now,
     const float* __restrict__ lambda_now,
-    const float* __restrict__ kappa_lambda_now,
+    const float* __restrict__ c_x,
+    const float* __restrict__ c_z,
+    const float* __restrict__ e_x,
+    const float* __restrict__ e_z,
     const float* __restrict__ vp,
     const float* __restrict__ z,
     const float* __restrict__ inv_z,
@@ -105,6 +140,24 @@ __global__ void calculate_grad_vrz2d(
         else if ((order) == 6) calculate_grad_vrz2d<6><<<grid, block>>>(__VA_ARGS__);        \
         else if ((order) == 8) calculate_grad_vrz2d<8><<<grid, block>>>(__VA_ARGS__);        \
         else                   calculate_grad_vrz2d<-1><<<grid, block>>>(__VA_ARGS__);       \
+    } while (0)
+
+#define BUILD_VRZ_GRAD_FIELDS(order, grid, block, ...)                                       \
+    do {                                                                                     \
+        if      ((order) == 2) build_vrz_grad_fields<2><<<grid, block>>>(__VA_ARGS__);       \
+        else if ((order) == 4) build_vrz_grad_fields<4><<<grid, block>>>(__VA_ARGS__);       \
+        else if ((order) == 6) build_vrz_grad_fields<6><<<grid, block>>>(__VA_ARGS__);       \
+        else if ((order) == 8) build_vrz_grad_fields<8><<<grid, block>>>(__VA_ARGS__);       \
+        else                   build_vrz_grad_fields<-1><<<grid, block>>>(__VA_ARGS__);      \
+    } while (0)
+
+#define BUILD_VRZ_ADJOINT_FIELDS(order, grid, block, ...)                                    \
+    do {                                                                                     \
+        if      ((order) == 2) build_vrz_adjoint_fields<2><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 4) build_vrz_adjoint_fields<4><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 6) build_vrz_adjoint_fields<6><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 8) build_vrz_adjoint_fields<8><<<grid, block>>>(__VA_ARGS__);    \
+        else                   build_vrz_adjoint_fields<-1><<<grid, block>>>(__VA_ARGS__);   \
     } while (0)
 
 template<int Order, int Direction>
@@ -377,12 +430,66 @@ __global__ void acoustic_vrz2nd_nopml(
     f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + solver.dt * solver.dt * rhs;
 }
 
+// Pre-multiply λ by the model-only adjoint coefficients so the transpose
+// stencils in acoustic_vrz2nd_adjoint can be applied without a read-then-write
+// race:  aq0 = b·κ·λ = vp²·λ,  aqx = (∂ₓb·κ)·λ,  aqz = (∂_z b·κ)·λ.
+template<int Order>
+__global__ void build_vrz_adjoint_fields(
+    const float* __restrict__ lambda_now,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    float* __restrict__ aq0,
+    float* __restrict__ aqx,
+    float* __restrict__ aqz,
+    GradParam grad_ctx,
+    SolverContext solver
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iz = blockIdx.y * blockDim.y + threadIdx.y;
+    int b  = blockIdx.z;
+    if (ix >= solver.nx || iz >= solver.nz) return;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int m_static = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : m_static;
+    if (ix < halo || ix >= solver.nx - halo || iz < halo || iz >= solver.nz - halo)
+        return;
+
+    int spatial_size = solver.nx * solver.nz;
+    int idx = iz * solver.nx + ix;
+    int gidx = b * spatial_size + idx;
+
+    const float* vp_b = vp + b * spatial_size;
+    const float* z_b = z + b * spatial_size;
+    const float* inv_z_b = inv_z + b * spatial_size;
+    const float* lam_b = lambda_now + b * spatial_size;
+
+    float dvpdx = gradient<2, Order, X>(vp_b, ix, 0, iz, grad_ctx);
+    float dvpdz = gradient<2, Order, Z>(vp_b, ix, 0, iz, grad_ctx);
+    float z1x = gradient<2, Order, X>(inv_z_b, ix, 0, iz, grad_ctx);
+    float z1z = gradient<2, Order, Z>(inv_z_b, ix, 0, iz, grad_ctx);
+    float v = vp_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float kappa = v * z_b[idx];
+    float dbdx = dvpdx * inv_z0 + v * z1x;
+    float dbdz = dvpdz * inv_z0 + v * z1z;
+    float lam = lam_b[idx];
+
+    aq0[gidx] = v * v * lam;            // b·κ·λ  (= vp²·λ)
+    aqx[gidx] = dbdx * kappa * lam;     // (∂ₓb·κ)·λ
+    aqz[gidx] = dbdz * kappa * lam;     // (∂_z b·κ)·λ
+}
+
 template<int Order>
 __global__ void acoustic_vrz2nd_adjoint(
     AcousticWavefieldPointer wf,
     const float* __restrict__ vp,
     const float* __restrict__ z,
     const float* __restrict__ inv_z,
+    const float* __restrict__ aq0,   // b·κ·λ      (= vp²·λ)
+    const float* __restrict__ aqx,   // (∂ₓb·κ)·λ
+    const float* __restrict__ aqz,   // (∂_z b·κ)·λ
     LaplaceParam lap_ctx,
     GradParam grad_ctx,
     GradParam grad_ctx_x,
@@ -407,6 +514,33 @@ __global__ void acoustic_vrz2nd_adjoint(
     int idx = iz * solver.nx + ix;
 
     auto f = wf.offset(b, spatial_size);
+
+    // Position-based PML / interior split (mirrors the forward fast-path).
+    bool in_pml = (ix < solver.abcn + halo) || (ix >= solver.nx - solver.abcn - halo) ||
+                  (iz < (solver.free_surface ? halo : solver.abcn + halo)) ||
+                  (iz >= solver.nz - solver.abcn - halo);
+
+    if (!in_pml) {
+        // Exact transpose Aᵀλ of the forward interior operator
+        //   A u = κ·(b·∇²u + ∂ₓb·∂ₓu + ∂_z b·∂_z u).
+        // L is symmetric and the centred first-difference antisymmetric, so
+        //   Aᵀλ = ∇²(b·κ·λ) − ∂ₓ((∂ₓb·κ)·λ) − ∂_z((∂_z b·κ)·λ),
+        // computed on the pre-multiplied buffers from build_vrz_adjoint_fields
+        // (split into a separate launch to keep the neighbour reads race-free).
+        const float* aq0_b = aq0 + b * spatial_size;
+        const float* aqx_b = aqx + b * spatial_size;
+        const float* aqz_b = aqz + b * spatial_size;
+        float lap_x = laplace<2, Order, X>(aq0_b, ix, 0, iz, lap_ctx);
+        float lap_z = laplace<2, Order, Z>(aq0_b, ix, 0, iz, lap_ctx);
+        float gx = gradient<2, Order, X>(aqx_b, ix, 0, iz, grad_ctx);
+        float gz = gradient<2, Order, Z>(aqz_b, ix, 0, iz, grad_ctx);
+        float rhs = (lap_x + lap_z) - gx - gz;
+        f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + solver.dt * solver.dt * rhs;
+        return;
+    }
+
+    // PML branch: forward formulation retained (small residual error confined
+    // to the absorbing zone, mirroring the acoustic proper-adjoint kernel).
     const float* vp_b = vp + b * spatial_size;
     const float* z_b = z + b * spatial_size;
     const float* inv_z_b = inv_z + b * spatial_size;
@@ -428,20 +562,6 @@ __global__ void acoustic_vrz2nd_adjoint(
     float dbdx = dvpdx * inv_z0 + v * z1x;
     float dbdz = dvpdz * inv_z0 + v * z1z;
     float kappa = v * z_b[idx];
-
-    // Position-based PML / interior split. Mirrors the forward
-    // acoustic_vrz2nd fast-path: ax/az/bx/bz/dbxdx/dbzdz vanish in the
-    // interior, so psixn=psizn=zetaxn=zetazn=0, tmpx=lap_x, tmpz=lap_z,
-    // qx=dqdx, qz=dqdz, w_sum=lap_x+lap_z. Skip the dpsix/dpsiz/daxdx/
-    // dazdz gradient loads and the four aux-field writes.
-    bool in_pml = (ix < solver.abcn + halo) || (ix >= solver.nx - solver.abcn - halo) ||
-                  (iz < (solver.free_surface ? halo : solver.abcn + halo)) ||
-                  (iz >= solver.nz - solver.abcn - halo);
-    if (!in_pml) {
-        float rhs = kappa * (beta * (lap_x + lap_z) + dbdx * dqdx + dbdz * dqdz);
-        f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + solver.dt * solver.dt * rhs;
-        return;
-    }
 
     float ax_ = cpml.ax[ix];
     float az_ = cpml.az[iz];
@@ -498,10 +618,68 @@ static __global__ void build_kappa_lambda_vrz2d(
 }
 
 template<int Order>
+__global__ void build_vrz_grad_fields(
+    const float* __restrict__ f_u_now,
+    const float* __restrict__ lambda_now,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    float* __restrict__ c_x,
+    float* __restrict__ c_z,
+    float* __restrict__ e_x,
+    float* __restrict__ e_z,
+    GradParam grad_ctx,
+    SolverContext solver
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iz = blockIdx.y * blockDim.y + threadIdx.y;
+    int b  = blockIdx.z;
+
+    if (ix >= solver.nx || iz >= solver.nz) return;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int m_static = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : m_static;
+    if (ix < halo || ix >= solver.nx - halo || iz < halo || iz >= solver.nz - halo)
+        return;
+
+    int spatial_size = solver.nx * solver.nz;
+    int idx = iz * solver.nx + ix;
+    int gidx = b * spatial_size + idx;
+
+    const float* p_b = f_u_now + b * spatial_size;
+    const float* lam_b = lambda_now + b * spatial_size;
+    const float* vp_b = vp + b * spatial_size;
+    const float* z_b = z + b * spatial_size;
+
+    float dpdx = gradient<2, Order, X>(p_b, ix, 0, iz, grad_ctx);
+    float dpdz = gradient<2, Order, Z>(p_b, ix, 0, iz, grad_ctx);
+    float v = vp_b[idx];
+    float lam = lam_b[idx];
+    float lam_v = lam * v;
+    float lam_v2z = lam * v * v * z_b[idx];
+
+    c_x[gidx] = lam_v * dpdx;          // λ·vp·∂ₓp
+    c_z[gidx] = lam_v * dpdz;          // λ·vp·∂_z p
+    e_x[gidx] = lam_v2z * dpdx;        // λ·vp²·z·∂ₓp
+    e_z[gidx] = lam_v2z * dpdz;        // λ·vp²·z·∂_z p
+}
+
+// Exact discrete-adjoint gradient (reverse-mode transpose of the forward rhs
+//   rhs = vp²·∇²p + vp·(∇vp·∇p) + vp²·z·(∇(1/z)·∇p) ).
+// SymPy-verified term-by-term against autograd (test/vrz_sympy_grad_audit.py):
+//   grad_vp = 2·vp·λ·∇²p + λ·(∇vp·∇p) - ∇·(λ·vp·∇p) + 2·vp·z·λ·(∇(1/z)·∇p)
+//   grad_z  = λ·vp²·(∇(1/z)·∇p) + ∇·(λ·vp²·z·∇p)/z²
+// The ∇·(...) divergences read the pre-computed c_d / e_d buffers (so the FD
+// gradient stencil — which is the transpose of the forward gradient — can read
+// neighbours).  The (-dt²) weight matches the forward u_next += dt²·rhs.
+template<int Order>
 __global__ void calculate_grad_vrz2d(
     const float* __restrict__ f_u_now,
     const float* __restrict__ lambda_now,
-    const float* __restrict__ kappa_lambda_now,
+    const float* __restrict__ c_x,
+    const float* __restrict__ c_z,
+    const float* __restrict__ e_x,
+    const float* __restrict__ e_z,
     const float* __restrict__ vp,
     const float* __restrict__ z,
     const float* __restrict__ inv_z,
@@ -530,7 +708,10 @@ __global__ void calculate_grad_vrz2d(
 
     const float* p_b = f_u_now + shift;
     const float* lambda_b = lambda_now + shift;
-    const float* q_b = kappa_lambda_now + shift;
+    const float* cx_b = c_x + shift;
+    const float* cz_b = c_z + shift;
+    const float* ex_b = e_x + shift;
+    const float* ez_b = e_z + shift;
     const float* vp_b = vp + shift;
     const float* z_b = z + shift;
     const float* inv_z_b = inv_z + shift;
@@ -548,20 +729,28 @@ __global__ void calculate_grad_vrz2d(
     float z1x = gradient<2, Order, X>(inv_z_b, ix, 0, iz, grad_ctx);
     float z1z = gradient<2, Order, Z>(inv_z_b, ix, 0, iz, grad_ctx);
 
-    float v = vp_b[idx];
-    float inv_z0 = inv_z_b[idx];
-    float beta = v * inv_z0;
-    float dbdx = dvpdx * inv_z0 + v * z1x;
-    float dbdz = dvpdz * inv_z0 + v * z1z;
-    float div_b_grad_p = beta * (lap_x + lap_z) + dbdx * dpdx + dbdz * dpdz;
+    // ∇·(c)  and  ∇·(e)  via the FD gradient stencil (transpose of forward grad).
+    float div_c = gradient<2, Order, X>(cx_b, ix, 0, iz, grad_ctx)
+                + gradient<2, Order, Z>(cz_b, ix, 0, iz, grad_ctx);
+    float div_e = gradient<2, Order, X>(ex_b, ix, 0, iz, grad_ctx)
+                + gradient<2, Order, Z>(ez_b, ix, 0, iz, grad_ctx);
 
-    float d_q_dpdx = vrz2d_split_grad_q_gradp<Order, X>(q_b, p_b, ix, iz, grad_ctx, solver);
-    float d_q_dpdz = vrz2d_split_grad_q_gradp<Order, Z>(q_b, p_b, ix, iz, grad_ctx, solver);
+    float v = vp_b[idx];
+    float zz = z_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float lam = lambda_b[idx];
+
+    float dp_dvp   = dpdx * dvpdx + dpdz * dvpdz;   // ∇p·∇vp
+    float dp_dinvz = dpdx * z1x  + dpdz * z1z;      // ∇p·∇(1/z)
+
+    float g_vp = 2.0f * v * lam * (lap_x + lap_z)
+               + lam * dp_dvp
+               - div_c
+               + 2.0f * v * zz * lam * dp_dinvz;
+    float g_z  = lam * v * v * dp_dinvz
+               + div_e * inv_z0 * inv_z0;           // ∇·(e)/z²
 
     float dt2 = solver.dt * solver.dt;
-    float g_kappa = -dt2 * lambda_b[idx] * div_b_grad_p;
-    float g_beta = dt2 * (d_q_dpdx + d_q_dpdz);
-
-    grad_vp_b[idx] += z_b[idx] * g_kappa + inv_z0 * g_beta;
-    grad_z_b[idx] += v * g_kappa - beta * inv_z0 * g_beta;
+    grad_vp_b[idx] += -dt2 * g_vp;
+    grad_z_b[idx]  += -dt2 * g_z;
 }

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/backward.cu
@@ -77,7 +77,16 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto kappa_lambda = torch::zeros_like(vp);
+    auto aq0 = torch::zeros_like(vp);   // adjoint transpose buffers (b·κ·λ, (∂b·κ)λ)
+    auto aqx = torch::zeros_like(vp);
+    auto aqy = torch::zeros_like(vp);
+    auto aqz = torch::zeros_like(vp);
+    auto c_x = torch::zeros_like(vp);   // gradient assembly buffers (λ·vp·∂p, λ·vp²z·∂p)
+    auto c_y = torch::zeros_like(vp);
+    auto c_z = torch::zeros_like(vp);
+    auto e_x = torch::zeros_like(vp);
+    auto e_y = torch::zeros_like(vp);
+    auto e_z = torch::zeros_like(vp);
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(in.pml_vals, 3);
     auto cpml = cpml_tensor.view();
@@ -93,6 +102,22 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
 
     for (int it = in.nt - 1; it >= 0; --it) {
         auto adj_view = adjoint.view();
+        BUILD_VRZ_ADJOINT_FIELDS_3D(
+            order,
+            launch_config.grid,
+            launch_config.block,
+            adj_view.u_now,
+            vp.data_ptr<float>(),
+            z.data_ptr<float>(),
+            inv_z.data_ptr<float>(),
+            aq0.data_ptr<float>(),
+            aqx.data_ptr<float>(),
+            aqy.data_ptr<float>(),
+            aqz.data_ptr<float>(),
+            grad_ctx,
+            ctx
+        );
+
         ACOUSTIC_VRZ3D_ADJOINT(
             order,
             launch_config.grid,
@@ -101,6 +126,10 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
+            aq0.data_ptr<float>(),
+            aqx.data_ptr<float>(),
+            aqy.data_ptr<float>(),
+            aqz.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
             grad_ctx_x,
@@ -121,11 +150,21 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
 
         adjoint.swap();
 
-        build_kappa_lambda_vrz3d<<<launch_config.grid, launch_config.block>>>(
+        BUILD_VRZ_GRAD_FIELDS_3D(
+            order,
+            launch_config.grid,
+            launch_config.block,
+            in.u_forward.select(0, it).select(0, 0).data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
-            kappa_lambda.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_y.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_y.data_ptr<float>(),
+            e_z.data_ptr<float>(),
+            grad_ctx,
             ctx
         );
 
@@ -135,7 +174,12 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
             launch_config.block,
             in.u_forward.select(0, it).select(0, 0).data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
-            kappa_lambda.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_y.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_y.data_ptr<float>(),
+            e_z.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
@@ -220,7 +264,16 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto kappa_lambda = torch::zeros_like(vp);
+    auto aq0 = torch::zeros_like(vp);   // adjoint transpose buffers (b·κ·λ, (∂b·κ)λ)
+    auto aqx = torch::zeros_like(vp);
+    auto aqy = torch::zeros_like(vp);
+    auto aqz = torch::zeros_like(vp);
+    auto c_x = torch::zeros_like(vp);   // gradient assembly buffers (λ·vp·∂p, λ·vp²z·∂p)
+    auto c_y = torch::zeros_like(vp);
+    auto c_z = torch::zeros_like(vp);
+    auto e_x = torch::zeros_like(vp);
+    auto e_y = torch::zeros_like(vp);
+    auto e_z = torch::zeros_like(vp);
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 3);
@@ -275,6 +328,22 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
     for (int it = p.nt - 1; it >= 1; --it) {
         auto adj_view = adjoint.view();
 
+        BUILD_VRZ_ADJOINT_FIELDS_3D(
+            order,
+            launch_config.grid,
+            launch_config.block,
+            adj_view.u_now,
+            vp.data_ptr<float>(),
+            z.data_ptr<float>(),
+            inv_z.data_ptr<float>(),
+            aq0.data_ptr<float>(),
+            aqx.data_ptr<float>(),
+            aqy.data_ptr<float>(),
+            aqz.data_ptr<float>(),
+            grad_ctx,
+            ctx
+        );
+
         ACOUSTIC_VRZ3D_ADJOINT(
             order,
             launch_config.grid,
@@ -283,6 +352,10 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
+            aq0.data_ptr<float>(),
+            aqx.data_ptr<float>(),
+            aqy.data_ptr<float>(),
+            aqz.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
             grad_ctx_x,
@@ -340,11 +413,21 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
 
         forward.swap();
 
-        build_kappa_lambda_vrz3d<<<launch_config.grid, launch_config.block>>>(
+        BUILD_VRZ_GRAD_FIELDS_3D(
+            order,
+            launch_config.grid,
+            launch_config.block,
+            forward.u_now_t.data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
-            kappa_lambda.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_y.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_y.data_ptr<float>(),
+            e_z.data_ptr<float>(),
+            grad_ctx,
             ctx
         );
 
@@ -354,7 +437,12 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
             launch_config.block,
             forward.u_now_t.data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
-            kappa_lambda.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_y.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_y.data_ptr<float>(),
+            e_z.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
@@ -436,7 +524,16 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto kappa_lambda = torch::zeros_like(vp);
+    auto aq0 = torch::zeros_like(vp);   // adjoint transpose buffers (b·κ·λ, (∂b·κ)λ)
+    auto aqx = torch::zeros_like(vp);
+    auto aqy = torch::zeros_like(vp);
+    auto aqz = torch::zeros_like(vp);
+    auto c_x = torch::zeros_like(vp);   // gradient assembly buffers (λ·vp·∂p, λ·vp²z·∂p)
+    auto c_y = torch::zeros_like(vp);
+    auto c_z = torch::zeros_like(vp);
+    auto e_x = torch::zeros_like(vp);
+    auto e_y = torch::zeros_like(vp);
+    auto e_z = torch::zeros_like(vp);
     auto checkpoint_steps_cpu = p.checkpoint_steps.defined()
         ? p.checkpoint_steps.to(torch::kCPU).to(torch::kInt32).contiguous()
         : torch::empty({0}, torch::TensorOptions().dtype(torch::kInt32));
@@ -552,6 +649,22 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
         for (int it = end - 1; it >= start; --it) {
             auto adj_view = adjoint.view();
 
+            BUILD_VRZ_ADJOINT_FIELDS_3D(
+                order,
+                launch_config.grid,
+                launch_config.block,
+                adj_view.u_now,
+                vp.data_ptr<float>(),
+                z.data_ptr<float>(),
+                inv_z.data_ptr<float>(),
+                aq0.data_ptr<float>(),
+                aqx.data_ptr<float>(),
+                aqy.data_ptr<float>(),
+                aqz.data_ptr<float>(),
+                grad_ctx,
+                ctx
+            );
+
             ACOUSTIC_VRZ3D_ADJOINT(
                 order,
                 launch_config.grid,
@@ -560,6 +673,10 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
                 vp.data_ptr<float>(),
                 z.data_ptr<float>(),
                 inv_z.data_ptr<float>(),
+                aq0.data_ptr<float>(),
+                aqx.data_ptr<float>(),
+                aqy.data_ptr<float>(),
+                aqz.data_ptr<float>(),
                 lap_ctx,
                 grad_ctx,
                 grad_ctx_x,
@@ -580,11 +697,21 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
 
             adjoint.swap();
 
-            build_kappa_lambda_vrz3d<<<launch_config.grid, launch_config.block>>>(
+            BUILD_VRZ_GRAD_FIELDS_3D(
+                order,
+                launch_config.grid,
+                launch_config.block,
+                chunk_forward[it - start].data_ptr<float>(),
                 adjoint.u_now_t.data_ptr<float>(),
                 vp.data_ptr<float>(),
                 z.data_ptr<float>(),
-                kappa_lambda.data_ptr<float>(),
+                c_x.data_ptr<float>(),
+                c_y.data_ptr<float>(),
+                c_z.data_ptr<float>(),
+                e_x.data_ptr<float>(),
+                e_y.data_ptr<float>(),
+                e_z.data_ptr<float>(),
+                grad_ctx,
                 ctx
             );
 
@@ -594,7 +721,12 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
                 launch_config.block,
                 chunk_forward[it - start].data_ptr<float>(),
                 adjoint.u_now_t.data_ptr<float>(),
-                kappa_lambda.data_ptr<float>(),
+                c_x.data_ptr<float>(),
+                c_y.data_ptr<float>(),
+                c_z.data_ptr<float>(),
+                e_x.data_ptr<float>(),
+                e_y.data_ptr<float>(),
+                e_z.data_ptr<float>(),
                 vp.data_ptr<float>(),
                 z.data_ptr<float>(),
                 inv_z.data_ptr<float>(),

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/kernels.cuh
@@ -42,10 +42,54 @@ static __global__ void build_kappa_lambda_vrz3d(
 );
 
 template<int Order>
+__global__ void build_vrz_grad_fields_3d(
+    const float* __restrict__ f_u_now,
+    const float* __restrict__ lambda_now,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    float* __restrict__ c_x, float* __restrict__ c_y, float* __restrict__ c_z,
+    float* __restrict__ e_x, float* __restrict__ e_y, float* __restrict__ e_z,
+    GradParam grad_ctx,
+    SolverContext solver
+);
+
+template<int Order>
+__global__ void build_vrz_adjoint_fields_3d(
+    const float* __restrict__ lambda_now,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    float* __restrict__ aq0, float* __restrict__ aqx,
+    float* __restrict__ aqy, float* __restrict__ aqz,
+    GradParam grad_ctx,
+    SolverContext solver
+);
+
+template<int Order>
+__global__ void acoustic_vrz3nd_adjoint(
+    AcousticWavefieldPointer wf,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    const float* __restrict__ aq0,
+    const float* __restrict__ aqx,
+    const float* __restrict__ aqy,
+    const float* __restrict__ aqz,
+    LaplaceParam lap_ctx,
+    GradParam grad_ctx,
+    GradParam grad_ctx_x,
+    GradParam grad_ctx_y,
+    GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml,
+    SolverContext solver
+);
+
+template<int Order>
 __global__ void calculate_grad_vrz3d(
     const float* __restrict__ f_u_now,
     const float* __restrict__ lambda_now,
-    const float* __restrict__ kappa_lambda_now,
+    const float* __restrict__ c_x, const float* __restrict__ c_y, const float* __restrict__ c_z,
+    const float* __restrict__ e_x, const float* __restrict__ e_y, const float* __restrict__ e_z,
     const float* __restrict__ vp,
     const float* __restrict__ z,
     const float* __restrict__ inv_z,
@@ -76,11 +120,29 @@ __global__ void calculate_grad_vrz3d(
 
 #define ACOUSTIC_VRZ3D_ADJOINT(order, grid, block, ...)                                     \
     do {                                                                                    \
-        if      ((order) == 2) acoustic_vrz3nd<2><<<grid, block>>>(__VA_ARGS__);            \
-        else if ((order) == 4) acoustic_vrz3nd<4><<<grid, block>>>(__VA_ARGS__);            \
-        else if ((order) == 6) acoustic_vrz3nd<6><<<grid, block>>>(__VA_ARGS__);            \
-        else if ((order) == 8) acoustic_vrz3nd<8><<<grid, block>>>(__VA_ARGS__);            \
-        else                   acoustic_vrz3nd<-1><<<grid, block>>>(__VA_ARGS__);           \
+        if      ((order) == 2) acoustic_vrz3nd_adjoint<2><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 4) acoustic_vrz3nd_adjoint<4><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 6) acoustic_vrz3nd_adjoint<6><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 8) acoustic_vrz3nd_adjoint<8><<<grid, block>>>(__VA_ARGS__);    \
+        else                   acoustic_vrz3nd_adjoint<-1><<<grid, block>>>(__VA_ARGS__);   \
+    } while (0)
+
+#define BUILD_VRZ_ADJOINT_FIELDS_3D(order, grid, block, ...)                                \
+    do {                                                                                    \
+        if      ((order) == 2) build_vrz_adjoint_fields_3d<2><<<grid, block>>>(__VA_ARGS__);\
+        else if ((order) == 4) build_vrz_adjoint_fields_3d<4><<<grid, block>>>(__VA_ARGS__);\
+        else if ((order) == 6) build_vrz_adjoint_fields_3d<6><<<grid, block>>>(__VA_ARGS__);\
+        else if ((order) == 8) build_vrz_adjoint_fields_3d<8><<<grid, block>>>(__VA_ARGS__);\
+        else                   build_vrz_adjoint_fields_3d<-1><<<grid, block>>>(__VA_ARGS__);\
+    } while (0)
+
+#define BUILD_VRZ_GRAD_FIELDS_3D(order, grid, block, ...)                                   \
+    do {                                                                                    \
+        if      ((order) == 2) build_vrz_grad_fields_3d<2><<<grid, block>>>(__VA_ARGS__);   \
+        else if ((order) == 4) build_vrz_grad_fields_3d<4><<<grid, block>>>(__VA_ARGS__);   \
+        else if ((order) == 6) build_vrz_grad_fields_3d<6><<<grid, block>>>(__VA_ARGS__);   \
+        else if ((order) == 8) build_vrz_grad_fields_3d<8><<<grid, block>>>(__VA_ARGS__);   \
+        else                   build_vrz_grad_fields_3d<-1><<<grid, block>>>(__VA_ARGS__);  \
     } while (0)
 
 #define CALCULATE_GRAD_VRZ3D(order, grid, block, ...)                                       \
@@ -441,11 +503,233 @@ static __global__ void build_kappa_lambda_vrz3d(
     kappa_lambda[idx] = vp[idx] * z[idx] * lambda_now[idx];
 }
 
+// Reverse-mode buffers for the exact discrete-adjoint gradient (3-D):
+//   c_d = λ·vp·∂_d p ,   e_d = λ·vp²·z·∂_d p   (d = x, y, z)
+template<int Order>
+__global__ void build_vrz_grad_fields_3d(
+    const float* __restrict__ f_u_now,
+    const float* __restrict__ lambda_now,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    float* __restrict__ c_x, float* __restrict__ c_y, float* __restrict__ c_z,
+    float* __restrict__ e_x, float* __restrict__ e_y, float* __restrict__ e_z,
+    GradParam grad_ctx,
+    SolverContext solver
+) {
+    int ix, iy, iz, b;
+    vrz3d_index<Order>(solver, ix, iy, iz, b);
+    if (!vrz3d_interior<Order>(solver, ix, iy, iz, b)) return;
+
+    int spatial_size = solver.nx * solver.ny * solver.nz;
+    int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
+    int gidx = b * spatial_size + idx;
+
+    const float* p_b = f_u_now + b * spatial_size;
+    const float* lam_b = lambda_now + b * spatial_size;
+    const float* vp_b = vp + b * spatial_size;
+    const float* z_b = z + b * spatial_size;
+
+    float dpdx = gradient<3, Order, X>(p_b, ix, iy, iz, grad_ctx);
+    float dpdy = gradient<3, Order, Y>(p_b, ix, iy, iz, grad_ctx);
+    float dpdz = gradient<3, Order, Z>(p_b, ix, iy, iz, grad_ctx);
+    float v = vp_b[idx];
+    float lam = lam_b[idx];
+    float lam_v = lam * v;
+    float lam_v2z = lam * v * v * z_b[idx];
+
+    c_x[gidx] = lam_v * dpdx;
+    c_y[gidx] = lam_v * dpdy;
+    c_z[gidx] = lam_v * dpdz;
+    e_x[gidx] = lam_v2z * dpdx;
+    e_y[gidx] = lam_v2z * dpdy;
+    e_z[gidx] = lam_v2z * dpdz;
+}
+
+// Pre-multiply λ by the model-only adjoint coefficients (race-free split):
+//   aq0 = b·κ·λ = vp²·λ ,  aq_d = (∂_d b·κ)·λ   (d = x, y, z)
+template<int Order>
+__global__ void build_vrz_adjoint_fields_3d(
+    const float* __restrict__ lambda_now,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    float* __restrict__ aq0, float* __restrict__ aqx,
+    float* __restrict__ aqy, float* __restrict__ aqz,
+    GradParam grad_ctx,
+    SolverContext solver
+) {
+    int ix, iy, iz, b;
+    vrz3d_index<Order>(solver, ix, iy, iz, b);
+    if (!vrz3d_interior<Order>(solver, ix, iy, iz, b)) return;
+
+    int spatial_size = solver.nx * solver.ny * solver.nz;
+    int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
+    int gidx = b * spatial_size + idx;
+
+    const float* vp_b = vp + b * spatial_size;
+    const float* z_b = z + b * spatial_size;
+    const float* inv_z_b = inv_z + b * spatial_size;
+    const float* lam_b = lambda_now + b * spatial_size;
+
+    float dvpdx = gradient<3, Order, X>(vp_b, ix, iy, iz, grad_ctx);
+    float dvpdy = gradient<3, Order, Y>(vp_b, ix, iy, iz, grad_ctx);
+    float dvpdz = gradient<3, Order, Z>(vp_b, ix, iy, iz, grad_ctx);
+    float z1x = gradient<3, Order, X>(inv_z_b, ix, iy, iz, grad_ctx);
+    float z1y = gradient<3, Order, Y>(inv_z_b, ix, iy, iz, grad_ctx);
+    float z1z = gradient<3, Order, Z>(inv_z_b, ix, iy, iz, grad_ctx);
+    float v = vp_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float kappa = v * z_b[idx];
+    float dbdx = dvpdx * inv_z0 + v * z1x;
+    float dbdy = dvpdy * inv_z0 + v * z1y;
+    float dbdz = dvpdz * inv_z0 + v * z1z;
+    float lam = lam_b[idx];
+
+    aq0[gidx] = v * v * lam;
+    aqx[gidx] = dbdx * kappa * lam;
+    aqy[gidx] = dbdy * kappa * lam;
+    aqz[gidx] = dbdz * kappa * lam;
+}
+
+// Proper adjoint propagation (3-D): transpose Aᵀλ of the forward interior
+//   A u = κ·(b·∇²u + ∂ₓb·∂ₓu + ∂_yb·∂_yu + ∂_zb·∂_zu) is
+//   Aᵀλ = ∇²(vp²λ) − ∂ₓ((κ∂ₓb)λ) − ∂_y((κ∂_yb)λ) − ∂_z((κ∂_zb)λ),
+// applied to the pre-multiplied buffers from build_vrz_adjoint_fields_3d.
+// PML branch keeps the forward formulation (as in acoustic / 2-D VRZ).
+template<int Order>
+__global__ void acoustic_vrz3nd_adjoint(
+    AcousticWavefieldPointer wf,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    const float* __restrict__ aq0,
+    const float* __restrict__ aqx,
+    const float* __restrict__ aqy,
+    const float* __restrict__ aqz,
+    LaplaceParam lap_ctx,
+    GradParam grad_ctx,
+    GradParam grad_ctx_x,
+    GradParam grad_ctx_y,
+    GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml,
+    SolverContext solver
+) {
+    int ix, iy, iz, b;
+    vrz3d_index<Order>(solver, ix, iy, iz, b);
+    if (!vrz3d_interior<Order>(solver, ix, iy, iz, b)) return;
+
+    int spatial_size = solver.nx * solver.ny * solver.nz;
+    int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int m_static = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : m_static;
+
+    auto f = wf.offset(b, spatial_size);
+
+    bool in_pml = (ix < solver.abcn + halo) || (ix >= solver.nx - solver.abcn - halo) ||
+                  (iy < solver.abcn + halo) || (iy >= solver.ny - solver.abcn - halo) ||
+                  (iz < (solver.free_surface ? halo : solver.abcn + halo)) ||
+                  (iz >= solver.nz - solver.abcn - halo);
+
+    if (!in_pml) {
+        const float* aq0_b = aq0 + b * spatial_size;
+        const float* aqx_b = aqx + b * spatial_size;
+        const float* aqy_b = aqy + b * spatial_size;
+        const float* aqz_b = aqz + b * spatial_size;
+        float lap_x = laplace<3, Order, X>(aq0_b, ix, iy, iz, lap_ctx);
+        float lap_y = laplace<3, Order, Y>(aq0_b, ix, iy, iz, lap_ctx);
+        float lap_z = laplace<3, Order, Z>(aq0_b, ix, iy, iz, lap_ctx);
+        float gx = gradient<3, Order, X>(aqx_b, ix, iy, iz, grad_ctx);
+        float gy = gradient<3, Order, Y>(aqy_b, ix, iy, iz, grad_ctx);
+        float gz = gradient<3, Order, Z>(aqz_b, ix, iy, iz, grad_ctx);
+        float rhs = (lap_x + lap_y + lap_z) - gx - gy - gz;
+        f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + solver.dt * solver.dt * rhs;
+        return;
+    }
+
+    const float* vp_b = vp + b * spatial_size;
+    const float* z_b = z + b * spatial_size;
+    const float* inv_z_b = inv_z + b * spatial_size;
+
+    float lap_x = laplace<3, Order, X>(f.u_now, ix, iy, iz, lap_ctx);
+    float lap_y = laplace<3, Order, Y>(f.u_now, ix, iy, iz, lap_ctx);
+    float lap_z = laplace<3, Order, Z>(f.u_now, ix, iy, iz, lap_ctx);
+
+    float dudx = gradient<3, Order, X>(f.u_now, ix, iy, iz, grad_ctx);
+    float dudy = gradient<3, Order, Y>(f.u_now, ix, iy, iz, grad_ctx);
+    float dudz = gradient<3, Order, Z>(f.u_now, ix, iy, iz, grad_ctx);
+
+    float dvpdx = gradient<3, Order, X>(vp_b, ix, iy, iz, grad_ctx);
+    float dvpdy = gradient<3, Order, Y>(vp_b, ix, iy, iz, grad_ctx);
+    float dvpdz = gradient<3, Order, Z>(vp_b, ix, iy, iz, grad_ctx);
+    float z1x = gradient<3, Order, X>(inv_z_b, ix, iy, iz, grad_ctx);
+    float z1y = gradient<3, Order, Y>(inv_z_b, ix, iy, iz, grad_ctx);
+    float z1z = gradient<3, Order, Z>(inv_z_b, ix, iy, iz, grad_ctx);
+
+    float v = vp_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float beta = v * inv_z0;
+    float kappa = v * z_b[idx];
+    float dbdx = dvpdx * inv_z0 + v * z1x;
+    float dbdy = dvpdy * inv_z0 + v * z1y;
+    float dbdz = dvpdz * inv_z0 + v * z1z;
+
+    float dpsixdx = gradient<3, Order, X>(f.psix, ix, iy, iz, grad_ctx);
+    float dpsiydy = gradient<3, Order, Y>(f.psiy, ix, iy, iz, grad_ctx);
+    float dpsizdz = gradient<3, Order, Z>(f.psiz, ix, iy, iz, grad_ctx);
+
+    float daxdx = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
+    float daydy = gradient<2, Order, X>(cpml.ay, iy, 0, 0, grad_ctx_y);
+    float dazdz = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
+
+    float ax_ = cpml.ax[ix];
+    float ay_ = cpml.ay[iy];
+    float az_ = cpml.az[iz];
+    float bx_ = cpml.bx[ix];
+    float by_ = cpml.by[iy];
+    float bz_ = cpml.bz[iz];
+
+    float tmpx = ((1.0f + bx_) * lap_x + cpml.dbxdx[ix] * dudx)
+               + daxdx * f.psix[idx] + ax_ * dpsixdx;
+    float tmpy = ((1.0f + by_) * lap_y + cpml.dbydy[iy] * dudy)
+               + daydy * f.psiy[idx] + ay_ * dpsiydy;
+    float tmpz = ((1.0f + bz_) * lap_z + cpml.dbzdz[iz] * dudz)
+               + dazdz * f.psiz[idx] + az_ * dpsizdz;
+
+    float psixn = bx_ * dudx + ax_ * f.psix[idx];
+    float psiyn = by_ * dudy + ay_ * f.psiy[idx];
+    float psizn = bz_ * dudz + az_ * f.psiz[idx];
+    float zetaxn = bx_ * tmpx + ax_ * f.zetax[idx];
+    float zetayn = by_ * tmpy + ay_ * f.zetay[idx];
+    float zetazn = bz_ * tmpz + az_ * f.zetaz[idx];
+
+    float px = dudx + psixn;
+    float py = dudy + psiyn;
+    float pz = dudz + psizn;
+    float w_sum = (1.0f + bx_) * tmpx + ax_ * f.zetax[idx]
+                + (1.0f + by_) * tmpy + ay_ * f.zetay[idx]
+                + (1.0f + bz_) * tmpz + az_ * f.zetaz[idx];
+
+    float rhs = kappa * (beta * w_sum + dbdx * px + dbdy * py + dbdz * pz);
+
+    f.psix[idx] = psixn;
+    f.psiy[idx] = psiyn;
+    f.psiz[idx] = psizn;
+    f.zetax[idx] = zetaxn;
+    f.zetay[idx] = zetayn;
+    f.zetaz[idx] = zetazn;
+    f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + solver.dt * solver.dt * rhs;
+}
+
+// Exact discrete-adjoint gradient (3-D), reverse-mode transpose of the forward
+//   rhs = vp²·∇²p + vp·(∇vp·∇p) + vp²·z·(∇(1/z)·∇p).  Mirrors calculate_grad_vrz2d.
 template<int Order>
 __global__ void calculate_grad_vrz3d(
     const float* __restrict__ f_u_now,
     const float* __restrict__ lambda_now,
-    const float* __restrict__ kappa_lambda_now,
+    const float* __restrict__ c_x, const float* __restrict__ c_y, const float* __restrict__ c_z,
+    const float* __restrict__ e_x, const float* __restrict__ e_y, const float* __restrict__ e_z,
     const float* __restrict__ vp,
     const float* __restrict__ z,
     const float* __restrict__ inv_z,
@@ -459,15 +743,18 @@ __global__ void calculate_grad_vrz3d(
     vrz3d_index<Order>(solver, ix, iy, iz, b);
     if (!vrz3d_interior<Order>(solver, ix, iy, iz, b)) return;
 
-    int stride_y = solver.nx;
-    int stride_z = solver.nx * solver.ny;
     int spatial_size = solver.nx * solver.ny * solver.nz;
-    int idx = iz * stride_z + iy * stride_y + ix;
+    int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
     int shift = b * spatial_size;
 
     const float* p_b = f_u_now + shift;
     const float* lambda_b = lambda_now + shift;
-    const float* q_b = kappa_lambda_now + shift;
+    const float* cx_b = c_x + shift;
+    const float* cy_b = c_y + shift;
+    const float* cz_b = c_z + shift;
+    const float* ex_b = e_x + shift;
+    const float* ey_b = e_y + shift;
+    const float* ez_b = e_z + shift;
     const float* vp_b = vp + shift;
     const float* z_b = z + shift;
     const float* inv_z_b = inv_z + shift;
@@ -489,23 +776,29 @@ __global__ void calculate_grad_vrz3d(
     float z1y = gradient<3, Order, Y>(inv_z_b, ix, iy, iz, grad_ctx);
     float z1z = gradient<3, Order, Z>(inv_z_b, ix, iy, iz, grad_ctx);
 
-    float v = vp_b[idx];
-    float inv_z0 = inv_z_b[idx];
-    float beta = v * inv_z0;
-    float dbdx = dvpdx * inv_z0 + v * z1x;
-    float dbdy = dvpdy * inv_z0 + v * z1y;
-    float dbdz = dvpdz * inv_z0 + v * z1z;
-    float div_b_grad_p = beta * (lap_x + lap_y + lap_z)
-                       + dbdx * dpdx + dbdy * dpdy + dbdz * dpdz;
+    float div_c = gradient<3, Order, X>(cx_b, ix, iy, iz, grad_ctx)
+                + gradient<3, Order, Y>(cy_b, ix, iy, iz, grad_ctx)
+                + gradient<3, Order, Z>(cz_b, ix, iy, iz, grad_ctx);
+    float div_e = gradient<3, Order, X>(ex_b, ix, iy, iz, grad_ctx)
+                + gradient<3, Order, Y>(ey_b, ix, iy, iz, grad_ctx)
+                + gradient<3, Order, Z>(ez_b, ix, iy, iz, grad_ctx);
 
-    float d_q_dpdx = vrz3d_grad_q_gradp<Order, X>(q_b, p_b, ix, iy, iz, grad_ctx, solver);
-    float d_q_dpdy = vrz3d_grad_q_gradp<Order, Y>(q_b, p_b, ix, iy, iz, grad_ctx, solver);
-    float d_q_dpdz = vrz3d_grad_q_gradp<Order, Z>(q_b, p_b, ix, iy, iz, grad_ctx, solver);
+    float v = vp_b[idx];
+    float zz = z_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float lam = lambda_b[idx];
+
+    float dp_dvp   = dpdx * dvpdx + dpdy * dvpdy + dpdz * dvpdz;
+    float dp_dinvz = dpdx * z1x  + dpdy * z1y  + dpdz * z1z;
+
+    float g_vp = 2.0f * v * lam * (lap_x + lap_y + lap_z)
+               + lam * dp_dvp
+               - div_c
+               + 2.0f * v * zz * lam * dp_dinvz;
+    float g_z  = lam * v * v * dp_dinvz
+               + div_e * inv_z0 * inv_z0;
 
     float dt2 = solver.dt * solver.dt;
-    float g_kappa = -dt2 * lambda_b[idx] * div_b_grad_p;
-    float g_beta = dt2 * (d_q_dpdx + d_q_dpdy + d_q_dpdz);
-
-    grad_vp_b[idx] += z_b[idx] * g_kappa + inv_z0 * g_beta;
-    grad_z_b[idx] += v * g_kappa - beta * inv_z0 * g_beta;
+    grad_vp_b[idx] += -dt2 * g_vp;
+    grad_z_b[idx]  += -dt2 * g_z;
 }

--- a/src/sweep/equations/acoustic_vrz.py
+++ b/src/sweep/equations/acoustic_vrz.py
@@ -36,10 +36,20 @@ def step_cpml(u_now, u_pre, psix, psiz, zetax, zetaz,
 
     dpdx = grad_op(u_now, h, axis=-1, kernels=grad_kernels)
     dpdz = grad_op(u_now, h, axis=-2, kernels=grad_kernels)
-    model_b = vp / z
+    inv_z = 1.0 / z
+    model_b = vp * inv_z
     kappa = z * vp
-    dbdx = grad_op(model_b, h, axis=-1, kernels=grad_kernels)
-    dbdz = grad_op(model_b, h, axis=-2, kernels=grad_kernels)
+    # ∇b via the product rule on (vp, 1/z) — matches the C kernel exactly:
+    #   dbdx = (∂x vp)·(1/z) + vp·∂x(1/z)   [NOT ∂x(vp/z), the field-gradient form]
+    # The two discretisations differ at O(h²); using the product rule keeps the
+    # eager forward operator identical to the compiled CUDA kernel so impl='c'
+    # and impl='eager' produce the same wavefields and the same gradients.
+    dvpdx = grad_op(vp, h, axis=-1, kernels=grad_kernels)
+    dvpdz = grad_op(vp, h, axis=-2, kernels=grad_kernels)
+    dinvzdx = grad_op(inv_z, h, axis=-1, kernels=grad_kernels)
+    dinvzdz = grad_op(inv_z, h, axis=-2, kernels=grad_kernels)
+    dbdx = dvpdx * inv_z + vp * dinvzdx
+    dbdz = dvpdz * inv_z + vp * dinvzdz
 
     # Z direction
     tmpz = ((1+bz)*lap_z + dbzdz * dpdz) + grad_op(az * psiz, h, axis=-2, kernels=grad_kernels)
@@ -79,11 +89,20 @@ def step_cpml_3d(
     dpdx = grad_op(u_now, h, axis=-1, kernels=grad_kernels)
     dpdy = grad_op(u_now, h, axis=-2, kernels=grad_kernels)
     dpdz = grad_op(u_now, h, axis=-3, kernels=grad_kernels)
-    model_b = vp / z
+    inv_z = 1.0 / z
+    model_b = vp * inv_z
     kappa = z * vp
-    dbdx = grad_op(model_b, h, axis=-1, kernels=grad_kernels)
-    dbdy = grad_op(model_b, h, axis=-2, kernels=grad_kernels)
-    dbdz = grad_op(model_b, h, axis=-3, kernels=grad_kernels)
+    # ∇b via the product rule on (vp, 1/z) — matches the C kernel exactly
+    # (see the 2-D step_cpml for why the field-gradient form is avoided).
+    dvpdx = grad_op(vp, h, axis=-1, kernels=grad_kernels)
+    dvpdy = grad_op(vp, h, axis=-2, kernels=grad_kernels)
+    dvpdz = grad_op(vp, h, axis=-3, kernels=grad_kernels)
+    dinvzdx = grad_op(inv_z, h, axis=-1, kernels=grad_kernels)
+    dinvzdy = grad_op(inv_z, h, axis=-2, kernels=grad_kernels)
+    dinvzdz = grad_op(inv_z, h, axis=-3, kernels=grad_kernels)
+    dbdx = dvpdx * inv_z + vp * dinvzdx
+    dbdy = dvpdy * inv_z + vp * dinvzdy
+    dbdz = dvpdz * inv_z + vp * dinvzdz
 
     # Z direction
     tmpz = ((1 + bz) * lap_z + dbzdz * dpdz) + grad_op(az * psiz, h, axis=-3, kernels=grad_kernels)

--- a/test/vrz_sympy_grad_audit.py
+++ b/test/vrz_sympy_grad_audit.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""SymPy audit of acoustic_vrz2d ``calculate_grad_vrz2d`` gradient formula.
+
+Build the DISCRETE 1-D VRZ forward RHS with explicit 2nd-order FD stencils,
+form the per-step adjoint inner product  loss = sum_i lam_i * rhs_i , and let
+SymPy differentiate w.r.t. vp_j and z_j.  That derivative IS the exact discrete
+adjoint gradient (what eager autograd computes).  Then evaluate the kernel's
+analytic formula and compare.
+
+Forward (matches kernels.cuh):  rhs_i = kappa_i ( b_i*lap_p_i + db_i*dp_i )
+  kappa = vp*z,  b = vp/z,  db = (d vp)/z + vp*d(1/z)   [product-rule form].
+"""
+import sympy as sp
+import random
+
+h = sp.symbols('h', positive=True)
+N = 7
+j = 3
+
+vp = sp.symbols(f'vp0:{N}', positive=True)
+z  = sp.symbols(f'z0:{N}',  positive=True)
+p  = sp.symbols(f'p0:{N}')
+lam = sp.symbols(f'lam0:{N}')
+
+invz = [1/z[i] for i in range(N)]
+kappa = [vp[i]*z[i] for i in range(N)]
+b = [vp[i]/z[i] for i in range(N)]
+
+def d1(f, i):
+    return (f[i+1] - f[i-1])/(2*h)
+def d2(f, i):
+    return (f[i-1] - 2*f[i] + f[i+1])/(h**2)
+
+rhs = {}
+for i in range(1, N-1):
+    dvp = d1(vp, i); dinvz = d1(invz, i)
+    db = dvp*invz[i] + vp[i]*dinvz
+    rhs[i] = kappa[i]*(b[i]*d2(p, i) + db*d1(p, i))
+
+loss = sum(lam[i]*rhs[i] for i in rhs)
+
+grad_vp_exact = sp.simplify(sp.diff(loss, vp[j]))
+grad_z_exact  = sp.simplify(sp.diff(loss, z[j]))
+
+q = [kappa[i]*lam[i] for i in range(N)]
+div_b_grad_p = b[j]*d2(p, j) + (d1(vp, j)*invz[j] + vp[j]*d1(invz, j))*d1(p, j)
+g_kappa = -lam[j]*div_b_grad_p
+g_beta  =  d1(q, j)*d1(p, j)
+grad_vp_code = sp.simplify(z[j]*g_kappa + invz[j]*g_beta)
+grad_z_code  = sp.simplify(vp[j]*g_kappa - b[j]*invz[j]*g_beta)
+
+# --- PROPOSED FIX: op-by-op reverse-mode exact discrete transpose ----------
+# rhs_i = vp_i^2 lap_i + vp_i (dvp_i)(dp_i) + vp_i^2 z_i (dinvz_i)(dp_i)
+# Buffers:  c_i = lam_i vp_i dp_i ;  e_i = lam_i vp_i^2 z_i dp_i
+dp = [d1(p, i) if 0 < i < N-1 else sp.Integer(0) for i in range(N)]
+c = [lam[i]*vp[i]*dp[i] for i in range(N)]
+e = [lam[i]*vp[i]**2*z[i]*dp[i] for i in range(N)]
+lap_j, dpj, dvpj, dinvzj = d2(p, j), d1(p, j), d1(vp, j), d1(invz, j)
+grad_vp_fix = sp.simplify(
+    2*vp[j]*lam[j]*lap_j + lam[j]*dvpj*dpj - d1(c, j) + 2*vp[j]*z[j]*lam[j]*dinvzj*dpj)
+grad_z_fix = sp.simplify(
+    lam[j]*vp[j]**2*dinvzj*dpj + d1(e, j)/z[j]**2)
+
+print("=== PROPOSED FIX vs exact discrete adjoint ===")
+for name, exact, fix in [("grad_vp", grad_vp_exact, grad_vp_fix),
+                         ("grad_z",  grad_z_exact,  grad_z_fix)]:
+    d = sp.simplify(exact - fix)
+    print(f"  {name}:  exact - fix = {d}   ->  {'MATCH ✅' if d == 0 else 'MISMATCH ❌'}")
+
+print("\n=== current kernel formula vs exact ===")
+for name, exact, code in [("grad_vp", grad_vp_exact, grad_vp_code),
+                          ("grad_z",  grad_z_exact,  grad_z_code)]:
+    diff_plus  = sp.simplify(exact - code)
+    diff_minus = sp.simplify(exact + code)
+    subs = {**{vp[i]: 1.5+random.random() for i in range(N)},
+            **{z[i]: 1.0+random.random() for i in range(N)},
+            **{p[i]: random.random()-0.5 for i in range(N)},
+            **{lam[i]: random.random()-0.5 for i in range(N)}, h: 10.0}
+    ev_e = float(exact.subs(subs)); ev_c = float(code.subs(subs))
+    print(f"\n{name}:")
+    print(f"  numeric: exact={ev_e:.6e}  code={ev_c:.6e}  exact/code={ev_e/ev_c:.4f}")
+    if diff_plus == 0 or diff_minus == 0:
+        print("  MATCH (up to overall sign) -- formula is exact discrete adjoint")
+    else:
+        print("  MISMATCH -- kernel formula is NOT the exact discrete adjoint")
+        print(f"  (exact + code) = {sp.nsimplify(diff_minus) if diff_minus != 0 else 0}")


### PR DESCRIPTION
## Summary
Make the compiled (`impl='c'`) `AcousticVRZ` / `AcousticVRZ3D` gradient the **exact discrete adjoint** of the forward operator, matching `impl='eager'`.

- C adjoint now applies **Aᵀ = ∇²(vp²λ) − Σ_d ∂_d((κ·∂_d b)λ)** (transpose of the forward VRZ operator); split into two kernels to avoid a read-then-write race on the premultiplied buffers.
- eager `∇b` switched to the matching product-rule discretization (`∂_d b = ∂_d vp · 1/z + vp · ∂_d(1/z)`) so eager and C agree at O(h²).
- 3D adjoint dispatch macro now calls the adjoint kernel (it was calling the forward kernel).

## Verification
- Taylor gradient-consistency slope ≈ 2 (2D + 3D).
- `grad_vp` / `grad_z` cosine ≈ 1.0 vs eager on Marmousi — even with source & receivers on the first grid cell.
- Adds `test/vrz_sympy_grad_audit.py`, a SymPy oracle for the gradient assembly.

The CPML-zone adjoint is intentionally kept as the forward operator (matching the existing acoustic adjoint design); the residual c-vs-eager difference is a near-source O(dt²) term, not an edge artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
