### PR TITLE
fix(docs): mobile drawer, search dropdown, code typography

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -85,6 +85,77 @@
   margin: 0.4rem 0 1rem;
   color: var(--md-default-fg-color);
 }
+
+/* Restore Material's compact typography inside the search results dropdown.
+   Our generic `.md-typeset h1/h2/h3` rules above have the same specificity
+   as Material's `.md-search-result .md-typeset h1` defaults but load after
+   them, so they were inflating result-list previews to full page heading
+   sizes. Re-scope to the search dropdown to keep results scannable. */
+[data-sweep-d] .md-search-result .md-typeset {
+  font-size: 0.64rem;
+  line-height: 1.6;
+}
+[data-sweep-d] .md-search-result .md-typeset h1 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0.55rem 0;
+  letter-spacing: -0.01em;
+}
+[data-sweep-d] .md-search-result .md-typeset h2 {
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0.5rem 0 0.3rem;
+  letter-spacing: -0.005em;
+}
+[data-sweep-d] .md-search-result .md-typeset h3,
+[data-sweep-d] .md-search-result .md-typeset h4,
+[data-sweep-d] .md-search-result .md-typeset h5,
+[data-sweep-d] .md-search-result .md-typeset h6 {
+  font-size: 0.68rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0.4rem 0 0.25rem;
+  letter-spacing: 0;
+}
+[data-sweep-d] .md-search-result .md-typeset p {
+  font-size: 0.64rem;
+  line-height: 1.6;
+  margin: 0.3rem 0;
+}
+[data-sweep-d] .md-search-result .md-typeset code {
+  font-size: 0.6rem;
+}
+[data-sweep-d] .md-search-result .md-typeset ol,
+[data-sweep-d] .md-search-result .md-typeset ul {
+  font-size: 0.64rem;
+  margin: 0.3rem 0 0.3rem 1rem;
+}
+/* Cap individual search-result snippets so notebook code cells (full
+   imports + parameter blocks) do not dump dozens of lines into the
+   dropdown. Fade the bottom edge with mask-image so the cut-off looks
+   intentional instead of a hard slice. */
+[data-sweep-d] .md-search-result__article {
+  max-height: 11em;
+  overflow: hidden;
+  mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+}
+
+/* Bump up code-block typography across the docs. Material's default
+   ``.md-typeset pre > code`` size combined with our Inter Tight body
+   font reads too small on API pages and in notebook cells; this
+   restores parity with surrounding prose without affecting inline
+   ``<code>`` spans. */
+[data-sweep-d] .md-typeset pre > code,
+[data-sweep-d] .md-typeset .highlight pre code,
+[data-sweep-d] .md-typeset .doc-signature,
+[data-sweep-d] .md-typeset .doc-signature pre,
+[data-sweep-d] .md-typeset .doc-signature code {
+  font-size: 0.78rem;
+}
+
 [data-sweep-d] .md-typeset h2 {
   font-family: 'Inter Tight', system-ui, sans-serif;
   font-weight: 700;
@@ -286,6 +357,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  /* Allow the long `pip install git+https://…` string to shrink below its
+     intrinsic width inside the flex pill. Without `min-width: 0`, flexbox
+     keeps the code at its max-content width and the whole pill overflows
+     the viewport on mobile despite the ellipsis. */
+  min-width: 0;
+  flex: 1 1 auto;
 }
 .sweep-hero__copy {
   width: 30px; height: 30px;
@@ -362,6 +439,30 @@
   color: var(--md-default-fg-color--lighter);
   padding: 0.8rem 0 0.5rem;
   background: transparent;
+}
+/* Restore Material's defaults for the mobile drawer header
+   (the `<label class="md-nav__title" for="__drawer">` at the top of the
+   primary nav). Our generic `.md-nav__title` rule above forces a small
+   uppercase eyebrow, which broke the drawer header into the same line as
+   the logo and caused them to overlap. The drawer header needs the
+   theme's default block layout (logo on its own row, site name below). */
+[data-sweep-d] .md-nav--primary > .md-nav__title[for="__drawer"] {
+  font-size: inherit;
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 600;
+  color: var(--md-default-fg-color);
+  padding: 1rem 0.8rem 0.6rem;
+  background: var(--sw-paper);
+}
+[data-sweep-d] .md-nav--primary > .md-nav__title[for="__drawer"] .md-nav__button.md-logo {
+  display: block;
+  margin: 0 0 0.4rem;
+}
+[data-sweep-d] .md-nav--primary > .md-nav__title[for="__drawer"] .md-nav__button.md-logo img,
+[data-sweep-d] .md-nav--primary > .md-nav__title[for="__drawer"] .md-nav__button.md-logo svg {
+  width: 36px;
+  height: 36px;
 }
 [data-sweep-d] .md-nav__link {
   font-size: 13.5px;
@@ -744,7 +845,27 @@
 }
 
 [data-sweep-d] .md-typeset .jp-Cell {
-  margin: 1.4rem 0;
+  margin: 0.6rem 0;
+  padding: 0;
+}
+/* Collapse JupyterLab's per-cell header/footer that ship as empty divs in
+   the static export — they reserve vertical space (1+ rem each) between
+   cells even though there's nothing to show in the static docs. */
+[data-sweep-d] .md-typeset .jp-Cell .jp-CellHeader,
+[data-sweep-d] .md-typeset .jp-Cell .jp-CellFooter {
+  display: none !important;
+}
+/* JupyterLab adds chunky vertical padding to input/output wrappers; the
+   static export doesn't need the editor breathing room. */
+[data-sweep-d] .md-typeset .jp-Cell-inputWrapper,
+[data-sweep-d] .md-typeset .jp-Cell-outputWrapper {
+  padding: 0 !important;
+  margin: 0.25rem 0 !important;
+}
+/* Markdown cells in particular shouldn't double-margin with the
+   surrounding cell wrapper. */
+[data-sweep-d] .md-typeset .jp-Cell:has(.jp-MarkdownCell) {
+  margin: 0.4rem 0;
 }
 
 /* JupyterLab's bundled CSS sets `.jp-InputArea-editor { width: 1px }` which,
@@ -1080,6 +1201,52 @@
   font-size: 0.78rem;
   color: var(--md-default-fg-color--light);
   line-height: 1.5;
+}
+/* Mobile: 2-up grid + tighter card chrome so the stack section stays
+   scannable instead of one giant card per row. */
+@media (max-width: 600px) {
+  [data-sweep-d] .sweep-stack {
+    margin: 1.6rem auto 1.4rem;
+    padding: 0 1rem;
+  }
+  [data-sweep-d] .md-typeset h2.sweep-stack__title {
+    font-size: 1.25rem;
+  }
+  [data-sweep-d] .md-typeset p.sweep-stack__lede {
+    font-size: 0.78rem;
+    margin: 0 auto 1rem;
+  }
+  [data-sweep-d] .sweep-stack__grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    margin-top: 0.6rem;
+  }
+  [data-sweep-d] .sweep-stack__card {
+    padding: 0.65rem 0.75rem 0.75rem;
+    border-radius: 10px;
+  }
+  [data-sweep-d] .sweep-stack__head {
+    margin-bottom: 0.5rem;
+  }
+  [data-sweep-d] .sweep-stack__dot { width: 9px; height: 9px; }
+  [data-sweep-d] .sweep-stack__dot--tri {
+    border-left-width: 5px;
+    border-right-width: 5px;
+    border-bottom-width: 9px;
+  }
+  [data-sweep-d] .sweep-stack__role { font-size: 8.5px; }
+  [data-sweep-d] .sweep-stack__name {
+    font-size: 0.92rem;
+    margin-bottom: 0.1rem;
+  }
+  [data-sweep-d] .sweep-stack__version {
+    font-size: 0.62rem;
+    margin-bottom: 0.4rem;
+  }
+  [data-sweep-d] .sweep-stack__desc {
+    font-size: 0.68rem;
+    line-height: 1.4;
+  }
 }
 
 /* ─── 13. RICH FOOTER (overrides Material's default) ─────────────────── */
@@ -1466,6 +1633,35 @@
 @media (max-width: 820px) {
   [data-sweep-d] .sweep-features-3 { grid-template-columns: 1fr; }
 }
+/* Mobile: tighten card padding + typography so single-column cards
+   aren't dominating the viewport. */
+@media (max-width: 600px) {
+  [data-sweep-d] .sweep-features-3 {
+    margin: 1rem auto 1.4rem;
+    padding: 0 1rem;
+    gap: 0.55rem;
+  }
+  [data-sweep-d] .sweep-features-3__card {
+    padding: 0.85rem 0.95rem 0.75rem;
+    border-radius: 11px;
+  }
+  [data-sweep-d] .sweep-features-3__tag {
+    font-size: 8.5px;
+    margin-bottom: 0.35rem;
+  }
+  [data-sweep-d] .md-typeset h3.sweep-features-3__title {
+    font-size: 0.95rem;
+    margin: 0 0 0.4rem;
+  }
+  [data-sweep-d] .sweep-features-3__desc {
+    font-size: 0.72rem !important;
+    line-height: 1.4 !important;
+    margin: 0 0 0.6rem !important;
+  }
+  [data-sweep-d] .sweep-features-3__link {
+    font-size: 0.72rem;
+  }
+}
 [data-sweep-d] .sweep-features-3__card {
   background: var(--sw-paper);
   border: 1px solid var(--sw-rule);
@@ -1570,6 +1766,33 @@
   max-width: 680px;
   margin: 0 auto 1.6rem !important;
   text-align: left;
+}
+/* Mobile: shrink the code font so the longest Python lines fit inside the
+   viewport without being clipped. Default Material code is ~14px; below
+   we step down to ~10.5px which keeps the 30-line example readable while
+   ensuring no horizontal swiping is needed on phones. We also force the
+   `.md-code__content` grid (Material renders each line as a grid row with
+   implicit `max-content` columns — which prevents wrapping) to a single
+   `minmax(0, 1fr)` column so long lines wrap inside the viewport. */
+@media (max-width: 600px) {
+  [data-sweep-d] .sweep-onefile .highlight pre,
+  [data-sweep-d] .sweep-onefile .highlight code {
+    font-size: 10.5px !important;
+    line-height: 1.5 !important;
+  }
+  [data-sweep-d] .sweep-onefile .highlight {
+    padding: 0;
+  }
+  [data-sweep-d] .md-typeset .md-code__content {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+  [data-sweep-d] .md-typeset .md-code__content > span,
+  [data-sweep-d] .md-typeset pre code {
+    white-space: pre-wrap !important;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    min-width: 0;
+  }
 }
 /* Ghost CTA on dark — outlined pill */
 [data-sweep-d] .sweep-cta--ghost-dark {
@@ -2243,3 +2466,99 @@ html[data-sweep-d] body .md-content > article.sweep-home-body {
    have visible left/right whitespace.
    ─────────────────────────────────────────────────────────────────────── */
 [data-sweep-d] .md-grid { max-width: 1400px; }
+
+/* Material's search overlay tracks the header/grid width via
+   `.md-search__inner`. Our wider 1400 px `.md-grid` (above) made the
+   search dropdown balloon to the full grid on large displays AND shifted
+   it so the inner scrollwrap (Material hard-codes `width: 34.4rem` at
+   ≥76.25em) ended up ~20 px past the right viewport edge, producing a
+   horizontal scrollbar even on the homepage. Cap both the inner pill and
+   the scroll panel to a comfortable reading width and let `max-width`
+   block any overflow. */
+@media screen and (min-width: 60em) {
+  [data-sweep-d] .md-search__inner { max-width: 38rem; }
+}
+@media screen and (min-width: 76.25em) {
+  [data-sweep-d] .md-search__scrollwrap {
+    width: auto;
+    max-width: 34.4rem;
+  }
+}
+
+/* On narrow viewports `.sweep-onefile` (the full-bleed dark "one file"
+   section) used `width: 100vw + margin-left: calc(50% - 50vw)` to break
+   out of the centred article column. The trick assumes the parent is
+   horizontally centred with auto margins; the home article is centred by
+   `max-width + margin: auto`, but `100vw` includes the vertical scrollbar
+   gutter on many browsers, so the section ended up a few px wider than
+   the visible viewport and triggered a horizontal scrollbar. Drop the
+   100vw trick on mobile — the section just fills its parent column,
+   which is already fine visually at narrow widths. */
+@media (max-width: 760px) {
+  [data-sweep-d] .sweep-onefile {
+    margin-left: -1.2rem;
+    margin-right: -1.2rem;
+    width: auto;
+    padding-left: 1.2rem;
+    padding-right: 1.2rem;
+    padding-top: 2.2rem;
+    padding-bottom: 2.4rem;
+  }
+}
+
+/* Belt-and-braces: clip any horizontal overflow at the root so transformed
+   off-screen panes (mobile nav nested sub-panes use `translateX(100%)` to
+   stack off the right edge, `position: fixed` sidebar) can't bleed into
+   document scroll width. `overflow-x: clip` is preferred over `hidden`
+   because it doesn't establish a new scroll container and preserves
+   `position: sticky` on descendants. */
+html[data-sweep-d],
+[data-sweep-d] body { overflow-x: clip; }
+
+/* ─── 21. HOMEPAGE — HIDE SIDEBARS ON DESKTOP, KEEP DRAWER ON MOBILE ────
+   home.html sets `data-sweep-home` on <html>. Material's drawer/sidebar
+   element is the same DOM node that becomes the mobile slide-out menu, so
+   we can't remove it from the template — hiding it via display:none would
+   break the hamburger button too. Instead, on screens wide enough that
+   Material switches to the "sidebars side-by-side" layout (≥76.25em ≈
+   1220 px in Material's defaults), hide both sidebars; on narrower
+   screens leave them alone so the mobile drawer still works.
+   ─────────────────────────────────────────────────────────────────────── */
+@media screen and (min-width: 76.25em) {
+  [data-sweep-home] .md-sidebar--primary,
+  [data-sweep-home] .md-sidebar--secondary {
+    display: none;
+  }
+}
+
+/* ─── 22. HOMEPAGE GALLERY — MOBILE TIGHTENING ─────────────────────────
+   At desktop the gallery uses 15rem cards with 9rem thumbnails. On a
+   narrow phone (≤480 px) a single 15rem (~240 px) card with a 9rem
+   (~144 px) image dominates the viewport. Switch to a two-column 1fr/1fr
+   layout with a shorter thumbnail strip so the gallery rows are compact
+   and scannable on mobile.
+   ─────────────────────────────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  [data-sweep-d] .md-typeset.sweep-home-body .grid.cards {
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    margin: 0.5rem 0 1rem;
+  }
+  [data-sweep-d] .md-typeset.sweep-home-body .grid.cards img {
+    height: 5rem;
+  }
+  [data-sweep-d] .md-typeset.sweep-home-body .grid.cards > ul > li,
+  [data-sweep-d] .md-typeset.sweep-home-body .grid.cards > ol > li,
+  [data-sweep-d] .md-typeset.sweep-home-body .grid > .card {
+    padding: 0.55rem !important;
+    border-radius: 10px !important;
+  }
+  [data-sweep-d] .md-typeset.sweep-home-body .grid.cards p {
+    font-size: 0.7rem;
+    line-height: 1.35;
+    margin: 0.25rem 0;
+  }
+  [data-sweep-d] .md-typeset.sweep-home-body .grid.cards p strong {
+    font-size: 0.78rem;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,7 @@ plugins:
             show_source: false
             show_root_heading: true
             docstring_style: google
-            docstring_section_style: table
+            docstring_section_style: list
             members_order: source
             separate_signature: true
             show_signature_annotations: true

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -70,5 +70,13 @@
   </div>
 {% endblock %}
 
-{# Hide the page tabs sidebar/TOC on the homepage even when present. #}
-{% block site_nav %}{% endblock %}
+{# Keep Material's default `site_nav` block intact so the mobile hamburger
+   has a drawer to open. On desktop we hide both sidebars via the
+   `data-sweep-home` attribute set below + CSS in extra.css. #}
+
+{% block extrahead %}
+  {{ super() }}
+  <script>
+    document.documentElement.setAttribute('data-sweep-home', 'true');
+  </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- **Search dropdown** — re-scope `.md-typeset h1/h2/h3/p/code/ul` to `.md-search-result` so previews use Material's compact defaults instead of inheriting full page heading sizes. Cap each snippet at ~11em with a `mask-image` fade so notebook code cells don't dump dozens of lines into the dropdown.
- **Mobile drawer** — restore Material's default `site_nav` block in `overrides/home.html` so the hamburger has content; hide the desktop sidebar via `data-sweep-home` + a `min-width: 76.25em` media query in `extra.css`.
- **Mobile home gallery** — at `≤600px` switch to a 2-column 1fr/1fr layout with shorter thumbnails / tighter padding so gallery rows stay scannable on phones.
- **Code typography** — bump `.md-typeset pre > code` / `.md-typeset .highlight pre code` / `.md-typeset .doc-signature` to `0.78rem` so API page signatures and notebook cells read on par with surrounding prose.
- **mkdocstrings** — switch \`docstring_section_style: table → list\`. The shipped equation \`__init__\` signatures have no type hints so the table left the TYPE column empty; the list layout reads cleaner until type hints are added (separate follow-up).

## Test plan
- [x] \`mkdocs build\` passes locally.
- [x] Search dropdown verified compact, snippets capped + faded.
- [x] Mobile drawer opens with full nav on viewport <76.25em.
- [x] API page signatures readable at 0.78rem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)