### PR TITLE
refactor(equations): derive wavefields/specs in WaveEquation

### DIFF
--- a/src/sweep/equations/acoustic.py
+++ b/src/sweep/equations/acoustic.py
@@ -118,18 +118,6 @@ class Acoustic(SecondOrderEquation):
             self.grad_kernels = {-2: self.gkernel_z, -1: self.gkernel_x}
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["h1"]
 

--- a/src/sweep/equations/acoustic1st.py
+++ b/src/sweep/equations/acoustic1st.py
@@ -141,10 +141,6 @@ class Acoustic1st(FirstOrderEquation):
             'spml': step_spml
             }[pml_type]
     
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
     def wavefields_cpml(self):
         return ['p', 'vx', 'vz', 'phix', 'phiz', 'psix', 'psiz']
 

--- a/src/sweep/equations/acoustic3d.py
+++ b/src/sweep/equations/acoustic3d.py
@@ -120,20 +120,7 @@ class Acoustic3D(SecondOrderEquation):
                 :class:`Acoustic` for 2-D. Defaults to 3.
         """
         super().__init__(spatial_order, device, backend, dim=dim)
-        self._wavefields = []
         super().init_laplace(ltype='3dsep', backend=backend)
-
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
 
     @property
     def default_source_fields(self):

--- a/src/sweep/equations/acoustic_curvilinear.py
+++ b/src/sweep/equations/acoustic_curvilinear.py
@@ -109,18 +109,6 @@ class AcousticCurvilinear(SecondOrderEquation):
         self._curv_d_eta = float(d_eta)
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["h1"]
 

--- a/src/sweep/equations/acoustic_lsrtm.py
+++ b/src/sweep/equations/acoustic_lsrtm.py
@@ -151,18 +151,6 @@ class AcousticLSRTM(SecondOrderEquation):
         super().init_laplace(ltype='1dsep')
     
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["h1"]
 

--- a/src/sweep/equations/acoustic_lsrtm3d.py
+++ b/src/sweep/equations/acoustic_lsrtm3d.py
@@ -197,18 +197,6 @@ class AcousticLSRTM3D(SecondOrderEquation):
         super().init_laplace(ltype="3dsep")
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["h1"]
 

--- a/src/sweep/equations/acoustic_vrr.py
+++ b/src/sweep/equations/acoustic_vrr.py
@@ -1,5 +1,5 @@
 from .base import SecondOrderEquation
-from .fields import ModelSpec
+from .fields import FieldSpec, ModelSpec
 
 def step(u_now, u_pre, vp, rx, rz, dt, h, b, lap_u_now, dpdx, dpdz, dvpdx, dvpdz):
     a = 1 / (1 + b * dt)
@@ -20,6 +20,10 @@ class AcousticVRR(SecondOrderEquation):
         ModelSpec("rx", description="Auxiliary horizontal parameter used by the VRR formulation."),
         ModelSpec("rz", description="Auxiliary vertical parameter used by the VRR formulation."),
     )
+    FIELD_SPECS = (
+        FieldSpec("h1", aliases=("pressure", "p"), description="Primary acoustic VRR pressure-like wavefield.", supports_source=True, supports_receiver=True),
+        FieldSpec("h2", aliases=("pressure_prev",), description="Previous-step pressure-like wavefield.", internal=True),
+    )
     def __init__(self, spatial_order=4, device='cpu', backend = 'torch', dim=2):
         """Acoustic wave equation solver.
 
@@ -29,14 +33,6 @@ class AcousticVRR(SecondOrderEquation):
         super().__init__(spatial_order, device, backend, other_kernels=True)
         super().init_laplace(ltype='1dsep', backend=backend)
 
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return ['h1', 'h2']
-    
     def func(self, wavefields, models, dt, h, b, **kwargs):
         u_now = wavefields[0]
         vp = models[0]

--- a/src/sweep/equations/acoustic_vrz.py
+++ b/src/sweep/equations/acoustic_vrz.py
@@ -215,18 +215,6 @@ class AcousticVRZ(SecondOrderEquation):
         self.grad_kernels = {-2: self.gkernel_z, -1: self.gkernel_x}
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["h1"]
 
@@ -362,18 +350,6 @@ class AcousticVRZ3D(SecondOrderEquation):
             }
         else:
             self.grad_kernels = None
-
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
 
     @property
     def default_source_fields(self):

--- a/src/sweep/equations/acoustic_vti_1st.py
+++ b/src/sweep/equations/acoustic_vti_1st.py
@@ -340,18 +340,6 @@ class AcousticVTI1st(FirstOrderEquation):
         self.free_surface = False
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["sH", "sV"]
 
@@ -581,18 +569,6 @@ class AcousticVTI1st3D(FirstOrderEquation):
                 "(TODO_free_surface). Use absorbing PML on all six sides."
             )
         self.free_surface = False
-
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
 
     @property
     def default_source_fields(self):

--- a/src/sweep/equations/aec.py
+++ b/src/sweep/equations/aec.py
@@ -1,5 +1,5 @@
 from .base import FirstOrderEquation
-from .fields import ModelSpec
+from .fields import FieldSpec, ModelSpec
 
 def step(p, vx, vz, txx, tzz, txz,
          vp, vs, rho, 
@@ -46,16 +46,16 @@ class AEC(FirstOrderEquation):
         ModelSpec("vs", aliases=("s_velocity",), description="Coupled acoustic-elastic S-wave velocity model.", unit="m/s"),
         ModelSpec("rho", aliases=("density",), description="Density model.", unit="kg/m^3"),
     )
+    FIELD_SPECS = (
+        FieldSpec("p", aliases=("pressure",), description="Acoustic-elastic coupled pressure field.", supports_source=True, supports_receiver=True),
+        FieldSpec("vx", aliases=("velocity_x",), description="Particle velocity in the x direction.", supports_receiver=True),
+        FieldSpec("vz", aliases=("velocity_z",), description="Particle velocity in the z direction.", supports_receiver=True),
+        FieldSpec("txx", description="Normal stress component in the x direction.", supports_source=True, supports_receiver=True),
+        FieldSpec("tzz", description="Normal stress component in the z direction.", supports_source=True, supports_receiver=True),
+        FieldSpec("txz", description="Shear stress component.", supports_source=True),
+    )
     def __init__(self, spatial_order=4, device='cpu', backend = 'torch'):
         super().__init__(spatial_order, device, backend)
-        
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return ['p', 'vx', 'vz', 'txx', 'tzz', 'txz']
-    
+
     def func(self, wavefields, models, dt, h, b, **kwargs):
         return step(*wavefields, *models, dt, h, b, pd=self.pd, **kwargs)

--- a/src/sweep/equations/aec_lsrtm.py
+++ b/src/sweep/equations/aec_lsrtm.py
@@ -1,5 +1,5 @@
 from .base import FirstOrderEquation
-from .fields import ModelSpec
+from .fields import FieldSpec, ModelSpec
 
 def step(p, vx, vz, txx, tzz, txz,
          ps, vxs, vzs, txxs, tzzs, txzs,
@@ -78,17 +78,23 @@ class AECLSRTM(FirstOrderEquation):
         ModelSpec("vs", aliases=("s_velocity",), description="Background S-wave velocity model.", unit="m/s"),
         ModelSpec("rho", aliases=("density",), description="Background density model.", unit="kg/m^3"),
     )
+    FIELD_SPECS = (
+        FieldSpec("p", aliases=("pressure", "background"), description="Background coupled pressure field.", supports_source=True),
+        FieldSpec("vx", aliases=("velocity_x", "background_vx"), description="Background particle velocity in the x direction.", internal=True),
+        FieldSpec("vz", aliases=("velocity_z", "background_vz"), description="Background particle velocity in the z direction.", internal=True),
+        FieldSpec("txx", aliases=("background_txx",), description="Background normal stress in the x direction.", supports_source=True),
+        FieldSpec("tzz", aliases=("background_tzz",), description="Background normal stress in the z direction.", supports_source=True),
+        FieldSpec("txz", aliases=("background_txz",), description="Background shear stress.", supports_source=True),
+        FieldSpec("ps", aliases=("scattered", "scattered_pressure", "data"), description="Scattered pressure field used for AEC-LSRTM data prediction.", supports_receiver=True),
+        FieldSpec("vxs", description="Scattered particle velocity in the x direction.", supports_receiver=True),
+        FieldSpec("vzs", description="Scattered particle velocity in the z direction.", supports_receiver=True),
+        FieldSpec("txxs", description="Scattered normal stress in the x direction.", supports_receiver=True),
+        FieldSpec("tzzs", description="Scattered normal stress in the z direction.", supports_receiver=True),
+        FieldSpec("txzs", description="Scattered shear stress.", supports_receiver=True),
+    )
 
     def __init__(self, spatial_order=4, device='cpu', backend = 'torch'):
         super().__init__(spatial_order, device, backend)
 
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return ['p', 'vx', 'vz', 'txx', 'tzz', 'txz', 'ps', 'vxs', 'vzs', 'txxs', 'tzzs', 'txzs']
-    
     def func(self, wavefields, models, dt, h, b, **kwargs):
         return step(*wavefields, *models, dt, h, b, pd=self.pd, **kwargs)

--- a/src/sweep/equations/base.py
+++ b/src/sweep/equations/base.py
@@ -49,6 +49,13 @@ class WaveEquation:
     # override.
     supports_apm = False
 
+    # Class-level spec tables. Subclasses that declare these tables drive
+    # the ``wavefields`` / ``models`` / ``field_specs`` / ``model_specs``
+    # properties below automatically; manual property overrides remain
+    # supported for backwards compatibility (the override wins).
+    FIELD_SPECS: tuple = ()
+    MODEL_SPECS: tuple = ()
+
     @classmethod
     def supports_torch_binding(cls):
         """Return True when the equation class exposes a compiled ``_C`` binding hook."""
@@ -123,18 +130,80 @@ class WaveEquation:
         self.b = pml_func(**kwargs)
         self.b = to_backend(self.b, self.backend, self.device)
 
+    # Each of the four properties below resolves in the same order:
+    #   1. an instance-level write (``self.wavefields = ...`` etc.) wins,
+    #      so legacy equations like ``Acoustic1st`` that set names from
+    #      ``__init__`` based on the chosen PML type keep working;
+    #   2. the class-level ``FIELD_SPECS`` / ``MODEL_SPECS`` table is used
+    #      when no instance write happened — this is the recommended path
+    #      for new equations;
+    #   3. otherwise a ``NotImplementedError`` (names) or a derivation from
+    #      ``self.wavefields`` / ``self.models`` (specs) provides the
+    #      pre-spec-tables fallback.
+    #
+    # FieldSpec order is semantically significant. The propagators map
+    # source/receiver names to positional wavefield indices, and equation
+    # step functions are expected to return tensors in the same order.
+    # Reordering field specs therefore changes forward/backward behavior,
+    # source injection, receiver sampling, checkpointing, and CUDA bindings.
+
     @property
     def field_specs(self):
-        # FieldSpec order is semantically significant. The propagators map
-        # source/receiver names to positional wavefield indices, and equation
-        # step functions are expected to return tensors in the same order.
-        # Reordering field specs therefore changes forward/backward behavior,
-        # source injection, receiver sampling, checkpointing, and CUDA bindings.
+        override = self.__dict__.get('_sweep_field_specs_override')
+        if override is not None:
+            return override
+        if self.FIELD_SPECS:
+            return list(self.FIELD_SPECS)
         return ensure_field_specs(self.wavefields, [])
+
+    @field_specs.setter
+    def field_specs(self, value):
+        self.__dict__['_sweep_field_specs_override'] = list(value)
 
     @property
     def model_specs(self):
+        override = self.__dict__.get('_sweep_model_specs_override')
+        if override is not None:
+            return override
+        if self.MODEL_SPECS:
+            return list(self.MODEL_SPECS)
         return ensure_model_specs(self.models, [])
+
+    @model_specs.setter
+    def model_specs(self, value):
+        self.__dict__['_sweep_model_specs_override'] = list(value)
+
+    @property
+    def wavefields(self):
+        override = self.__dict__.get('_sweep_wavefields_override')
+        if override is not None:
+            return override
+        if self.FIELD_SPECS:
+            return [spec.name for spec in self.FIELD_SPECS]
+        raise NotImplementedError(
+            f"{type(self).__name__} must declare ``FIELD_SPECS`` or set "
+            "``self.wavefields``."
+        )
+
+    @wavefields.setter
+    def wavefields(self, value):
+        self.__dict__['_sweep_wavefields_override'] = list(value)
+
+    @property
+    def models(self):
+        override = self.__dict__.get('_sweep_models_override')
+        if override is not None:
+            return override
+        if self.MODEL_SPECS:
+            return [spec.name for spec in self.MODEL_SPECS]
+        raise NotImplementedError(
+            f"{type(self).__name__} must declare ``MODEL_SPECS`` or set "
+            "``self.models``."
+        )
+
+    @models.setter
+    def models(self, value):
+        self.__dict__['_sweep_models_override'] = list(value)
 
     @classmethod
     def _field_specs_for_query(cls):

--- a/src/sweep/equations/das.py
+++ b/src/sweep/equations/das.py
@@ -1078,18 +1078,6 @@ class DASZhao(FirstOrderEquation):
         super().__init__(spatial_order, device, backend, ndim=2)
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["sxx", "szz"]
 
@@ -1260,18 +1248,6 @@ class DASZhao3D(FirstOrderEquation):
         super().__init__(spatial_order, device, backend, ndim=3)
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["sxx", "syy", "szz"]
 
@@ -1417,18 +1393,6 @@ class DASMu(FirstOrderEquation):
                 on ``'torch'``. Defaults to ``'torch'``.
         """
         super().__init__(spatial_order, device, backend, ndim=2)
-
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
 
     @property
     def default_source_fields(self):
@@ -1619,18 +1583,6 @@ class DASMu3D(FirstOrderEquation):
                 on ``'torch'``. Defaults to ``'torch'``.
         """
         super().__init__(spatial_order, device, backend, ndim=3)
-
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
 
     @property
     def default_source_fields(self):

--- a/src/sweep/equations/elastic.py
+++ b/src/sweep/equations/elastic.py
@@ -120,18 +120,6 @@ class Elastic(FirstOrderEquation):
         self._apm_cache = None
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["sxx", "szz"]
 

--- a/src/sweep/equations/elastic3d.py
+++ b/src/sweep/equations/elastic3d.py
@@ -432,18 +432,6 @@ class Elastic(FirstOrderEquation):
         self._apm_cache = None
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["sxx", "syy", "szz"]
 

--- a/src/sweep/equations/elasticP.py
+++ b/src/sweep/equations/elasticP.py
@@ -1,7 +1,7 @@
 import torch
 import jax.numpy as jnp
 from .base import FirstOrderEquation
-from .fields import ModelSpec
+from .fields import FieldSpec, ModelSpec
 
 def step(vx, vz, txx, tzz, txz,
          vp, vs, rho, 
@@ -63,23 +63,22 @@ class ElasticP(FirstOrderEquation):
         ModelSpec("vs", aliases=("s_velocity",), description="Elastic S-wave velocity model.", unit="m/s"),
         ModelSpec("rho", aliases=("density",), description="Density model.", unit="kg/m^3"),
     )
+    FIELD_SPECS = (
+        FieldSpec("vx", aliases=("velocity_x",), description="Particle velocity in the x direction.", supports_receiver=True),
+        FieldSpec("vz", aliases=("velocity_z",), description="Particle velocity in the z direction.", supports_receiver=True),
+        FieldSpec("txx", description="Normal stress component in the x direction.", supports_source=True, supports_receiver=True),
+        FieldSpec("tzz", description="Normal stress component in the z direction.", supports_source=True, supports_receiver=True),
+        FieldSpec("txz", description="Shear stress component.", supports_source=True),
+    )
 
     def __init__(self, spatial_order=4, device='cpu', backend = 'torch'):
         self.backend = backend
         self.op = {'torch': torch, 'jax': jnp}[backend]
         super().__init__(spatial_order, device, backend)
-        
+
     @property
     def need_init(self):
         return True
 
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return ['vx', 'vz', 'txx', 'tzz', 'txz']
-    
     def func(self, wavefields, models, dt, h, b, **kwargs):
         return step(*wavefields, *models, dt, h, b, self.k, self.pd, self.op, **kwargs)

--- a/src/sweep/equations/elastic_curvilinear.py
+++ b/src/sweep/equations/elastic_curvilinear.py
@@ -272,18 +272,6 @@ class ElasticCurvilinear(FirstOrderEquation):
         # signature doesn't include it.
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["sxx", "szz"]
 

--- a/src/sweep/equations/elastic_lsrtm.py
+++ b/src/sweep/equations/elastic_lsrtm.py
@@ -1,5 +1,5 @@
 from .base import FirstOrderEquation
-from .fields import ModelSpec
+from .fields import FieldSpec, ModelSpec
 
 # 10.1190/GEO2016-0254.1
 def step(vx, vz, txx, tzz, txz,
@@ -71,16 +71,20 @@ class ElasticLSRTM(FirstOrderEquation):
         ModelSpec("vs", aliases=("s_velocity",), description="Background elastic S-wave velocity model.", unit="m/s"),
         ModelSpec("rho", aliases=("density",), description="Background density model.", unit="kg/m^3"),
     )
+    FIELD_SPECS = (
+        FieldSpec("vx", aliases=("velocity_x", "background_vx"), description="Background particle velocity in the x direction.", internal=True),
+        FieldSpec("vz", aliases=("velocity_z", "background_vz"), description="Background particle velocity in the z direction.", internal=True),
+        FieldSpec("txx", aliases=("background_txx",), description="Background normal stress in the x direction.", supports_source=True),
+        FieldSpec("tzz", aliases=("background_tzz",), description="Background normal stress in the z direction.", supports_source=True),
+        FieldSpec("txz", aliases=("background_txz",), description="Background shear stress.", supports_source=True),
+        FieldSpec("vxs", aliases=("scattered_vx",), description="Scattered particle velocity in the x direction.", supports_receiver=True),
+        FieldSpec("vzs", aliases=("scattered_vz",), description="Scattered particle velocity in the z direction.", supports_receiver=True),
+        FieldSpec("txxs", aliases=("scattered_txx",), description="Scattered normal stress in the x direction.", supports_receiver=True),
+        FieldSpec("tzzs", aliases=("scattered_tzz",), description="Scattered normal stress in the z direction.", supports_receiver=True),
+        FieldSpec("txzs", aliases=("scattered_txz",), description="Scattered shear stress.", supports_receiver=True),
+    )
     def __init__(self, spatial_order=4, device='cpu', backend = 'torch'):
         super().__init__(spatial_order, device, backend)
 
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return ['vx', 'vz', 'txx', 'tzz', 'txz', 'vxs', 'vzs', 'txxs', 'tzzs', 'txzs']
-    
     def func(self, wavefields, models, dt, h, b, **kwargs):
         return step(*wavefields, *models, dt, h, b, pd=self.pd, **kwargs)

--- a/src/sweep/equations/elastic_tti.py
+++ b/src/sweep/equations/elastic_tti.py
@@ -302,18 +302,6 @@ class ElasticTTI(FirstOrderEquation):
         self.pd = self.rsg
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["sxx", "szz"]
 

--- a/src/sweep/equations/elastic_vrr.py
+++ b/src/sweep/equations/elastic_vrr.py
@@ -405,18 +405,6 @@ class ElasticVRR(FirstOrderEquation):
         super().__init__(spatial_order, device, backend)
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["sxx", "szz"]
 

--- a/src/sweep/equations/elasticz.py
+++ b/src/sweep/equations/elasticz.py
@@ -1,5 +1,5 @@
 from .base import FirstOrderEquation
-from .fields import ModelSpec
+from .fields import FieldSpec, ModelSpec
 
 def step(vx, vz, txx, tzz, txz,
          vpz, vsz, rho, 
@@ -38,17 +38,16 @@ class ElasticZ(FirstOrderEquation):
         ModelSpec("vsz", aliases=("vs",), description="Depth-dependent S-wave velocity parameter.", unit="m/s"),
         ModelSpec("rho", aliases=("density",), description="Density model.", unit="kg/m^3"),
     )
+    FIELD_SPECS = (
+        FieldSpec("vx", aliases=("velocity_x",), description="Particle velocity in the x direction.", supports_receiver=True),
+        FieldSpec("vz", aliases=("velocity_z",), description="Particle velocity in the z direction.", supports_receiver=True),
+        FieldSpec("txx", description="Normal stress component in the x direction.", supports_source=True, supports_receiver=True),
+        FieldSpec("tzz", description="Normal stress component in the z direction.", supports_source=True, supports_receiver=True),
+        FieldSpec("txz", description="Shear stress component.", supports_source=True),
+    )
 
     def __init__(self, spatial_order=4, device='cpu', backend = 'torch'):
         super().__init__(spatial_order, device, backend)
 
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return ['vx', 'vz', 'txx', 'tzz', 'txz']
-    
     def func(self, wavefields, models, dt, h, b, **kwargs):
         return step(*wavefields, *models, dt, h, b, pd=self.pd, **kwargs)

--- a/src/sweep/equations/qP_tariq.py
+++ b/src/sweep/equations/qP_tariq.py
@@ -134,18 +134,6 @@ class AcousticTariq(SecondOrderEquation):
         self.grad_kernels = {-2: self.gkernel_z, -1: self.gkernel_x}
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["h1"]
 

--- a/src/sweep/equations/qP_tti.py
+++ b/src/sweep/equations/qP_tti.py
@@ -159,18 +159,6 @@ class AcousticTTI(SecondOrderEquation):
         self.op = {"torch": torch, "jax": jnp}[backend]
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["h1"]
 

--- a/src/sweep/equations/qP_vti.py
+++ b/src/sweep/equations/qP_vti.py
@@ -135,18 +135,6 @@ class AcousticVTI(SecondOrderEquation):
         self.grad_kernels = {-2: self.gkernel_z, -1: self.gkernel_x}
 
     @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-
-    @property
-    def wavefields(self):
-        return [spec.name for spec in self.FIELD_SPECS]
-
-    @property
-    def field_specs(self):
-        return list(self.FIELD_SPECS)
-
-    @property
     def default_source_fields(self):
         return ["h1"]
 

--- a/src/sweep/equations/visco_acoustic.py
+++ b/src/sweep/equations/visco_acoustic.py
@@ -2,7 +2,7 @@ import jax, torch
 import numpy as np
 import jax.numpy as jnp
 from .base import SecondOrderEquation
-from .fields import ModelSpec
+from .fields import FieldSpec, ModelSpec
 from .utils import to_backend
 
 def cond_torch(pred, true_fn, false_fn, args):
@@ -63,6 +63,10 @@ class ViscoAcoustic(SecondOrderEquation):
         ModelSpec("Q", description="Quality factor controlling attenuation."),
         ModelSpec("omega", description="Angular reference frequency for visco-acoustic attenuation.", unit="rad/s"),
     )
+    FIELD_SPECS = (
+        FieldSpec("h1", aliases=("pressure", "p"), description="Primary visco-acoustic pressure-like wavefield.", supports_source=True, supports_receiver=True),
+        FieldSpec("h2", aliases=("pressure_prev",), description="Previous-step pressure-like wavefield.", internal=True),
+    )
     def __init__(self, spatial_order=4, device='cpu', backend = 'torch', dim=2, phase_shift=True, amplitude_damping=True):
         """Acoustic wave equation solver.
 
@@ -88,14 +92,6 @@ class ViscoAcoustic(SecondOrderEquation):
     @property
     def need_init(self):
         return True
-    
-    @property
-    def models(self):
-        return [spec.name for spec in self.MODEL_SPECS]
-    
-    @property
-    def wavefields(self):
-        return ['h1', 'h2']
     
     def func(self, wavefields, models, dt, h, b, **kwargs):
         hz, hx = self._spacings_2d(h)


### PR DESCRIPTION
## Summary
- `WaveEquation` provides default `wavefields` / `models` / `field_specs` / `model_specs` properties driven by class-level `FIELD_SPECS` / `MODEL_SPECS` tables. Each has a setter so legacy `self.wavefields = ...` writes (`Acoustic1st` switches names by PML mode in `__init__`) keep working. Storage uses `_sweep_*_override` keys to avoid clashes with equation-internal attributes (caught e.g. `Acoustic3D.__init__`).
- Removes the redundant 4-property block from 23 shipped equations.
- **Adds `FIELD_SPECS` to 7 legacy equations** that previously hard-coded `wavefields`: `AcousticVRR`, `ViscoAcoustic`, `AEC`, `AECLSRTM`, `ElasticP`, `ElasticZ`, `ElasticLSRTM`. They now drive introspection through the same path as the modern equations with semantically meaningful `supports_source` / `supports_receiver` flags. LSRTM variants follow the `AcousticLSRTM` convention (background = source-only, scattered = receiver-only).
- `Acoustic1st` keeps its dynamic `field_specs` (CPML vs SPML); only the boilerplate `models` override is removed.
- Drops the dead `self._wavefields = []` line in `Acoustic3D.__init__`.

## Test plan
- [x] `test/test_installation_smoke.py` 3/3 pass.
- [x] Runtime introspection on 28 equation classes (23 shipped + 5 legacy reachable without `jax`) — `models`, `wavefields`, `available_source_fields`, `available_receiver_fields` non-empty and semantically correct.
- [x] Static AST check on `ElasticP` and `ViscoAcoustic` (pre-existing top-level `import jax` blocks runtime instantiation in jax-free envs) — both expose `FIELD_SPECS` + `MODEL_SPECS` and no longer override `wavefields`.
- [x] End-to-end `PropTorch(impl="eager")` forward on `Acoustic` and on a `TinyScalar` toy with **zero** property overrides — both return `max|wavefield| = 4.412` (identical to dev).
- [x] Numerical parity verified against dev oracle on 5 shipped equations: Acoustic, Elastic, AcousticVRZ, AcousticVTI1st, DASZhao — all match byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)