### PR TITLE
ci(docs): install CPU torch for sweep.equations imports

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r docs/requirements.txt
+          # CPU-only torch wheel — sweep's optional torch backend is
+          # imported at the top of several equation modules (das.py,
+          # elasticP.py, visco_acoustic.py); without it, mkdocstrings
+          # cannot resolve `sweep.equations.DAS` and the docs build
+          # fails.
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
           # Install sweep itself (without the CUDA extension) so
           # mkdocstrings' force_inspection mode can import the
           # package — its docstring section comes from the runtime


### PR DESCRIPTION
Follow-up to #32. With sweep installed, griffe gets past the numpy import, but `sweep.equations.das`, `elasticP`, and `visco_acoustic` import torch at module top — without it, mkdocstrings raises `Could not collect 'sweep.equations.DAS'`. Add the CPU-only torch wheel before `pip install -e .`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)