### PR TITLE
ci(docs): install sweep so griffe can inspect it

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,13 @@ jobs:
           cache-dependency-path: docs/requirements.txt
 
       - name: Install dependencies
-        run: pip install -r docs/requirements.txt
+        run: |
+          pip install -r docs/requirements.txt
+          # Install sweep itself (without the CUDA extension) so
+          # mkdocstrings' force_inspection mode can import the
+          # package — its docstring section comes from the runtime
+          # `WaveEquation.__init_subclass__` admonition injection.
+          pip install --no-build-isolation -e .
 
       - name: Build site
         run: mkdocs build


### PR DESCRIPTION
Hotfix for the GitHub Pages build failure introduced by #30. mkdocstrings now runs in \`force_inspection\` mode, so griffe imports \`sweep\` at docs build time — but the workflow only installs \`docs/requirements.txt\`, not sweep itself, so \`from sweep.equations.base import numpy as np\` raises \`ModuleNotFoundError: No module named 'numpy'\`.

## Summary
- Add \`pip install --no-build-isolation -e .\` after the docs requirements. \`--no-build-isolation\` keeps setuptools from re-resolving build deps it does not need; \`SWEEP_BUILD_CUDA\` is unset by default so the CUDA extension is skipped.

## Test plan
- [x] Re-run will be visible in Actions; the failed run was https://github.com/DeepWave-KAUST/sweep/actions/runs/26839038507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)