### PR TITLE
fix(boundary): derive storage dtype from buffers, not env

### DIFF
--- a/src/sweep/csrc/cuda/common/boundary/saver.cuh
+++ b/src/sweep/csrc/cuda/common/boundary/saver.cuh
@@ -13,6 +13,18 @@
 #include "kernels.cuh"
 #include "types.cuh"
 
+// Map a boundary-buffer tensor's dtype to the storage-dtype enum.  Python
+// allocates the buffers in the requested precision, so the tensor itself is
+// the source of truth (uint8 == the INT8 path's quantized main buffer).
+static inline BoundaryDtype boundary_dtype_from_tensor(const torch::Tensor& t) {
+    switch (t.scalar_type()) {
+        case torch::kUInt8:    return BoundaryDtype::INT8;
+        case torch::kHalf:     return BoundaryDtype::FP16;
+        case torch::kBFloat16: return BoundaryDtype::BF16;
+        default:               return BoundaryDtype::FP32;
+    }
+}
+
 struct EffectiveBoundarySaver {
 
     torch::Tensor left_t, right_t;
@@ -345,13 +357,25 @@ struct EffectiveBoundarySaver {
         else
             store_on_gpu = (dim == 2);   // default
 
-        // FP16 / BF16 / INT8 storage gate.  Sourced from
-        // SWEEP_BOUNDARY_DTYPE env (with legacy SWEEP_FP16_BOUNDARY
-        // fallback).  Last-two and staging buffers remain FP32 —
-        // last_two is a full-wavefield snapshot used to bootstrap
-        // backward, staging is the INT8 path's per-timestep FP32 view
-        // before quantization.
-        const BoundaryDtype runtime_dtype = sweep_boundary_dtype_env();
+        // FP16 / BF16 / INT8 storage gate.  Derived from the boundary buffers
+        // Python hands us (allocated in the requested precision) rather than a
+        // process-global env var — this prevents a per-instance storage_dtype
+        // from leaking across propagator instances.  The SWEEP_BOUNDARY_DTYPE
+        // env is consulted only for the (normally unreachable) C++-side
+        // self-allocation fallback where no buffer is passed.  Last-two and
+        // staging buffers remain FP32 — last_two is a full-wavefield snapshot
+        // used to bootstrap backward, staging is the INT8 path's per-timestep
+        // FP32 view before quantization.
+        BoundaryDtype runtime_dtype;
+        if (!boundary_gpu.empty() && boundary_gpu[0].scalar_type() == torch::kUInt8) {
+            runtime_dtype = BoundaryDtype::INT8;        // uint8 main buffer => INT8 path
+        } else if (!boundary_cpu.empty()) {
+            runtime_dtype = boundary_dtype_from_tensor(boundary_cpu[0]);
+        } else if (!boundary_gpu.empty()) {
+            runtime_dtype = boundary_dtype_from_tensor(boundary_gpu[0]);
+        } else {
+            runtime_dtype = sweep_boundary_dtype_env();
+        }
         const bool use_int8 = (runtime_dtype == BoundaryDtype::INT8);
         torch::Dtype dtype_storage;
         switch (runtime_dtype) {

--- a/src/sweep/propagator/_c.py
+++ b/src/sweep/propagator/_c.py
@@ -665,22 +665,24 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         staging_pinned = use_pinned_memory or boundary_storage == "disk"
         staging_interval = transfer_interval * ring_buffers
         # Precedence: explicit Python kwarg (from BoundaryOptions /
-        # boundary_saving_config dict) wins over env var, which wins over
-        # the legacy SWEEP_FP16_BOUNDARY=1 gate, which wins over the
-        # ``fp32`` default.  Once resolved, sync into the env so the C++
-        # saver's ``sweep_boundary_dtype_env()`` sees the same choice.
-        import os as _os_d
+        # boundary_saving_config dict) wins over the SWEEP_BOUNDARY_DTYPE env
+        # var (the documented global override), which wins over the legacy
+        # SWEEP_FP16_BOUNDARY=1 gate, which wins over the ``fp32`` default.
+        # This only decides what dtype to ALLOCATE the boundary buffers in; we
+        # deliberately do NOT write the choice back into os.environ.  The C++
+        # saver derives the storage dtype from the buffer tensors it is handed
+        # (see csrc/.../boundary/saver.cuh), so a per-instance storage_dtype
+        # cannot leak into later default-config propagators in the same process.
         if boundary_dtype is None:
-            _env_dtype = _os_d.environ.get('SWEEP_BOUNDARY_DTYPE', '').strip().lower()
+            _env_dtype = os.environ.get('SWEEP_BOUNDARY_DTYPE', '').strip().lower()
             if _env_dtype in ('fp32', 'fp16', 'bf16', 'int8'):
                 boundary_dtype = _env_dtype
-            elif _os_d.environ.get('SWEEP_FP16_BOUNDARY', '') in ('1', 'true', 'yes', 'on'):
+            elif os.environ.get('SWEEP_FP16_BOUNDARY', '') in ('1', 'true', 'yes', 'on'):
                 boundary_dtype = 'fp16'
             else:
                 boundary_dtype = 'fp32'
         if boundary_dtype not in ('fp32', 'fp16', 'bf16', 'int8'):
             raise ValueError(f"boundary_dtype must be 'fp32'/'fp16'/'bf16'/'int8', got {boundary_dtype!r}")
-        _os_d.environ['SWEEP_BOUNDARY_DTYPE'] = boundary_dtype
         if (
             self._boundary_cache_batch == self.B
             and

--- a/test/test_boundary_dtype_env_leak.py
+++ b/test/test_boundary_dtype_env_leak.py
@@ -1,0 +1,119 @@
+"""Regression test: per-instance boundary ``storage_dtype`` must not leak into
+later default-configured PropTorch instances in the same process.
+
+Before the fix, the storage dtype was passed Python->C++ via a process-global
+``SWEEP_BOUNDARY_DTYPE`` env var that ``_ensure_boundary_buffers`` set
+permanently; a solver configured with e.g. ``storage_dtype='int8'`` then
+silently forced int8 boundary storage on every later default-configured
+PropTorch.  The C++ saver now derives the storage dtype from the boundary
+buffer tensors it is handed (csrc/.../boundary/saver.cuh), and Python no longer
+writes the env -- so the choice is per-instance and cannot leak.
+"""
+import os
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+K = "SWEEP_BOUNDARY_DTYPE"
+
+
+def _binding_ready():
+    if not torch.cuda.is_available():
+        return False
+    try:
+        from sweep import is_torch_binding_available
+
+        return bool(is_torch_binding_available())
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _binding_ready(), reason="CUDA + compiled sweep._C required")
+def test_storage_dtype_does_not_leak_across_instances(monkeypatch):
+    from sweep.equations import Acoustic
+    from sweep.propagator.options import BoundaryOptions, CUDAOptions, MemoryOptions
+    from sweep.propagator.torch import PropTorch
+
+    monkeypatch.delenv(K, raising=False)
+    dev = "cuda"
+    nz, nx, nt, dt, dh = 40, 48, 80, 0.0015, 10.0
+    vp = np.full((nz, nx), 2000.0, dtype=np.float32)
+    vp[nz // 2 :, :] += 300.0
+    sources = np.array([[nx // 2, nz // 4]], dtype=np.int32)
+    rec_x = np.arange(2, nx - 2, 4, dtype=np.int32)
+    receivers = np.stack([rec_x, np.full(rec_x.size, 2, dtype=np.int32)], -1)[None]
+    t = np.arange(nt) * dt
+    f, delay = 12.0, 0.08
+    wav = torch.tensor(
+        ((1 - 2 * (np.pi * f * (t - delay)) ** 2) * np.exp(-((np.pi * f * (t - delay)) ** 2))).astype(np.float32),
+        device=dev,
+    )
+    common = dict(shape=(nz, nx), dev=dev, dh=(dh, dh), dt=dt, source_type=["h1"],
+                  receiver_type=["h1"], abcn=20, pml_type="cpmlr", nt=nt, B=1, allow_growth=True)
+
+    def acoustic():
+        return Acoustic(spatial_order=4, device=dev, backend="torch")
+
+    def run(solver):
+        m = torch.tensor(vp, device=dev, requires_grad=True)
+        rec = solver(wav, sources.copy(), receivers.copy(), models=[m])
+        rec.pow(2).mean().backward()
+        assert torch.isfinite(m.grad).all()
+        return m.grad.detach().double()
+
+    def int8_solver():
+        co = CUDAOptions(memory=MemoryOptions(strategy="boundary",
+                boundary=BoundaryOptions(storage="gpu", storage_dtype="int8")))
+        return PropTorch(acoustic(), backend="torch", impl="c", cuda_options=co, **common)
+
+    def default_solver():  # no boundary config -> default boundary saving (leak victim)
+        return PropTorch(acoustic(), backend="torch", impl="c", **common)
+
+    # Reference fp32 gradient from a default solver on a clean process.
+    g_ref = run(default_solver())
+    assert K not in os.environ
+
+    # A per-instance int8 storage_dtype must NOT persist in the process env ...
+    g_int8 = run(int8_solver())
+    assert K not in os.environ, "per-instance storage_dtype leaked into os.environ"
+
+    # ... and a default solver built AFTER it must still run fp32, bit-identical
+    # to the clean-process reference (it would differ if it silently inherited
+    # int8 via a leaked env).
+    g_after = run(default_solver())
+    assert K not in os.environ
+    max_abs = (g_after - g_ref).abs().max().item()
+    assert max_abs < 1e-6, f"default solver after int8 diverged from fp32 ref ({max_abs})"
+
+    # Sanity: int8 boundary storage still produces a valid (near-identical,
+    # slightly lossy) gradient -- i.e. the dtype really is being delivered.
+    cos = float(torch.nn.functional.cosine_similarity(
+        g_int8.flatten().unsqueeze(0), g_ref.flatten().unsqueeze(0))[0])
+    assert cos > 0.99, f"int8 boundary gradient diverged unexpectedly (cos={cos})"
+
+
+@pytest.mark.skipif(not _binding_ready(), reason="CUDA + compiled sweep._C required")
+def test_shell_env_override_is_preserved(monkeypatch):
+    """A user-set SWEEP_BOUNDARY_DTYPE (global override) must survive a run --
+    the propagator no longer clobbers it."""
+    from sweep.equations import Acoustic
+    from sweep.propagator.torch import PropTorch
+
+    monkeypatch.setenv(K, "bf16")
+    dev = "cuda"
+    nz, nx, nt, dt = 40, 48, 60, 0.0015
+    vp = np.full((nz, nx), 2000.0, dtype=np.float32)
+    sources = np.array([[nx // 2, nz // 4]], dtype=np.int32)
+    receivers = np.stack([np.arange(2, nx - 2, 4, dtype=np.int32),
+                          np.full(len(range(2, nx - 2, 4)), 2, dtype=np.int32)], -1)[None]
+    wav = torch.zeros(nt, device=dev)
+    wav[5] = 1.0
+    solver = PropTorch(Acoustic(spatial_order=4, device=dev, backend="torch"),
+                       backend="torch", impl="c", shape=(nz, nx), dev=dev, dh=(10.0, 10.0),
+                       dt=dt, source_type=["h1"], receiver_type=["h1"], abcn=20,
+                       pml_type="cpmlr", nt=nt, B=1, allow_growth=True)
+    m = torch.tensor(vp, device=dev, requires_grad=True)
+    solver(wav, sources.copy(), receivers.copy(), models=[m]).pow(2).mean().backward()
+    assert os.environ.get(K) == "bf16", "user SWEEP_BOUNDARY_DTYPE override was clobbered"


### PR DESCRIPTION
## Problem

`_CompiledPropagator._ensure_boundary_buffers` permanently set the process-global `os.environ['SWEEP_BOUNDARY_DTYPE']`. A solver configured with a per-instance `BoundaryOptions(storage_dtype=...)` (e.g. `int8`) leaked that choice into **every later default-configured `PropTorch(impl='c')`** in the same process: the default path resolves `boundary_dtype=None` by reading that env, so it silently inherited int8/fp16 instead of fp32.

## Fix

The boundary storage dtype is already encoded in the buffer tensors Python allocates and hands to C++. The saver now derives it from those tensors (`uint8`→int8, `kHalf`→fp16, `kBFloat16`→bf16, else fp32) instead of reading the env, and Python no longer writes the env. `SWEEP_BOUNDARY_DTYPE` remains only as (a) the user-facing global allocation override read on the Python side, and (b) the normally-unreachable C++ self-allocation fallback.

## Verification (RTX 6000 Ada, sm_89)

- New regression test `test/test_boundary_dtype_env_leak.py`: a per-instance int8 run doesn't leak into `os.environ`; a default solver built after it is bit-identical to the fp32 reference; an externally-set env override is preserved.
- `solver_gradient_mode_suite.py` acoustic2d + elastic2d x {full, bs_gpu, bs_gpu_bf16, bs_gpu_int8, bs_cpu, ckpt_chunk}: all cos=1.000 vs eager (dtype still delivered, no mode regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
