### PR TITLE
Align eager↔CUDA FWI gradients (race-free fwd + fused adjoint + lsrtm)

### DIFF
--- a/src/sweep/csrc/cuda/common/acoustic.h
+++ b/src/sweep/csrc/cuda/common/acoustic.h
@@ -98,13 +98,26 @@ struct AcousticWavefieldPointer {
     float* __restrict__ zetay;
     float* __restrict__ zetaz;
 
+    // Optional double-buffer "next" psi (race-free forward: read psi*, write psi*n).
+    // nullptr when the equation does not opt into psi double-buffering.
+    float* __restrict__ psixn = nullptr;
+    float* __restrict__ psiyn = nullptr;
+    float* __restrict__ psizn = nullptr;
+
+    // Optional double-buffer "next" zeta (fused adjoint: read zeta at neighbours
+    // via g_tmp, write next zeta to a SEPARATE buffer).  nullptr unless the bound
+    // tensor list opts into the aux (zeta) double-buffer.
+    float* __restrict__ zetaxn = nullptr;
+    float* __restrict__ zetayn = nullptr;
+    float* __restrict__ zetazn = nullptr;
+
     __device__ AcousticWavefieldPointer offset(
         int b,
         int spatial_size
     ) const {
 
         AcousticWavefieldPointer out = *this;
- 
+
         int shift = b * spatial_size;
 
         out.u_prev += shift;
@@ -118,6 +131,14 @@ struct AcousticWavefieldPointer {
         if (out.zetax) out.zetax += shift;
         if (out.zetay) out.zetay += shift;
         if (out.zetaz) out.zetaz += shift;
+
+        if (out.psixn) out.psixn += shift;
+        if (out.psiyn) out.psiyn += shift;
+        if (out.psizn) out.psizn += shift;
+
+        if (out.zetaxn) out.zetaxn += shift;
+        if (out.zetayn) out.zetayn += shift;
+        if (out.zetazn) out.zetazn += shift;
 
         return out;
     }
@@ -141,9 +162,22 @@ struct AcousticWavefieldTensor {
     torch::Tensor zetay_t;
     torch::Tensor zetaz_t;
 
+    // Optional double-buffer "next" psi (set only when the bound tensor list
+    // includes them, i.e. the equation opts into psi double-buffering).
+    torch::Tensor psixn_t;
+    torch::Tensor psiyn_t;
+    torch::Tensor psizn_t;
+
+    // Optional double-buffer "next" zeta (fused adjoint only).
+    torch::Tensor zetaxn_t;
+    torch::Tensor zetayn_t;
+    torch::Tensor zetazn_t;
+
     int dim = 2;
     bool use_pml = true;
     bool allocated = false;
+    bool double_buffer_psi = false;   // true when psi*n_t are present
+    bool double_buffer_aux = false;   // true when zeta*n_t are present (fused adjoint)
 
     // =========================
     // Allocate (only once)
@@ -192,13 +226,15 @@ struct AcousticWavefieldTensor {
 
         if (dim == 2) {
             TORCH_CHECK(
-                tensors.size() == (use_pml ? 7 : 3),
-                "Acoustic 2D wavefields expect 7 tensors with PML or 3 tensors without PML"
+                !use_pml ? tensors.size() == 3
+                         : (tensors.size() == 7 || tensors.size() == 9 || tensors.size() == 11),
+                "Acoustic 2D wavefields expect 3 (no PML), 7 (PML), 9 (PML+psi double-buffer), or 11 (PML+psi+zeta double-buffer) tensors"
             );
         } else {
             TORCH_CHECK(
-                tensors.size() == (use_pml ? 9 : 3),
-                "Acoustic 3D wavefields expect 9 tensors with PML or 3 tensors without PML"
+                !use_pml ? tensors.size() == 3
+                         : (tensors.size() == 9 || tensors.size() == 12 || tensors.size() == 15),
+                "Acoustic 3D wavefields expect 3 (no PML), 9 (PML), 12 (PML+psi double-buffer), or 15 (PML+psi+zeta double-buffer) tensors"
             );
         }
 
@@ -219,6 +255,34 @@ struct AcousticWavefieldTensor {
                 psiy_t = torch::Tensor();
                 zetay_t = torch::Tensor();
             }
+
+            // Optional psi double-buffer: extra "next" psi tensors appended
+            // after the standard PML set (2D: +2 -> 9, 3D: +3 -> 12).  The fused
+            // adjoint adds a zeta double-buffer on top (2D: +2 -> 11, 3D: +3 -> 15);
+            // tail order is psixn,psizn[,psiyn], zetaxn,zetazn[,zetayn].
+            double_buffer_aux = (dim == 2 ? tensors.size() == 11
+                                          : tensors.size() == 15);
+            double_buffer_psi = double_buffer_aux ||
+                                (dim == 2 ? tensors.size() == 9
+                                          : tensors.size() == 12);
+            if (double_buffer_psi) {
+                psixn_t = tensors[i++];
+                psizn_t = tensors[i++];
+                if (dim == 3) psiyn_t = tensors[i++];
+            } else {
+                psixn_t = torch::Tensor();
+                psizn_t = torch::Tensor();
+                psiyn_t = torch::Tensor();
+            }
+            if (double_buffer_aux) {
+                zetaxn_t = tensors[i++];
+                zetazn_t = tensors[i++];
+                if (dim == 3) zetayn_t = tensors[i++];
+            } else {
+                zetaxn_t = torch::Tensor();
+                zetazn_t = torch::Tensor();
+                zetayn_t = torch::Tensor();
+            }
         } else {
             psix_t = torch::Tensor();
             psiy_t = torch::Tensor();
@@ -226,6 +290,8 @@ struct AcousticWavefieldTensor {
             zetax_t = torch::Tensor();
             zetay_t = torch::Tensor();
             zetaz_t = torch::Tensor();
+            double_buffer_psi = false;
+            double_buffer_aux = false;
         }
 
         allocated = true;
@@ -255,9 +321,27 @@ struct AcousticWavefieldTensor {
                 v.psiy = nullptr;
                 v.zetay = nullptr;
             }
+
+            if (double_buffer_psi) {
+                v.psixn = psixn_t.data_ptr<float>();
+                v.psizn = psizn_t.data_ptr<float>();
+                v.psiyn = (dim == 3) ? psiyn_t.data_ptr<float>() : nullptr;
+            } else {
+                v.psixn = v.psiyn = v.psizn = nullptr;
+            }
+
+            if (double_buffer_aux) {
+                v.zetaxn = zetaxn_t.data_ptr<float>();
+                v.zetazn = zetazn_t.data_ptr<float>();
+                v.zetayn = (dim == 3) ? zetayn_t.data_ptr<float>() : nullptr;
+            } else {
+                v.zetaxn = v.zetayn = v.zetazn = nullptr;
+            }
         } else {
             v.psix = v.psiy = v.psiz = nullptr;
             v.zetax = v.zetay = v.zetaz = nullptr;
+            v.psixn = v.psiyn = v.psizn = nullptr;
+            v.zetaxn = v.zetayn = v.zetazn = nullptr;
         }
 
         return v;
@@ -289,6 +373,39 @@ struct AcousticWavefieldTensor {
     {
         std::swap(u_prev_t, u_now_t);
         std::swap(u_now_t,  u_next_t);
+    }
+
+    // Forward double-buffer swap: rotate u AND swap psi <-> psin so the next
+    // step reads the freshly-written psi (race-free forward).  Use this only
+    // when the forward kernel writes psi*n; otherwise use swap() (u-only).
+    // No-op on psi if not double-buffering, so it is safe to call either way.
+    void swap_pml()
+    {
+        std::swap(u_prev_t, u_now_t);
+        std::swap(u_now_t,  u_next_t);
+        if (double_buffer_psi) {
+            std::swap(psix_t, psixn_t);
+            std::swap(psiz_t, psizn_t);
+            if (dim == 3) std::swap(psiy_t, psiyn_t);
+        }
+    }
+
+    // Fused-adjoint double-buffer swap: rotate u AND psi<->psin AND zeta<->zetan.
+    // Use ONLY with the fused adjoint kernel (which writes psi*n AND zeta*n).
+    void swap_aux()
+    {
+        std::swap(u_prev_t, u_now_t);
+        std::swap(u_now_t,  u_next_t);
+        if (double_buffer_psi) {
+            std::swap(psix_t, psixn_t);
+            std::swap(psiz_t, psizn_t);
+            if (dim == 3) std::swap(psiy_t, psiyn_t);
+        }
+        if (double_buffer_aux) {
+            std::swap(zetax_t, zetaxn_t);
+            std::swap(zetaz_t, zetazn_t);
+            if (dim == 3) std::swap(zetay_t, zetayn_t);
+        }
     }
 
 };

--- a/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
@@ -17,6 +17,37 @@ namespace acoustic2d {
 
 namespace {
 
+// Scratch buffers for the exact discrete-adjoint step (prepare/apply).  Six
+// per-cell fields (g_lx, g_lz, g_gx, g_gz, g_qx, g_qz) packed into one tensor.
+// Allocated with zeros so halo/air cells (never touched by PREPARE) carry the
+// correct adjoint value 0; see acoustic2nd_adjoint_prepare.
+
+// One exact-adjoint time step: PREPARE (local scratch) then APPLY (transposed
+// stencils on scratch).  Replaces the old compute_v2_lambda + acoustic2nd_adjoint
+// pair, which only transposed the interior and copied the forward in the PML
+// band.  Works for interior + PML uniformly (PML coeffs are 0 in the interior).
+static inline void run_acoustic2d_adjoint_step(
+    int order, dim3 grid, dim3 block,
+    AcousticWavefieldPointer adj_view,
+    const float* vp_ptr,
+    LaplaceParam lap_ctx, GradParam grad_ctx,
+    GradParam grad_ctx_x, GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml, SolverContext ctx)
+{
+    // FUSED single-kernel exact adjoint: recompute the per-cell g_* inline at
+    // each stencil tap and write next-step psi/zeta into the wavefield's
+    // double-buffer out-tensors (psixn/psizn/zetaxn/zetazn).  Read-old/write-new
+    // => race-free even though aux is read at neighbours; no 6-field scratch
+    // round-trip => ~forward bandwidth.  Caller must swap_aux() each step.
+    TORCH_CHECK(adj_view.zetaxn != nullptr && adj_view.psixn != nullptr,
+        "fused adjoint needs the adjoint wavefield bound with psi+zeta "
+        "double-buffer (11 tensors in 2D); set cuda_layout.adjoint_extra_nvar=2.");
+    (void)grad_ctx;
+    ACOUSTIC2D_ADJOINT_FUSED(order, grid, block,
+        adj_view, vp_ptr, lap_ctx, grad_ctx_x, grad_ctx_z, cpml, ctx,
+        adj_view.psixn, adj_view.psizn, adj_view.zetaxn, adj_view.zetazn);
+}
+
 void init_rtm_output_2d(RTMOutput& out, const torch::Tensor& vp)
 {
     out.image = torch::zeros_like(vp);
@@ -115,14 +146,7 @@ void run_full_imaging(
 
     float* u_thist = nullptr;
 
-    // Buffer for pre-computed v^2 * lambda_now (proper-adjoint kernel input).
-    // Python-side (PropTorch) manages the buffer via adjoint_workspace[0] so
-    // it can be reused across backward calls; fall back to a local alloc when
-    // the caller has not bound one.  compute_v2_lambda_2d overwrites the
-    // full grid every step, so the buffer's initial values do not matter.
-    auto v2_lambda = !p.adjoint_workspace.empty()
-        ? p.adjoint_workspace[0]
-        : torch::empty_like(vp);
+    // Scratch for the exact discrete-adjoint step (prepare/apply).
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 2);
@@ -147,29 +171,12 @@ void run_full_imaging(
 
         auto adj_view = adjoint.view();
 
-        // Pre-compute v^2 * lambda_now into the buffer that the adjoint
-        // kernel reads via the laplace stencil.
-        compute_v2_lambda_2d<<<launch_config.grid, launch_config.block>>>(
-            vp.data_ptr<float>(),
-            adj_view.u_now,
-            v2_lambda.data_ptr<float>(),
-            nx, nz, B
-        );
-
-        ACOUSTIC2D_ADJOINT(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            v2_lambda.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        // Exact discrete adjoint of the CPML forward step (interior + PML).
+        run_acoustic2d_adjoint_step(
+            order, launch_config.grid, launch_config.block,
+            adj_view, vp.data_ptr<float>(),
+            lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z,
+            cpml, ctx);
 
         add_source<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -180,7 +187,7 @@ void run_full_imaging(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_aux();   // fused adjoint: rotate u + psi + zeta double-buffer
 
         accumulate_source_gradient_2d(
             forward_source_config.grid,
@@ -293,11 +300,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
     RTMOutput illumination;
     init_rtm_output_2d(illumination, vp);
 
-    // Buffer for pre-computed v^2 * lambda_now (proper-adjoint kernel input);
-    // Python-managed via adjoint_workspace[0] for reuse across calls.
-    auto v2_lambda = !p.adjoint_workspace.empty()
-        ? p.adjoint_workspace[0]
-        : torch::empty_like(vp);
+    // Scratch for the exact discrete-adjoint step (prepare/apply).
 
     // For checking wavefields
     // torch::Tensor u_allt = torch::zeros({nt, B, 1, nz, nx}, vp.options());
@@ -355,28 +358,12 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
         // u_allt[it].copy_(forward.u_now_t);
 
-        // adjoint modeling
-        compute_v2_lambda_2d<<<launch_config.grid, launch_config.block>>>(
-            vp.data_ptr<float>(),
-            adj_view.u_now,
-            v2_lambda.data_ptr<float>(),
-            nx, nz, B
-        );
-
-        ACOUSTIC2D_ADJOINT(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            v2_lambda.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        // adjoint modeling (exact discrete adjoint of the CPML forward step)
+        run_acoustic2d_adjoint_step(
+            order, launch_config.grid, launch_config.block,
+            adj_view, vp.data_ptr<float>(),
+            lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z,
+            cpml, ctx);
 
         add_source<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -387,7 +374,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_aux();   // fused adjoint: rotate u + psi + zeta double-buffer
 
         accumulate_source_gradient_2d(
             fwd_source_config.grid,
@@ -458,27 +445,11 @@ BackwardOutput backward_bs(const BackwardInput& in)
     if (p.nt > 0) {
         auto adj_view = adjoint.view();
 
-        compute_v2_lambda_2d<<<launch_config.grid, launch_config.block>>>(
-            vp.data_ptr<float>(),
-            adj_view.u_now,
-            v2_lambda.data_ptr<float>(),
-            nx, nz, B
-        );
-
-        ACOUSTIC2D_ADJOINT(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            v2_lambda.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_acoustic2d_adjoint_step(
+            order, launch_config.grid, launch_config.block,
+            adj_view, vp.data_ptr<float>(),
+            lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z,
+            cpml, ctx);
 
         add_source<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -489,7 +460,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_aux();   // fused adjoint: rotate u + psi + zeta double-buffer
 
         accumulate_source_gradient_2d(
             fwd_source_config.grid,
@@ -603,7 +574,6 @@ void process_recursive_interval_2d(
     std::vector<AcousticWavefieldTensor>& scratch_states,
     int scratch_depth,
     torch::Tensor& u_this_scratch,
-    torch::Tensor& v2_lambda_scratch,
     int nx,
     int nz
 )
@@ -645,27 +615,11 @@ void process_recursive_interval_2d(
 
         auto adj_view = adjoint.view();
 
-        compute_v2_lambda_2d<<<wave_grid, wave_block>>>(
-            vp.data_ptr<float>(),
-            adj_view.u_now,
-            v2_lambda_scratch.data_ptr<float>(),
-            nx, nz, ctx.B
-        );
-
-        ACOUSTIC2D_ADJOINT(
-            order,
-            wave_grid,
-            wave_block,
-            adj_view,
-            v2_lambda_scratch.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_acoustic2d_adjoint_step(
+            order, wave_grid, wave_block,
+            adj_view, vp.data_ptr<float>(),
+            lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z,
+            cpml, ctx);
 
         add_source<<<adj_source_grid, adj_source_block>>>(
             adj_view.u_next,
@@ -676,7 +630,7 @@ void process_recursive_interval_2d(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_aux();   // fused adjoint: rotate u + psi + zeta double-buffer
 
         accumulate_source_gradient_2d(
             forward_source_grid,
@@ -761,7 +715,6 @@ void process_recursive_interval_2d(
         scratch_states,
         scratch_depth + 1,
         u_this_scratch,
-        v2_lambda_scratch,
         nx,
         nz
     );
@@ -795,7 +748,6 @@ void process_recursive_interval_2d(
         scratch_states,
         scratch_depth + 1,
         u_this_scratch,
-        v2_lambda_scratch,
         nx,
         nz
     );
@@ -861,10 +813,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
     RTMOutput illumination;
     init_rtm_output_2d(illumination, vp);
 
-    // Buffer for v^2 * lambda_now; Python-managed via adjoint_workspace[0].
-    auto v2_lambda = !p.adjoint_workspace.empty()
-        ? p.adjoint_workspace[0]
-        : torch::empty_like(vp);
+    // Scratch for the exact discrete-adjoint step (prepare/apply).
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 2);
@@ -924,27 +873,11 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
         for (int it = end - 1; it >= start; --it) {
             auto adj_view = adjoint.view();
 
-            compute_v2_lambda_2d<<<launch_config.grid, launch_config.block>>>(
-                vp.data_ptr<float>(),
-                adj_view.u_now,
-                v2_lambda.data_ptr<float>(),
-                nx, nz, B
-            );
-
-            ACOUSTIC2D_ADJOINT(
-                order,
-                launch_config.grid,
-                launch_config.block,
-                adj_view,
-                v2_lambda.data_ptr<float>(),
-                vp.data_ptr<float>(),
-                lap_ctx,
-                grad_ctx,
-                grad_ctx_x,
-                grad_ctx_z,
-                cpml,
-                ctx
-            );
+            run_acoustic2d_adjoint_step(
+                order, launch_config.grid, launch_config.block,
+                adj_view, vp.data_ptr<float>(),
+                lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z,
+                cpml, ctx);
 
             add_source<<<adj_source_config.grid, adj_source_config.block>>>(
                 adj_view.u_next,
@@ -955,7 +888,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
                 ctx
             );
 
-            adjoint.swap();
+            adjoint.swap_aux();   // fused adjoint: rotate u + psi + zeta double-buffer
 
             accumulate_source_gradient_2d(
                 fwd_source_config.grid,
@@ -1084,10 +1017,7 @@ BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
     for (auto& scratch_state : scratch_states)
         scratch_state.allocate(vp, 2, true);
     auto u_this_scratch = torch::empty_like(vp);
-    // Scratch buffer for v^2 * lambda_now; Python-managed via adjoint_workspace[0].
-    auto v2_lambda_scratch = !p.adjoint_workspace.empty()
-        ? p.adjoint_workspace[0]
-        : torch::empty_like(vp);
+    // Scratch for the exact discrete-adjoint step (prepare/apply).
 
     AcousticWavefieldTensor start_state;
     start_state.allocate(vp, 2, true);
@@ -1130,7 +1060,6 @@ BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
             scratch_states,
             0,
             u_this_scratch,
-            v2_lambda_scratch,
             nx,
             nz
         );

--- a/src/sweep/csrc/cuda/equations/acoustic2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/forward.cu
@@ -193,7 +193,7 @@ ForwardOutput forward(const ForwardInput& in) {
             ctx
         );
 
-        wavefield.swap();
+        wavefield.swap_pml();   // rotate u AND psi<->psin: race-free psi double-buffer
 
         checkpoint_runtime.save_forward(it, static_cast<int>(p.nt), wavefield.checkpoint_tensors());
 

--- a/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cuh
@@ -15,19 +15,19 @@
         else                   acoustic2nd<-1><<<grid, block>>>(__VA_ARGS__);\
     } while (0)
 
-// Proper adjoint of `L u = v^2 · ∇²u`:  L^* λ = ∇²(v^2 · λ)
-// Used in adjoint propagation. Differs from forward kernel only in the
-// non-PML branch (interior): computes ∇²(v²·λ) on a pre-computed `v2_lambda`
-// buffer instead of v²·∇²λ. PML branch left identical to forward (slight
-// residual error in PML zone; sufficient to clean up the interior box
-// anomaly).
-#define ACOUSTIC2D_ADJOINT(order, grid, block, ...)                                  \
-    do {                                                        \
-        if      ((order) == 2) acoustic2nd_adjoint<2><<<grid, block>>>(__VA_ARGS__); \
-        else if ((order) == 4) acoustic2nd_adjoint<4><<<grid, block>>>(__VA_ARGS__); \
-        else if ((order) == 6) acoustic2nd_adjoint<6><<<grid, block>>>(__VA_ARGS__); \
-        else if ((order) == 8) acoustic2nd_adjoint<8><<<grid, block>>>(__VA_ARGS__); \
-        else                   acoustic2nd_adjoint<-1><<<grid, block>>>(__VA_ARGS__);\
+
+
+
+// FUSED exact adjoint: ONE launch, no scratch (recompute g_* inline at each tap),
+// writes next psi/zeta to SEPARATE buffers (double-buffer) -> race-free + ~forward
+// bandwidth.  Caller swaps psi/zeta via swap_aux() each step.
+#define ACOUSTIC2D_ADJOINT_FUSED(order, grid, block, ...)                                     \
+    do {                                                                                       \
+        if      ((order) == 2) acoustic2nd_adjoint_fused<2><<<grid, block>>>(__VA_ARGS__);     \
+        else if ((order) == 4) acoustic2nd_adjoint_fused<4><<<grid, block>>>(__VA_ARGS__);     \
+        else if ((order) == 6) acoustic2nd_adjoint_fused<6><<<grid, block>>>(__VA_ARGS__);     \
+        else if ((order) == 8) acoustic2nd_adjoint_fused<8><<<grid, block>>>(__VA_ARGS__);     \
+        else                   acoustic2nd_adjoint_fused<-1><<<grid, block>>>(__VA_ARGS__);    \
     } while (0)
 
 // Pre-pass: clear air cells (above per-column topo surface).  Launched
@@ -156,16 +156,18 @@ __global__ void acoustic2nd(
     float daipsiz_dz = az_ * dpsizdz + dazdz * f.psiz[idx];
     float daipxix_dx = ax_ * dpsixdx + daxdx * f.psix[idx];
 
-    // X direction
+    // X direction.  Race-free: read psix at neighbours (above), write the NEXT
+    // psix to a separate buffer (psixn) when double-buffering; fall back to
+    // in-place when psixn is null (equations that have not opted in).
     float tmpx = ((1.0f+bx_)*lap_x + dbxdx_*dudx) + daipxix_dx;
     w_sum += (1.0f+bx_) * tmpx + ax_ * f.zetax[idx];
-    f.psix[idx]  = bx_ * dudx + ax_ * f.psix[idx];
+    (f.psixn ? f.psixn : f.psix)[idx]  = bx_ * dudx + ax_ * f.psix[idx];
     f.zetax[idx] = bx_ * tmpx + ax_ * f.zetax[idx];
 
     // Z direction
     float tmpz = ((1.0f+bz_)*lap_z + dbzdz_*dudz) + daipsiz_dz;
     w_sum += (1.0f+bz_) * tmpz + az_ * f.zetaz[idx];
-    f.psiz[idx]  = bz_ * dudz + az_ * f.psiz[idx];
+    (f.psizn ? f.psizn : f.psiz)[idx]  = bz_ * dudz + az_ * f.psiz[idx];
     f.zetaz[idx] = bz_ * tmpz + az_ * f.zetaz[idx];
 
     f.u_next[idx] =
@@ -177,116 +179,138 @@ __global__ void acoustic2nd(
         u_this_b[idx] = (v * v) * (lap_x + lap_z);
 }
 
-// Helper: pre-compute v2_lambda[idx] = vp[idx]^2 * lambda[idx]
-// Used by the adjoint kernel which then computes ∇²(v²·λ) on this buffer.
-// `static` so each translation unit has its own copy (header-defined).
-static __global__ void compute_v2_lambda_2d(
-    const float* __restrict__ vp,
-    const float* __restrict__ lambda,
-    float* __restrict__ v2_lambda,
-    int nx, int nz, int B
-) {
-    int ix = blockIdx.x * blockDim.x + threadIdx.x;
-    int iz = blockIdx.y * blockDim.y + threadIdx.y;
-    int b  = blockIdx.z;
-    if (ix >= nx || iz >= nz || b >= B) return;
-    int spatial_size = nx * nz;
-    int idx = b * spatial_size + iz * nx + ix;
-    float v = vp[idx];
-    v2_lambda[idx] = v * v * lambda[idx];
-}
 
-// Proper-adjoint kernel for the acoustic wave equation.
-// Computes  λ_next = 2 λ_now - λ_pre + dt² · ∇²(v² · λ_now)
-// in the non-PML branch.  PML branch retains forward formulation for now.
+
+
+
+// ---------------------------------------------------------------------------
+// FUSED exact discrete adjoint — single kernel, NO scratch.
+// Same math as prepare/apply but the per-cell scratch (g_l/g_g/g_q) is
+// recomputed INLINE at each stencil tap from the *current* adjoint fields,
+// instead of being materialised in global memory.  Reads current
+// lambda(u_now)/psi/zeta at idx+neighbours, writes next-step lambda (u_next)
+// and the next-step aux into SEPARATE buffers (psi*_out/zeta*_out) -> read-old
+// / write-new, exactly like the forward time-step, so there is no race even
+// though aux is now read at neighbours.  Caller must double-buffer the aux and
+// swap (psi*_out/zeta*_out) <-> (f.psi*/f.zeta*) each step.
+// Each tap is read once and feeds all three transposed stencils
+// (Lx(g_lx), Dx(g_gx), Dx(g_qx)) -> bandwidth-optimal (no 6/9-field round-trip).
 template<int Order>
-__global__ void acoustic2nd_adjoint(
+__global__ void acoustic2nd_adjoint_fused(
     AcousticWavefieldPointer wf,
-    const float* __restrict__ v2_lambda,  // pre-computed v^2 · λ_now
     const float* __restrict__ vp,
     LaplaceParam lap_ctx,
-    GradParam grad_ctx,
     GradParam grad_ctx_x,
     GradParam grad_ctx_z,
     AcousticCPMLPointer cpml,
-    SolverContext solver
+    SolverContext solver,
+    float* __restrict__ psix_out,
+    float* __restrict__ psiz_out,
+    float* __restrict__ zetax_out,
+    float* __restrict__ zetaz_out
 ){
     int ix = blockIdx.x * blockDim.x + threadIdx.x;
     int iz = blockIdx.y * blockDim.y + threadIdx.y;
     int b  = blockIdx.z;
-
     if (ix >= solver.nx || iz >= solver.nz) return;
 
     constexpr bool is_runtime = (Order == -1);
     constexpr int  M_static  = is_runtime ? 0 : (Order / 2);
     int halo = is_runtime ? solver.M : M_static;
-
     if (ix < halo || ix >= solver.nx - halo ||
-        iz < halo || iz >= solver.nz - halo)
-        return;
+        iz < halo || iz >= solver.nz - halo) return;
+    if (solver.has_topo && iz < solver.topo_rows[ix]) return;
 
-    int spatial_size = solver.nx * solver.nz;
+    int sp = solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
+    int oidx = b * sp + idx;
+    auto f = wf.offset(b, sp);
+    const float* vpb = vp + b * sp;
+    int sz = solver.nx;                       // z-stride
+    float dt2 = solver.dt * solver.dt;
+    const float* lc = lap_ctx.coeff;          // [c0(center), c1, ..., cM]
+    const float* gc = grad_ctx_x.coeff;       // [_, c1, ..., cM]  (antisymmetric)
+    float invdx2 = 1.0f / (lap_ctx.dx * lap_ctx.dx);
+    float invdz2 = 1.0f / (lap_ctx.dz * lap_ctx.dz);
+    float invdx  = 1.0f / lap_ctx.dx;
+    float invdz  = 1.0f / lap_ctx.dz;
 
-    auto f = wf.offset(b, spatial_size);
-    const float* vp_b = vp + b * spatial_size;
-    const float* v2l_b = v2_lambda + b * spatial_size;
+    float gun = f.u_now[idx];
+    float c0c = vpb[idx]; c0c = c0c * c0c * dt2;
+    float gw  = c0c * gun;                     // c * lambda at idx
 
-    if (solver.has_topo && iz < solver.topo_rows[ix]) {
+    // gw at a linear index n  (c[n]*lambda[n])
+    #define GW_AT(n) ( vpb[n]*vpb[n]*dt2 * f.u_now[n] )
+
+    // Interior fast-path: aux all 0, g_lx=g_lz=gw -> 2L - L_prev + Lap(gw).
+    bool pure_interior =
+        (ix >= solver.abcn + 2 * halo) && (ix < solver.nx - solver.abcn - 2 * halo) &&
+        (iz >= (solver.free_surface ? 0 : solver.abcn) + 2 * halo) &&
+        (iz < solver.nz - solver.abcn - 2 * halo);
+    if (pure_interior) {
+        float lapx = -lc[0] * gw, lapz = -lc[0] * gw;
+        #pragma unroll
+        for (int k = 1; k <= halo; ++k) {
+            lapx += lc[k] * (GW_AT(idx + k)      + GW_AT(idx - k));
+            lapz += lc[k] * (GW_AT(idx + k * sz) + GW_AT(idx - k * sz));
+        }
+        f.u_next[idx] = 2.0f * gun - f.u_prev[idx] + lapx * invdx2 + lapz * invdz2;
+        psix_out[oidx] = 0.f; psiz_out[oidx] = 0.f;
+        zetax_out[oidx] = 0.f; zetaz_out[oidx] = 0.f;
         return;
     }
 
-    bool in_pml = (ix < solver.abcn + halo) || (ix >= solver.nx - solver.abcn - halo) ||
-                  (iz < (solver.free_surface ? halo : solver.abcn + halo)) ||
-                  (iz >= solver.nz - solver.abcn - halo);
+    float ax_ = cpml.ax[ix], az_ = cpml.az[iz];
+    float bx_ = cpml.bx[ix], bz_ = cpml.bz[iz];
+    float daxdx = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
+    float dazdz = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
 
-    if (!in_pml) {
-        // Non-PML: proper adjoint. Compute ∇²(v² · λ_now) on the pre-computed
-        // v2_lambda buffer.  This is the transpose of `v² · ∇²λ` from the
-        // forward kernel.
-        float lap_x = laplace<2, Order, X>(v2l_b, ix, 0, iz, lap_ctx);
-        float lap_z = laplace<2, Order, Z>(v2l_b, ix, 0, iz, lap_ctx);
-        float dt2 = solver.dt * solver.dt;
-        f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] +
-                        dt2 * (lap_x + lap_z);
-        return;
+    float gtmpx0 = bx_ * f.zetax[idx] + (1.0f + bx_) * gw;
+    float gtmpz0 = bz_ * f.zetaz[idx] + (1.0f + bz_) * gw;
+
+    // local g_tmp / g_l / g_g / g_q at a tap, given the 1D PML index for that axis
+    #define GTMP_X(n, nix) ( cpml.bx[nix]*f.zetax[n] + (1.0f+cpml.bx[nix])*(vpb[n]*vpb[n]*dt2)*f.u_now[n] )
+    #define GTMP_Z(n, niz) ( cpml.bz[niz]*f.zetaz[n] + (1.0f+cpml.bz[niz])*(vpb[n]*vpb[n]*dt2)*f.u_now[n] )
+
+    // X-direction: Lx(g_lx), Dx(g_gx), Dx(g_qx); one read per tap.
+    float Lx_glx = -lc[0] * ((1.0f + bx_) * gtmpx0);
+    float Dx_ggx = 0.0f, Dx_gqx = 0.0f;
+    #pragma unroll
+    for (int k = 1; k <= halo; ++k) {
+        int np = idx + k, nm = idx - k, nixp = ix + k, nixm = ix - k;
+        float tp = GTMP_X(np, nixp), tm = GTMP_X(nm, nixm);
+        float bxp = cpml.bx[nixp], bxm = cpml.bx[nixm];
+        Lx_glx += lc[k] * ((1.0f + bxp) * tp + (1.0f + bxm) * tm);
+        Dx_ggx += gc[k] * ((bxp * f.psix[np] + cpml.dbxdx[nixp] * tp)
+                         - (bxm * f.psix[nm] + cpml.dbxdx[nixm] * tm));
+        Dx_gqx += gc[k] * (cpml.ax[nixp] * tp - cpml.ax[nixm] * tm);
     }
+    Lx_glx *= invdx2; Dx_ggx *= invdx; Dx_gqx *= invdx;
 
-    // PML branch: keep forward formulation for now (residual error in PML
-    // zone but main bug — box anomaly in non-PML interior — is addressed).
-    float v  = vp_b[idx];
-    float v2_dt2 = (v * v) * solver.dt * solver.dt;
-    float lap_x = laplace<2, Order, X>(f.u_now, ix, 0, iz, lap_ctx);
-    float lap_z = laplace<2, Order, Z>(f.u_now, ix, 0, iz, lap_ctx);
+    // Z-direction
+    float Lz_glz = -lc[0] * ((1.0f + bz_) * gtmpz0);
+    float Dz_ggz = 0.0f, Dz_gqz = 0.0f;
+    #pragma unroll
+    for (int k = 1; k <= halo; ++k) {
+        int np = idx + k * sz, nm = idx - k * sz, nizp = iz + k, nizm = iz - k;
+        float tp = GTMP_Z(np, nizp), tm = GTMP_Z(nm, nizm);
+        float bzp = cpml.bz[nizp], bzm = cpml.bz[nizm];
+        Lz_glz += lc[k] * ((1.0f + bzp) * tp + (1.0f + bzm) * tm);
+        Dz_ggz += gc[k] * ((bzp * f.psiz[np] + cpml.dbzdz[nizp] * tp)
+                         - (bzm * f.psiz[nm] + cpml.dbzdz[nizm] * tm));
+        Dz_gqz += gc[k] * (cpml.az[nizp] * tp - cpml.az[nizm] * tm);
+    }
+    Lz_glz *= invdz2; Dz_ggz *= invdz; Dz_gqz *= invdz;
 
-    float ax_ = cpml.ax[ix];
-    float az_ = cpml.az[iz];
-    float bx_ = cpml.bx[ix];
-    float bz_ = cpml.bz[iz];
-    float dbxdx_ = cpml.dbxdx[ix];
-    float dbzdz_ = cpml.dbzdz[iz];
-
-    float w_sum = 0.0f;
-    float dudz     = gradient<2, Order, Z>(f.u_now, ix, 0, iz, grad_ctx);
-    float dudx     = gradient<2, Order, X>(f.u_now, ix, 0, iz, grad_ctx);
-    float dpsizdz  = gradient<2, Order, Z>(f.psiz, ix, 0, iz, grad_ctx);
-    float dpsixdx  = gradient<2, Order, X>(f.psix, ix, 0, iz, grad_ctx);
-    float daxdx    = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
-    float dazdz    = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
-    float daipsiz_dz = az_ * dpsizdz + dazdz * f.psiz[idx];
-    float daipxix_dx = ax_ * dpsixdx + daxdx * f.psix[idx];
-
-    float tmpx = ((1.0f+bx_)*lap_x + dbxdx_*dudx) + daipxix_dx;
-    w_sum += (1.0f+bx_) * tmpx + ax_ * f.zetax[idx];
-    f.psix[idx]  = bx_ * dudx + ax_ * f.psix[idx];
-    f.zetax[idx] = bx_ * tmpx + ax_ * f.zetax[idx];
-
-    float tmpz = ((1.0f+bz_)*lap_z + dbzdz_*dudz) + daipsiz_dz;
-    w_sum += (1.0f+bz_) * tmpz + az_ * f.zetaz[idx];
-    f.psiz[idx]  = bz_ * dudz + az_ * f.psiz[idx];
-    f.zetaz[idx] = bz_ * tmpz + az_ * f.zetaz[idx];
-
-    f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + v2_dt2 * w_sum;
+    f.u_next[idx] = 2.0f * gun - f.u_prev[idx]
+                  + (Lx_glx + Lz_glz - Dx_ggx - Dz_ggz);
+    psix_out[oidx]  = ax_ * f.psix[idx] + daxdx * gtmpx0 - Dx_gqx;
+    psiz_out[oidx]  = az_ * f.psiz[idx] + dazdz * gtmpz0 - Dz_gqz;
+    zetax_out[oidx] = ax_ * (f.zetax[idx] + gw);
+    zetaz_out[oidx] = az_ * (f.zetaz[idx] + gw);
+    #undef GW_AT
+    #undef GTMP_X
+    #undef GTMP_Z
 }
 
 template<int Order>

--- a/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
@@ -42,6 +42,35 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
 namespace {
 
+// Scratch for the 3D exact discrete-adjoint step: 9 per-cell fields packed
+// into one zeros tensor (halo/air cells stay 0; see acoustic_adjoint_prepare_3d).
+
+// One exact-adjoint 3D time step: PREPARE (local scratch) then APPLY
+// (transposed stencils on scratch).  Replaces compute_v2_lambda_3d +
+// acoustic_adjoint_kernel_3d (which copied the forward in the PML band).
+static inline void run_acoustic3d_adjoint_step(
+    int order, dim3 grid, dim3 block,
+    AcousticWavefieldPointer adj_view,
+    const float* vp_ptr,
+    LaplaceParam lap_ctx, GradParam grad_ctx,
+    GradParam grad_ctx_x, GradParam grad_ctx_y, GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml, SolverContext ctx)
+{
+    // FUSED single-kernel exact 3D adjoint: recompute the per-cell g_* inline at
+    // each stencil tap and write next-step psi/zeta into the wavefield's
+    // double-buffer out-tensors (psi*n/zeta*n).  Read-old/write-new => race-free
+    // even though aux is read at neighbours; no 9-field scratch round-trip =>
+    // ~forward bandwidth.  Caller must swap_aux() each step.
+    TORCH_CHECK(adj_view.zetaxn != nullptr && adj_view.psixn != nullptr,
+        "fused 3D adjoint needs the adjoint wavefield bound with psi+zeta "
+        "double-buffer (15 tensors); set cuda_layout.adjoint_extra_nvar=3.");
+    (void)grad_ctx;
+    ACOUSTIC3D_ADJOINT_FUSED(order, grid, block,
+        adj_view, vp_ptr, lap_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z, cpml, ctx,
+        adj_view.psixn, adj_view.psiyn, adj_view.psizn,
+        adj_view.zetaxn, adj_view.zetayn, adj_view.zetazn);
+}
+
 void init_rtm_output_3d(RTMOutput& out, const torch::Tensor& vp)
 {
     out.image = torch::zeros_like(vp);
@@ -254,7 +283,6 @@ void process_recursive_interval_3d(
     std::vector<AcousticWavefieldTensor>& scratch_states,
     int scratch_depth,
     torch::Tensor& u_this_scratch,
-    torch::Tensor& v2_lambda_scratch,
     int B,
     int nx,
     int ny,
@@ -299,28 +327,11 @@ void process_recursive_interval_3d(
 
         auto adj_view = adjoint.view();
 
-        compute_v2_lambda_3d<<<wave_grid, wave_block>>>(
-            vp.data_ptr<float>(),
-            adj_view.u_now,
-            v2_lambda_scratch.data_ptr<float>(),
-            nx, ny, nz, ctx.B
-        );
-
-        ACOUSTIC3D_ADJOINT(
-            order,
-            wave_grid,
-            wave_block,
-            adj_view,
-            v2_lambda_scratch.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_y,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_acoustic3d_adjoint_step(
+            order, wave_grid, wave_block,
+            adj_view, vp.data_ptr<float>(),
+            lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z,
+            cpml, ctx);
 
         add_source_3d<<<adj_source_grid, adj_source_block>>>(
             adj_view.u_next,
@@ -331,7 +342,7 @@ void process_recursive_interval_3d(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_aux();   // fused adjoint: rotate u + psi + zeta double-buffer
 
         accumulate_source_gradient_3d(
             forward_source_grid,
@@ -420,7 +431,6 @@ void process_recursive_interval_3d(
         scratch_states,
         scratch_depth + 1,
         u_this_scratch,
-        v2_lambda_scratch,
         B,
         nx,
         ny,
@@ -457,7 +467,6 @@ void process_recursive_interval_3d(
         scratch_states,
         scratch_depth + 1,
         u_this_scratch,
-        v2_lambda_scratch,
         B,
         nx,
         ny,
@@ -496,9 +505,6 @@ void run_full_imaging(
     // Buffer for pre-computed v^2 * lambda_now (proper-adjoint kernel input).
     // Python-side (PropTorch) manages the buffer via adjoint_workspace[0] so
     // it can be reused across backward calls.
-    auto v2_lambda = !p.adjoint_workspace.empty()
-        ? p.adjoint_workspace[0]
-        : torch::empty_like(vp);
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 3);
@@ -524,28 +530,11 @@ void run_full_imaging(
     for (int it = p.nt - 1; it >= 0; --it) {
         auto adj_view = adjoint.view();
 
-        compute_v2_lambda_3d<<<launch_config.grid, launch_config.block>>>(
-            vp.data_ptr<float>(),
-            adj_view.u_now,
-            v2_lambda.data_ptr<float>(),
-            nx, ny, nz, B
-        );
-
-        ACOUSTIC3D_ADJOINT(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            v2_lambda.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_y,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_acoustic3d_adjoint_step(
+            order, launch_config.grid, launch_config.block,
+            adj_view, vp.data_ptr<float>(),
+            lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z,
+            cpml, ctx);
 
         add_source_3d<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -556,7 +545,7 @@ void run_full_imaging(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_aux();   // fused adjoint: rotate u + psi + zeta double-buffer
 
         accumulate_source_gradient_3d(
             forward_source_config.grid,
@@ -653,9 +642,6 @@ void run_bs_imaging(
     auto f_this = torch::zeros_like(vp);
 
     // Buffer for v^2 * lambda_now; Python-managed via adjoint_workspace[0].
-    auto v2_lambda = !p.adjoint_workspace.empty()
-        ? p.adjoint_workspace[0]
-        : torch::empty_like(vp);
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 3);
@@ -710,28 +696,11 @@ void run_bs_imaging(
         auto adj_view = adjoint.view();
         auto for_view = forward.view();
 
-        compute_v2_lambda_3d<<<launch_config.grid, launch_config.block>>>(
-            vp.data_ptr<float>(),
-            adj_view.u_now,
-            v2_lambda.data_ptr<float>(),
-            nx, ny, nz, B
-        );
-
-        ACOUSTIC3D_ADJOINT(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            v2_lambda.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_y,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_acoustic3d_adjoint_step(
+            order, launch_config.grid, launch_config.block,
+            adj_view, vp.data_ptr<float>(),
+            lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z,
+            cpml, ctx);
 
         add_source_3d<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -742,7 +711,7 @@ void run_bs_imaging(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_aux();   // fused adjoint: rotate u + psi + zeta double-buffer
 
         accumulate_source_gradient_3d(
             fwd_source_config.grid,
@@ -811,28 +780,11 @@ void run_bs_imaging(
     if (p.nt > 0) {
         auto adj_view = adjoint.view();
 
-        compute_v2_lambda_3d<<<launch_config.grid, launch_config.block>>>(
-            vp.data_ptr<float>(),
-            adj_view.u_now,
-            v2_lambda.data_ptr<float>(),
-            nx, ny, nz, B
-        );
-
-        ACOUSTIC3D_ADJOINT(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            v2_lambda.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_y,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_acoustic3d_adjoint_step(
+            order, launch_config.grid, launch_config.block,
+            adj_view, vp.data_ptr<float>(),
+            lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z,
+            cpml, ctx);
 
         add_source_3d<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -843,7 +795,7 @@ void run_bs_imaging(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_aux();   // fused adjoint: rotate u + psi + zeta double-buffer
 
         accumulate_source_gradient_3d(
             fwd_source_config.grid,
@@ -935,9 +887,6 @@ void run_ckpt_imaging(
     auto chunk_forward = torch::zeros({p.checkpoint_interval, B, nz, ny, nx}, vp.options());
 
     // Buffer for v^2 * lambda_now; Python-managed via adjoint_workspace[0].
-    auto v2_lambda = !p.adjoint_workspace.empty()
-        ? p.adjoint_workspace[0]
-        : torch::empty_like(vp);
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 3);
@@ -998,28 +947,11 @@ void run_ckpt_imaging(
         for (int it = end - 1; it >= start; --it) {
             auto adj_view = adjoint.view();
 
-            compute_v2_lambda_3d<<<launch_config.grid, launch_config.block>>>(
-                vp.data_ptr<float>(),
-                adj_view.u_now,
-                v2_lambda.data_ptr<float>(),
-                nx, ny, nz, B
-            );
-
-            ACOUSTIC3D_ADJOINT(
-                order,
-                launch_config.grid,
-                launch_config.block,
-                adj_view,
-                v2_lambda.data_ptr<float>(),
-                vp.data_ptr<float>(),
-                lap_ctx,
-                grad_ctx,
-                grad_ctx_x,
-                grad_ctx_y,
-                grad_ctx_z,
-                cpml,
-                ctx
-            );
+            run_acoustic3d_adjoint_step(
+                order, launch_config.grid, launch_config.block,
+                adj_view, vp.data_ptr<float>(),
+                lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z,
+                cpml, ctx);
 
             add_source_3d<<<adj_source_config.grid, adj_source_config.block>>>(
                 adj_view.u_next,
@@ -1030,7 +962,7 @@ void run_ckpt_imaging(
                 ctx
             );
 
-            adjoint.swap();
+            adjoint.swap_aux();   // fused adjoint: rotate u + psi + zeta double-buffer
 
             accumulate_source_gradient_3d(
                 fwd_source_config.grid,
@@ -1169,10 +1101,7 @@ void run_recursive_imaging(
     for (auto& scratch_state : scratch_states)
         scratch_state.allocate(vp, 3, true);
     auto u_this_scratch = torch::empty_like(vp);
-    // Scratch buffer for v^2 * lambda_now; Python-managed via adjoint_workspace[0].
-    auto v2_lambda_scratch = !p.adjoint_workspace.empty()
-        ? p.adjoint_workspace[0]
-        : torch::empty_like(vp);
+    // Scratch for the exact discrete-adjoint step (prepare/apply).
 
     AcousticWavefieldTensor start_state;
     start_state.allocate(vp, 3, true);
@@ -1216,7 +1145,6 @@ void run_recursive_imaging(
             scratch_states,
             0,
             u_this_scratch,
-            v2_lambda_scratch,
             B,
             nx,
             ny,

--- a/src/sweep/csrc/cuda/equations/acoustic3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/forward.cu
@@ -215,7 +215,7 @@ ForwardOutput forward(const ForwardInput& in)
             ctx
         );
 
-        wavefield.swap();
+        wavefield.swap_pml();   // rotate u AND psi<->psin: race-free psi double-buffer
 
         checkpoint_runtime.save_forward(it, static_cast<int>(nt), wavefield.checkpoint_tensors());
     }

--- a/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cuh
@@ -24,17 +24,19 @@
         else                   acoustic_nopml_3d<-1><<<grid, block>>>(__VA_ARGS__);\
     } while (0)
 
-// Proper adjoint of `L u = v^2 · ∇²u`:  L^* λ = ∇²(v^2 · λ).
-// Same structure as the 2D version.  Non-PML branch uses a pre-computed
-// `v2_lambda` buffer; PML branch keeps the forward formulation (residual
-// error in PML zone but fixes the interior box-anomaly bug).
-#define ACOUSTIC3D_ADJOINT(order, grid, block, ...)                                  \
-    do {                                                                                    \
-        if      ((order) == 2) acoustic_adjoint_kernel_3d<2><<<grid, block>>>(__VA_ARGS__); \
-        else if ((order) == 4) acoustic_adjoint_kernel_3d<4><<<grid, block>>>(__VA_ARGS__); \
-        else if ((order) == 6) acoustic_adjoint_kernel_3d<6><<<grid, block>>>(__VA_ARGS__); \
-        else if ((order) == 8) acoustic_adjoint_kernel_3d<8><<<grid, block>>>(__VA_ARGS__); \
-        else                   acoustic_adjoint_kernel_3d<-1><<<grid, block>>>(__VA_ARGS__);\
+
+
+
+// FUSED exact 3D adjoint: ONE launch, no scratch (recompute g_* inline per tap),
+// writes next psi/zeta to SEPARATE buffers (double-buffer) -> race-free + no
+// 9-field scratch round-trip.  Caller swaps psi/zeta via swap_aux() each step.
+#define ACOUSTIC3D_ADJOINT_FUSED(order, grid, block, ...)                                      \
+    do {                                                                                        \
+        if      ((order) == 2) acoustic_adjoint_fused_3d<2><<<grid, block>>>(__VA_ARGS__);      \
+        else if ((order) == 4) acoustic_adjoint_fused_3d<4><<<grid, block>>>(__VA_ARGS__);      \
+        else if ((order) == 6) acoustic_adjoint_fused_3d<6><<<grid, block>>>(__VA_ARGS__);      \
+        else if ((order) == 8) acoustic_adjoint_fused_3d<8><<<grid, block>>>(__VA_ARGS__);      \
+        else                   acoustic_adjoint_fused_3d<-1><<<grid, block>>>(__VA_ARGS__);     \
     } while (0)
 
 // Pre-pass: clear air cells (above per-(iy,ix) surface row).  Launched
@@ -182,7 +184,7 @@ __global__ void acoustic_forward_kernel_3d(
 
         w_sum += (1.f + bx_) * tmpx + ax_ * f.zetax[idx];
 
-        f.psix[idx]  = bx_ * dudx + ax_ * f.psix[idx];
+        (f.psixn ? f.psixn : f.psix)[idx]  = bx_ * dudx + ax_ * f.psix[idx];
         f.zetax[idx] = bx_ * tmpx + ax_ * f.zetax[idx];
     } else {
         w_sum += lap_x;
@@ -204,7 +206,7 @@ __global__ void acoustic_forward_kernel_3d(
 
         w_sum += (1.f + by_) * tmpy + ay_ * f.zetay[idx];
 
-        f.psiy[idx]  = by_ * dudy + ay_ * f.psiy[idx];
+        (f.psiyn ? f.psiyn : f.psiy)[idx]  = by_ * dudy + ay_ * f.psiy[idx];
         f.zetay[idx] = by_ * tmpy + ay_ * f.zetay[idx];
     } else {
         w_sum += lap_y;
@@ -226,7 +228,7 @@ __global__ void acoustic_forward_kernel_3d(
 
         w_sum += (1.f + bz_) * tmpz + az_ * f.zetaz[idx];
 
-        f.psiz[idx]  = bz_ * dudz + az_ * f.psiz[idx];
+        (f.psizn ? f.psizn : f.psiz)[idx]  = bz_ * dudz + az_ * f.psiz[idx];
         f.zetaz[idx] = bz_ * tmpz + az_ * f.zetaz[idx];
     } else {
         w_sum += lap_z;
@@ -249,171 +251,170 @@ __global__ void acoustic_forward_kernel_3d(
 }
 
 
-// Helper: pre-compute v2_lambda[idx] = vp[idx]^2 * lambda[idx]  for 3D.
-// `static` so each .cu including this header gets its own copy.
-static __global__ void compute_v2_lambda_3d(
-    const float* __restrict__ vp,
-    const float* __restrict__ lambda,
-    float* __restrict__ v2_lambda,
-    int nx, int ny, int nz, int B
-) {
-    int ix = blockIdx.x * blockDim.x + threadIdx.x;
-    int iy = blockIdx.y * blockDim.y + threadIdx.y;
-    int iz_global = blockIdx.z * blockDim.z + threadIdx.z;
-    int b  = iz_global / nz;
-    int iz = iz_global % nz;
-    if (b >= B || ix >= nx || iy >= ny || iz >= nz) return;
-    int spatial_size = nx * ny * nz;
-    int stride_y = nx;
-    int stride_z = nx * ny;
-    int idx = b * spatial_size + iz * stride_z + iy * stride_y + ix;
-    float v = vp[idx];
-    v2_lambda[idx] = v * v * lambda[idx];
-}
 
-// Proper adjoint kernel for the 3D acoustic wave equation.
-// Non-PML branch:  λ_next = 2 λ_now - λ_pre + dt² · ∇²(v² · λ_now)
-// using a pre-computed `v2_lambda` buffer.  PML branch retains forward
-// formulation (acceptable since the PML interior is sponge-zone anyway).
+
+
+
+// ---------------------------------------------------------------------------
+// FUSED exact 3D discrete adjoint — single kernel, NO scratch.  3D twin of the
+// 2D acoustic2nd_adjoint_fused: recompute the per-cell g_* (g_l/g_g/g_q) INLINE
+// at each stencil tap from the current adjoint fields, instead of materialising
+// 9 scratch fields in global memory.  Reads current lambda(u_now)/psi/zeta at
+// idx+neighbours; writes next-step lambda (u_next) and the next-step aux into
+// SEPARATE out-buffers (psi*_out/zeta*_out) -> read-old/write-new, exactly like
+// the forward step, so it is race-free even though aux is read at neighbours.
+// Caller must double-buffer the aux and swap_aux() each step.  Transpose math is
+// identical to acoustic_adjoint_{prepare,apply}_3d (verified): Lx^T=Lx (sym),
+// Dx^T=-Dx (antisym, folded as +np-nm then subtracted).
 template<int Order>
-__global__ void acoustic_adjoint_kernel_3d(
+__global__ void acoustic_adjoint_fused_3d(
     AcousticWavefieldPointer wf,
-    const float* __restrict__ v2_lambda,
     const float* __restrict__ vp,
     LaplaceParam lap_ctx,
-    GradParam grad_ctx,
     GradParam grad_ctx_x,
     GradParam grad_ctx_y,
     GradParam grad_ctx_z,
     AcousticCPMLPointer cpml,
-    SolverContext solver
-)
-{
+    SolverContext solver,
+    float* __restrict__ psix_out,
+    float* __restrict__ psiy_out,
+    float* __restrict__ psiz_out,
+    float* __restrict__ zetax_out,
+    float* __restrict__ zetay_out,
+    float* __restrict__ zetaz_out
+){
     int ix = blockIdx.x * blockDim.x + threadIdx.x;
     int iy = blockIdx.y * blockDim.y + threadIdx.y;
     int iz_global = blockIdx.z * blockDim.z + threadIdx.z;
-
     int b  = iz_global / solver.nz;
     int iz = iz_global % solver.nz;
-
-    if (b >= solver.B || ix >= solver.nx || iy >= solver.ny || iz >= solver.nz)
-        return;
+    if (b >= solver.B || ix >= solver.nx || iy >= solver.ny || iz >= solver.nz) return;
 
     constexpr bool is_runtime = (Order == -1);
-    constexpr int  M_static   = is_runtime ? 0 : (Order / 2);
-
+    constexpr int  M_static  = is_runtime ? 0 : (Order / 2);
     int halo = is_runtime ? solver.M : M_static;
-
     if (ix < halo || ix >= solver.nx - halo ||
         iy < halo || iy >= solver.ny - halo ||
-        iz < halo || iz >= solver.nz - halo)
+        iz < halo || iz >= solver.nz - halo) return;
+    if (solver.has_topo && iz < solver.topo_rows[iy * solver.nx + ix]) return;
+
+    int sy = solver.nx;                       // y-stride
+    int sz = solver.nx * solver.ny;           // z-stride
+    int sp = sz * solver.nz;
+    int idx  = iz * sz + iy * sy + ix;
+    int oidx = b * sp + idx;
+    auto f = wf.offset(b, sp);
+    const float* vpb = vp + b * sp;
+    float dt2 = solver.dt * solver.dt;
+    const float* lc = lap_ctx.coeff;          // [c0(center), c1, ..., cM]
+    const float* gc = grad_ctx_x.coeff;       // antisymmetric grad coeffs
+    float invdx2 = 1.0f / (lap_ctx.dx * lap_ctx.dx);
+    float invdy2 = 1.0f / (lap_ctx.dy * lap_ctx.dy);
+    float invdz2 = 1.0f / (lap_ctx.dz * lap_ctx.dz);
+    float invdx  = 1.0f / lap_ctx.dx;
+    float invdy  = 1.0f / lap_ctx.dy;
+    float invdz  = 1.0f / lap_ctx.dz;
+
+    float gun = f.u_now[idx];
+    float c0c = vpb[idx]; c0c = c0c * c0c * dt2;
+    float gw  = c0c * gun;                     // c * lambda at idx
+
+    #define GW_AT(n) ( vpb[n]*vpb[n]*dt2 * f.u_now[n] )
+
+    // Interior fast-path (aux all 0, g_l*=gw): 2L - L_prev + Lap(gw).
+    int x0 = solver.phys_x0(), x1 = solver.phys_x1();
+    int y0 = solver.phys_y0(), y1 = solver.phys_y1();
+    int z0 = solver.phys_z0(), z1 = solver.phys_z1();
+    bool pure_interior =
+        (ix >= x0 + halo) && (ix < x1 - halo) &&
+        (iy >= y0 + halo) && (iy < y1 - halo) &&
+        (iz >= z0 + halo) && (iz < z1 - halo);
+    if (pure_interior) {
+        float lapx = -lc[0] * gw, lapy = -lc[0] * gw, lapz = -lc[0] * gw;
+        #pragma unroll
+        for (int k = 1; k <= halo; ++k) {
+            lapx += lc[k] * (GW_AT(idx + k)      + GW_AT(idx - k));
+            lapy += lc[k] * (GW_AT(idx + k * sy) + GW_AT(idx - k * sy));
+            lapz += lc[k] * (GW_AT(idx + k * sz) + GW_AT(idx - k * sz));
+        }
+        f.u_next[idx] = 2.0f * gun - f.u_prev[idx]
+                      + lapx * invdx2 + lapy * invdy2 + lapz * invdz2;
+        psix_out[oidx] = psiy_out[oidx] = psiz_out[oidx] = 0.f;
+        zetax_out[oidx] = zetay_out[oidx] = zetaz_out[oidx] = 0.f;
         return;
-
-    int stride_y = solver.nx;
-    int stride_z = solver.nx * solver.ny;
-    int spatial_size = solver.nx * solver.ny * solver.nz;
-
-    int idx = iz * stride_z + iy * stride_y + ix;
-
-    auto f = wf.offset(b, spatial_size);
-
-    if (solver.has_topo && iz < solver.topo_rows[iy * solver.nx + ix]) {
-        return;
     }
 
-    const float* vp_b   = vp        + spatial_size * b;
-    const float* v2l_b  = v2_lambda + spatial_size * b;
+    float ax_ = cpml.ax[ix], ay_ = cpml.ay[iy], az_ = cpml.az[iz];
+    float bx_ = cpml.bx[ix], by_ = cpml.by[iy], bz_ = cpml.bz[iz];
+    float daxdx = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
+    float daydy = gradient<2, Order, X>(cpml.ay, iy, 0, 0, grad_ctx_y);
+    float dazdz = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
 
-    int x0 = solver.phys_x0();
-    int x1 = solver.phys_x1();
-    int y0 = solver.phys_y0();
-    int y1 = solver.phys_y1();
-    int z0 = solver.phys_z0();
-    int z1 = solver.phys_z1();
+    float gtmpx0 = bx_ * f.zetax[idx] + (1.0f + bx_) * gw;
+    float gtmpy0 = by_ * f.zetay[idx] + (1.0f + by_) * gw;
+    float gtmpz0 = bz_ * f.zetaz[idx] + (1.0f + bz_) * gw;
 
-    bool in_pml_x = (ix < x0) || (ix >= x1);
-    bool in_pml_y = (iy < y0) || (iy >= y1);
-    bool in_pml_z = (iz < z0) || (iz >= z1);
+    #define GTMP_X(n, nix) ( cpml.bx[nix]*f.zetax[n] + (1.0f+cpml.bx[nix])*(vpb[n]*vpb[n]*dt2)*f.u_now[n] )
+    #define GTMP_Y(n, niy) ( cpml.by[niy]*f.zetay[n] + (1.0f+cpml.by[niy])*(vpb[n]*vpb[n]*dt2)*f.u_now[n] )
+    #define GTMP_Z(n, niz) ( cpml.bz[niz]*f.zetaz[n] + (1.0f+cpml.bz[niz])*(vpb[n]*vpb[n]*dt2)*f.u_now[n] )
 
-    if (!(in_pml_x || in_pml_y || in_pml_z)) {
-        // Proper adjoint in the non-PML interior:  ∇²(v² · λ_now)
-        float lap_x = laplace<3, Order, X>(v2l_b, ix, iy, iz, lap_ctx);
-        float lap_y = laplace<3, Order, Y>(v2l_b, ix, iy, iz, lap_ctx);
-        float lap_z = laplace<3, Order, Z>(v2l_b, ix, iy, iz, lap_ctx);
-        float dt2 = solver.dt * solver.dt;
-        f.u_next[idx] = 2.f * f.u_now[idx] - f.u_prev[idx] + dt2 * (lap_x + lap_y + lap_z);
-        return;
+    // X-direction
+    float Lx_glx = -lc[0] * ((1.0f + bx_) * gtmpx0);
+    float Dx_ggx = 0.0f, Dx_gqx = 0.0f;
+    #pragma unroll
+    for (int k = 1; k <= halo; ++k) {
+        int np = idx + k, nm = idx - k, nixp = ix + k, nixm = ix - k;
+        float tp = GTMP_X(np, nixp), tm = GTMP_X(nm, nixm);
+        float bxp = cpml.bx[nixp], bxm = cpml.bx[nixm];
+        Lx_glx += lc[k] * ((1.0f + bxp) * tp + (1.0f + bxm) * tm);
+        Dx_ggx += gc[k] * ((bxp * f.psix[np] + cpml.dbxdx[nixp] * tp)
+                         - (bxm * f.psix[nm] + cpml.dbxdx[nixm] * tm));
+        Dx_gqx += gc[k] * (cpml.ax[nixp] * tp - cpml.ax[nixm] * tm);
     }
+    Lx_glx *= invdx2; Dx_ggx *= invdx; Dx_gqx *= invdx;
 
-    // PML branch: retain forward formulation.
-    float lap_x = laplace<3, Order, X>(f.u_now, ix, iy, iz, lap_ctx);
-    float lap_y = laplace<3, Order, Y>(f.u_now, ix, iy, iz, lap_ctx);
-    float lap_z = laplace<3, Order, Z>(f.u_now, ix, iy, iz, lap_ctx);
-
-    float w_sum = 0.f;
-
-    if (in_pml_x) {
-        float dudx = gradient<3, Order, X>(f.u_now, ix, iy, iz, grad_ctx);
-        float dpsixdx = gradient<3, Order, X>(f.psix, ix, iy, iz, grad_ctx);
-        float ax_ = cpml.ax[ix];
-        float bx_ = cpml.bx[ix];
-        float dbxdx_ = cpml.dbxdx[ix];
-        float daxdx = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
-
-        float tmpx = ((1.f + bx_) * lap_x + dbxdx_ * dudx)
-                     + ax_ * dpsixdx + daxdx * f.psix[idx];
-
-        w_sum += (1.f + bx_) * tmpx + ax_ * f.zetax[idx];
-
-        f.psix[idx]  = bx_ * dudx + ax_ * f.psix[idx];
-        f.zetax[idx] = bx_ * tmpx + ax_ * f.zetax[idx];
-    } else {
-        w_sum += lap_x;
+    // Y-direction
+    float Ly_gly = -lc[0] * ((1.0f + by_) * gtmpy0);
+    float Dy_ggy = 0.0f, Dy_gqy = 0.0f;
+    #pragma unroll
+    for (int k = 1; k <= halo; ++k) {
+        int np = idx + k * sy, nm = idx - k * sy, niyp = iy + k, niym = iy - k;
+        float tp = GTMP_Y(np, niyp), tm = GTMP_Y(nm, niym);
+        float byp = cpml.by[niyp], bym = cpml.by[niym];
+        Ly_gly += lc[k] * ((1.0f + byp) * tp + (1.0f + bym) * tm);
+        Dy_ggy += gc[k] * ((byp * f.psiy[np] + cpml.dbydy[niyp] * tp)
+                         - (bym * f.psiy[nm] + cpml.dbydy[niym] * tm));
+        Dy_gqy += gc[k] * (cpml.ay[niyp] * tp - cpml.ay[niym] * tm);
     }
+    Ly_gly *= invdy2; Dy_ggy *= invdy; Dy_gqy *= invdy;
 
-    if (in_pml_y) {
-        float dudy = gradient<3, Order, Y>(f.u_now, ix, iy, iz, grad_ctx);
-        float dpsiydy = gradient<3, Order, Y>(f.psiy, ix, iy, iz, grad_ctx);
-        float ay_ = cpml.ay[iy];
-        float by_ = cpml.by[iy];
-        float dbydy_ = cpml.dbydy[iy];
-        float daydy = gradient<2, Order, X>(cpml.ay, iy, 0, 0, grad_ctx_y);
-
-        float tmpy = ((1.f + by_) * lap_y + dbydy_ * dudy)
-                     + ay_ * dpsiydy + daydy * f.psiy[idx];
-
-        w_sum += (1.f + by_) * tmpy + ay_ * f.zetay[idx];
-
-        f.psiy[idx]  = by_ * dudy + ay_ * f.psiy[idx];
-        f.zetay[idx] = by_ * tmpy + ay_ * f.zetay[idx];
-    } else {
-        w_sum += lap_y;
+    // Z-direction
+    float Lz_glz = -lc[0] * ((1.0f + bz_) * gtmpz0);
+    float Dz_ggz = 0.0f, Dz_gqz = 0.0f;
+    #pragma unroll
+    for (int k = 1; k <= halo; ++k) {
+        int np = idx + k * sz, nm = idx - k * sz, nizp = iz + k, nizm = iz - k;
+        float tp = GTMP_Z(np, nizp), tm = GTMP_Z(nm, nizm);
+        float bzp = cpml.bz[nizp], bzm = cpml.bz[nizm];
+        Lz_glz += lc[k] * ((1.0f + bzp) * tp + (1.0f + bzm) * tm);
+        Dz_ggz += gc[k] * ((bzp * f.psiz[np] + cpml.dbzdz[nizp] * tp)
+                         - (bzm * f.psiz[nm] + cpml.dbzdz[nizm] * tm));
+        Dz_gqz += gc[k] * (cpml.az[nizp] * tp - cpml.az[nizm] * tm);
     }
+    Lz_glz *= invdz2; Dz_ggz *= invdz; Dz_gqz *= invdz;
 
-    if (in_pml_z) {
-        float dudz = gradient<3, Order, Z>(f.u_now, ix, iy, iz, grad_ctx);
-        float dpsizdz = gradient<3, Order, Z>(f.psiz, ix, iy, iz, grad_ctx);
-        float az_ = cpml.az[iz];
-        float bz_ = cpml.bz[iz];
-        float dbzdz_ = cpml.dbzdz[iz];
-        float dazdz = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
-
-        float tmpz = ((1.f + bz_) * lap_z + dbzdz_ * dudz)
-                     + az_ * dpsizdz + dazdz * f.psiz[idx];
-
-        w_sum += (1.f + bz_) * tmpz + az_ * f.zetaz[idx];
-
-        f.psiz[idx]  = bz_ * dudz + az_ * f.psiz[idx];
-        f.zetaz[idx] = bz_ * tmpz + az_ * f.zetaz[idx];
-    } else {
-        w_sum += lap_z;
-    }
-
-    float v  = vp_b[idx];
-    f.u_next[idx] =
-        2.f * f.u_now[idx] -
-        f.u_prev[idx] +
-        (v * v) * solver.dt * solver.dt * w_sum;
+    f.u_next[idx] = 2.0f * gun - f.u_prev[idx]
+                  + (Lx_glx + Ly_gly + Lz_glz - Dx_ggx - Dy_ggy - Dz_ggz);
+    psix_out[oidx]  = ax_ * f.psix[idx] + daxdx * gtmpx0 - Dx_gqx;
+    psiy_out[oidx]  = ay_ * f.psiy[idx] + daydy * gtmpy0 - Dy_gqy;
+    psiz_out[oidx]  = az_ * f.psiz[idx] + dazdz * gtmpz0 - Dz_gqz;
+    zetax_out[oidx] = ax_ * (f.zetax[idx] + gw);
+    zetay_out[oidx] = ay_ * (f.zetay[idx] + gw);
+    zetaz_out[oidx] = az_ * (f.zetaz[idx] + gw);
+    #undef GW_AT
+    #undef GTMP_X
+    #undef GTMP_Y
+    #undef GTMP_Z
 }
 
 

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/backward.cu
@@ -19,6 +19,25 @@ namespace acoustic_lsrtm2d {
 
 namespace {
 
+// Proper transpose adjoint step for the lsrtm scattered field: v2_lambda =
+// vp^2 * lambda_now, then L* = lap(v2_lambda) (interior) / forward CPML (PML).
+// Replaces the old forward-operator adjoint (acoustic2nd = vp^2*lap), which is
+// non-self-adjoint when vp varies (~15% grad[mp] error in variable velocity).
+static inline void run_lsrtm2d_adjoint_step(
+    int order, dim3 grid, dim3 block,
+    AcousticWavefieldPointer adj_view,
+    const torch::Tensor& vp,
+    LaplaceParam lap_ctx, GradParam grad_ctx, GradParam grad_ctx_x, GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml, SolverContext ctx)
+{
+    auto v2_lambda = torch::empty_like(vp);   // vp^2 * lambda_now (fully overwritten each step)
+    compute_v2_lambda_lsrtm2d<<<grid, block>>>(
+        vp.data_ptr<float>(), adj_view.u_now, v2_lambda.data_ptr<float>(), ctx.nx, ctx.nz, ctx.B);
+    ACOUSTIC_LSRTM2D_ADJOINT(order, grid, block,
+        adj_view, v2_lambda.data_ptr<float>(), vp.data_ptr<float>(),
+        lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z, cpml, ctx);
+}
+
 void advance_forward_interval_2d(
     AcousticWavefieldTensor& forward,
     int start,
@@ -138,21 +157,9 @@ void process_recursive_interval_2d(
         forward_step.swap();
 
         auto adj_view = adjoint.view();
-        ACOUSTIC_LSRTM2D_SINGLE(
-            order,
-            wave_grid,
-            wave_block,
-            adj_view,
-            false,
-            nullptr,
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_lsrtm2d_adjoint_step(
+            order, wave_grid, wave_block, adj_view,
+            vp, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z, cpml, ctx);
 
         add_source<<<adj_source_grid, adj_source_block>>>(
             adj_view.u_next,
@@ -300,21 +307,9 @@ void run_full_imaging(const BackwardInput& p, torch::Tensor& grad_mp)
     for (int it = p.nt - 1; it >= 0; --it) {
         auto adj_view = adjoint.view();
 
-        ACOUSTIC_LSRTM2D_SINGLE(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            false,
-            nullptr,
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_lsrtm2d_adjoint_step(
+            order, launch_config.grid, launch_config.block, adj_view,
+            vp, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z, cpml, ctx);
 
         add_source<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -453,21 +448,9 @@ BackwardOutput backward_bs(const BackwardInput& in)
         auto adj_view = adjoint.view();
         auto for_view_iter = forward.view();
 
-        ACOUSTIC_LSRTM2D_SINGLE(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            false,
-            nullptr,
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_lsrtm2d_adjoint_step(
+            order, launch_config.grid, launch_config.block, adj_view,
+            vp, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z, cpml, ctx);
 
         add_source<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -526,21 +509,9 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
     if (p.nt > 0) {
         auto adj_view = adjoint.view();
-        ACOUSTIC_LSRTM2D_SINGLE(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            false,
-            nullptr,
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_lsrtm2d_adjoint_step(
+            order, launch_config.grid, launch_config.block, adj_view,
+            vp, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z, cpml, ctx);
 
         add_source<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -674,21 +645,9 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
         for (int it = end - 1; it >= start; --it) {
             auto adj_view = adjoint.view();
 
-            ACOUSTIC_LSRTM2D_SINGLE(
-                order,
-                launch_config.grid,
-                launch_config.block,
-                adj_view,
-                false,
-                nullptr,
-                vp.data_ptr<float>(),
-                lap_ctx,
-                grad_ctx,
-                grad_ctx_x,
-                grad_ctx_z,
-                cpml,
-                ctx
-            );
+            run_lsrtm2d_adjoint_step(
+                order, launch_config.grid, launch_config.block, adj_view,
+                vp, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z, cpml, ctx);
 
             add_source<<<adj_source_config.grid, adj_source_config.block>>>(
                 adj_view.u_next,

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/forward.cu
@@ -66,9 +66,9 @@ ForwardOutput forward(const ForwardInput& in) {
     AcousticWavefieldTensor bg;
     AcousticWavefieldTensor sc;
     if (!p.wavefields.empty()) {
-        TORCH_CHECK(p.wavefields.size() == 14, "Acoustic LSRTM 2D expects 14 wavefield tensors.");
-        bg.bind(slice_wavefields(p.wavefields, 0, 7), 2, true);
-        sc.bind(slice_wavefields(p.wavefields, 7, 7), 2, true);
+        TORCH_CHECK(p.wavefields.size() == 18, "Acoustic LSRTM 2D expects 18 wavefield tensors (bg+sc, each 9 with psi double-buffer).");
+        bg.bind(slice_wavefields(p.wavefields, 0, 9), 2, true);
+        sc.bind(slice_wavefields(p.wavefields, 9, 9), 2, true);
     } else {
         bg.allocate(vp, 2, true);
         sc.allocate(vp, 2, true);
@@ -197,8 +197,8 @@ ForwardOutput forward(const ForwardInput& in) {
             ctx
         );
 
-        bg.swap();
-        sc.swap();
+        bg.swap_pml();   // rotate u AND psi<->psin: race-free psi double-buffer
+        sc.swap_pml();
 
         checkpoint_runtime.save_forward(it, static_cast<int>(p.nt), bg.checkpoint_tensors());
     }

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/kernels.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/kernels.cu
@@ -24,8 +24,11 @@ __global__ void calculate_grad_lsrtm_mp(
     const float* vp_b = vp + b * spatial_size;
     float* grad_b = grad_mp + b * spatial_size;
 
-    float v = vp_b[idx];
-    grad_b[idx] += (u_tt_b[idx] / (v * v)) * u_backward_b[idx];
+    // grad[mp] = sum_t adjoint_sc * d(sc_next)/d(mp).  Forward couples
+    //   sc_next += dt^2 * mp * bg_utt   (bg_utt = vp^2 * bg_w_sum, == saved u_tt_bg),
+    // so d(sc_next)/d(mp) = dt^2 * bg_utt = dt^2 * u_tt_bg.  (Was u_tt_bg/vp^2, which
+    // dropped dt^2*vp^2 -> grad ~1/(dt^2 vp^2) too small vs eager autograd.)
+    grad_b[idx] += dt * dt * u_tt_b[idx] * u_backward_b[idx];
 }
 
 __global__ void calculate_grad_lsrtm_mp_utt(
@@ -56,7 +59,7 @@ __global__ void calculate_grad_lsrtm_mp_utt(
     const float* vp_b = vp + b * spatial_size;
     float* grad_b = grad_mp + b * spatial_size;
 
+    // u_tt = d^2(bg)/dt^2 = bg_utt (= vp^2 * bg_w_sum); grad[mp] = sum_t u_back * dt^2 * bg_utt.
     float u_tt = (u_now_b[idx] - 2.0f * u_prev_b[idx] + u_next_b[idx]) / (dt * dt);
-    float v = vp_b[idx];
-    grad_b[idx] += (u_tt / (v * v)) * u_backward_b[idx];
+    grad_b[idx] += dt * dt * u_tt * u_backward_b[idx];
 }

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/kernels.cuh
@@ -79,12 +79,12 @@ __device__ inline float acoustic_cpml_update_2d(
 
     float tmpx = ((1.0f + bx_) * lap_x + dbxdx_ * dudx) + daipxix_dx;
     w_sum += (1.0f + bx_) * tmpx + ax_ * f.zetax[idx];
-    f.psix[idx] = bx_ * dudx + ax_ * f.psix[idx];
+    (f.psixn ? f.psixn : f.psix)[idx] = bx_ * dudx + ax_ * f.psix[idx];   // race-free fwd double-buffer
     f.zetax[idx] = bx_ * tmpx + ax_ * f.zetax[idx];
 
     float tmpz = ((1.0f + bz_) * lap_z + dbzdz_ * dudz) + daipsiz_dz;
     w_sum += (1.0f + bz_) * tmpz + az_ * f.zetaz[idx];
-    f.psiz[idx] = bz_ * dudz + az_ * f.psiz[idx];
+    (f.psizn ? f.psizn : f.psiz)[idx] = bz_ * dudz + az_ * f.psiz[idx];   // race-free fwd double-buffer
     f.zetaz[idx] = bz_ * tmpz + az_ * f.zetaz[idx];
 
     return w_sum;

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/kernels.cuh
@@ -35,6 +35,16 @@
         else                   acoustic_lsrtm2nd<-1><<<grid, block>>>(__VA_ARGS__); \
     } while (0)
 
+// Proper-adjoint (transpose) of the scattered-field propagation: L* = lap(v^2.l).
+#define ACOUSTIC_LSRTM2D_ADJOINT(order, grid, block, ...)                                 \
+    do {                                                                                   \
+        if      ((order) == 2) acoustic_lsrtm2nd_adjoint<2><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 4) acoustic_lsrtm2nd_adjoint<4><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 6) acoustic_lsrtm2nd_adjoint<6><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 8) acoustic_lsrtm2nd_adjoint<8><<<grid, block>>>(__VA_ARGS__); \
+        else                   acoustic_lsrtm2nd_adjoint<-1><<<grid, block>>>(__VA_ARGS__); \
+    } while (0)
+
 template <int Order>
 __device__ inline float acoustic_cpml_update_2d(
     AcousticWavefieldPointer f,
@@ -161,6 +171,77 @@ __global__ void acoustic2nd_nopml(
     float w_sum = lap_x + lap_z;
     float v = vp_b[idx];
     f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + solver.dt * solver.dt * (v * v) * w_sum;
+}
+
+// v2_lambda = vp^2 * lambda  (per-cell, race-free pre-pass for the L* adjoint).
+static __global__ void compute_v2_lambda_lsrtm2d(
+    const float* __restrict__ vp,
+    const float* __restrict__ lambda,
+    float* __restrict__ v2_lambda,
+    int nx, int nz, int B
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iz = blockIdx.y * blockDim.y + threadIdx.y;
+    int b  = blockIdx.z;
+    if (ix >= nx || iz >= nz || b >= B) return;
+    int sp = nx * nz; int idx = b * sp + iz * nx + ix;
+    float v = vp[idx];
+    v2_lambda[idx] = v * v * lambda[idx];
+}
+
+// Proper adjoint (transpose) of the lsrtm scattered-field propagation:
+//   lambda_next = 2 lambda_now - lambda_pre + dt^2 * lap(v^2 * lambda_now)
+// in the non-PML interior -- the transpose of the forward  v^2 * lap(lambda)
+// (vp^2 * laplacian is non-self-adjoint when vp varies).  The PML band keeps
+// the forward CPML formulation (reusing acoustic_cpml_update_2d); the dominant
+// non-self-adjoint error is in the variable-velocity interior.  Mirrors the
+// acoustic2d fix (5188031).  Requires v2_lambda = vp^2*lambda_now pre-computed.
+template <int Order>
+__global__ void acoustic_lsrtm2nd_adjoint(
+    AcousticWavefieldPointer wf,
+    const float* __restrict__ v2_lambda,
+    const float* __restrict__ vp,
+    LaplaceParam lap_ctx,
+    GradParam grad_ctx,
+    GradParam grad_ctx_x,
+    GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml,
+    SolverContext solver
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iz = blockIdx.y * blockDim.y + threadIdx.y;
+    int b = blockIdx.z;
+    if (ix >= solver.nx || iz >= solver.nz) return;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int M_static = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : M_static;
+    if (ix < halo || ix >= solver.nx - halo || iz < halo || iz >= solver.nz - halo)
+        return;
+
+    int spatial_size = solver.nx * solver.nz;
+    int idx = iz * solver.nx + ix;
+    auto f = wf.offset(b, spatial_size);
+    const float* vp_b = vp + b * spatial_size;
+    const float* v2l_b = v2_lambda + b * spatial_size;
+    float dt2 = solver.dt * solver.dt;
+
+    bool in_pml = (ix < solver.abcn + halo) || (ix >= solver.nx - solver.abcn - halo) ||
+                  (iz < (solver.free_surface ? halo : solver.abcn + halo)) ||
+                  (iz >= solver.nz - solver.abcn - halo);
+
+    if (!in_pml) {
+        // L* = lap(v^2 . lambda)  (transpose of forward v^2 . lap(lambda))
+        float lap_x = laplace<2, Order, X>(v2l_b, ix, 0, iz, lap_ctx);
+        float lap_z = laplace<2, Order, Z>(v2l_b, ix, 0, iz, lap_ctx);
+        f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + dt2 * (lap_x + lap_z);
+        return;
+    }
+
+    // PML band: keep the forward CPML formulation (shared lsrtm update).
+    float w_sum = acoustic_cpml_update_2d<Order>(f, ix, iz, idx, cpml, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z, solver, halo);
+    float v = vp_b[idx];
+    f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + (v * v) * dt2 * w_sum;
 }
 
 template <int Order>

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/backward.cu
@@ -99,7 +99,8 @@ void accumulate_imaging_3d(
     int B,
     int nx,
     int ny,
-    int nz
+    int nz,
+    float dt
 )
 {
     if (grad != nullptr) {
@@ -108,7 +109,7 @@ void accumulate_imaging_3d(
             adjoint_ptr,
             vp.data_ptr<float>(),
             grad->data_ptr<float>(),
-            B, nx, ny, nz
+            B, nx, ny, nz, dt
         );
         return;
     }
@@ -349,7 +350,7 @@ void process_recursive_interval_3d(
                 adjoint.u_now_t.data_ptr<float>(),
                 vp.data_ptr<float>(),
                 grad->data_ptr<float>(),
-                B, nx, ny, nz
+                B, nx, ny, nz, p.dt
             );
         } else {
             TORCH_CHECK(rtm_out != nullptr, "Recursive RTM accumulation requested without RTM output.");
@@ -562,7 +563,8 @@ void run_full_imaging(
             B,
             nx,
             ny,
-            nz
+            nz,
+            ctx.dt
         );
     }
 }
@@ -998,7 +1000,8 @@ void run_ckpt_imaging(
                 B,
                 nx,
                 ny,
-                nz
+                nz,
+                ctx.dt
             );
         }
     }

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/backward.cu
@@ -17,6 +17,25 @@ namespace acoustic_lsrtm3d {
 
 namespace {
 
+// Proper transpose adjoint step for the lsrtm 3D scattered field: v2_lambda =
+// vp^2 * lambda_now, then L* = lap(v2_lambda) (interior) / forward CPML (PML).
+// Replaces the old forward-operator adjoint (acoustic3d_single = vp^2*lap),
+// non-self-adjoint when vp varies (~15% grad[mp] error in variable velocity).
+static inline void run_lsrtm3d_adjoint_step(
+    int order, dim3 grid, dim3 block,
+    AcousticWavefieldPointer adj_view,
+    const torch::Tensor& vp,
+    LaplaceParam lap_ctx, GradParam grad_ctx, GradParam grad_ctx_x, GradParam grad_ctx_y, GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml, SolverContext ctx)
+{
+    auto v2_lambda = torch::empty_like(vp);   // vp^2 * lambda_now (fully overwritten each step)
+    compute_v2_lambda_lsrtm3d<<<grid, block>>>(
+        vp.data_ptr<float>(), adj_view.u_now, v2_lambda.data_ptr<float>(), ctx.nx, ctx.ny, ctx.nz, ctx.B);
+    ACOUSTIC_LSRTM3D_ADJOINT(order, grid, block,
+        adj_view, v2_lambda.data_ptr<float>(), vp.data_ptr<float>(),
+        lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z, cpml, ctx);
+}
+
 std::vector<torch::Tensor> slice_wavefields(
     const std::vector<torch::Tensor>& tensors,
     size_t start,
@@ -305,22 +324,9 @@ void process_recursive_interval_3d(
 
         auto adj_view = adjoint.view();
 
-        ACOUSTIC_LSRTM3D_SINGLE(
-            order,
-            wave_grid,
-            wave_block,
-            adj_view,
-            false,
-            nullptr,
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_y,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_lsrtm3d_adjoint_step(
+            order, wave_grid, wave_block, adj_view,
+            vp, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z, cpml, ctx);
 
         add_source_3d<<<adj_source_grid, adj_source_block>>>(
             adj_view.u_next,
@@ -513,22 +519,9 @@ void run_full_imaging(
     for (int it = p.nt - 1; it >= 0; --it) {
         auto adj_view = adjoint.view();
 
-        ACOUSTIC_LSRTM3D_SINGLE(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            false,
-            u_thist,
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_y,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_lsrtm3d_adjoint_step(
+            order, launch_config.grid, launch_config.block, adj_view,
+            vp, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z, cpml, ctx);
 
         add_source_3d<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -684,22 +677,9 @@ void run_bs_imaging(
         auto adj_view = adjoint.view();
         auto for_view = forward.view();
 
-        ACOUSTIC_LSRTM3D_SINGLE(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            false,
-            nullptr,
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_y,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_lsrtm3d_adjoint_step(
+            order, launch_config.grid, launch_config.block, adj_view,
+            vp, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z, cpml, ctx);
 
         add_source_3d<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -778,22 +758,9 @@ void run_bs_imaging(
     if (p.nt > 0) {
         auto adj_view = adjoint.view();
 
-        ACOUSTIC_LSRTM3D_SINGLE(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            false,
-            nullptr,
-            vp.data_ptr<float>(),
-            lap_ctx,
-            grad_ctx,
-            grad_ctx_x,
-            grad_ctx_y,
-            grad_ctx_z,
-            cpml,
-            ctx
-        );
+        run_lsrtm3d_adjoint_step(
+            order, launch_config.grid, launch_config.block, adj_view,
+            vp, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z, cpml, ctx);
 
         add_source_3d<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -950,22 +917,9 @@ void run_ckpt_imaging(
         for (int it = end - 1; it >= start; --it) {
             auto adj_view = adjoint.view();
 
-            ACOUSTIC_LSRTM3D_SINGLE(
-                order,
-                launch_config.grid,
-                launch_config.block,
-                adj_view,
-                false,
-                nullptr,
-                vp.data_ptr<float>(),
-                lap_ctx,
-                grad_ctx,
-                grad_ctx_x,
-                grad_ctx_y,
-                grad_ctx_z,
-                cpml,
-                ctx
-            );
+            run_lsrtm3d_adjoint_step(
+                order, launch_config.grid, launch_config.block, adj_view,
+                vp, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z, cpml, ctx);
 
             add_source_3d<<<adj_source_config.grid, adj_source_config.block>>>(
                 adj_view.u_next,

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/forward.cu
@@ -67,9 +67,9 @@ ForwardOutput forward(const ForwardInput& in) {
     AcousticWavefieldTensor bg;
     AcousticWavefieldTensor sc;
     if (!p.wavefields.empty()) {
-        TORCH_CHECK(p.wavefields.size() == 18, "Acoustic LSRTM 3D expects 18 wavefield tensors.");
-        bg.bind(slice_wavefields(p.wavefields, 0, 9), 3, true);
-        sc.bind(slice_wavefields(p.wavefields, 9, 9), 3, true);
+        TORCH_CHECK(p.wavefields.size() == 24, "Acoustic LSRTM 3D expects 24 wavefield tensors (bg+sc, each 12 with psi double-buffer).");
+        bg.bind(slice_wavefields(p.wavefields, 0, 12), 3, true);
+        sc.bind(slice_wavefields(p.wavefields, 12, 12), 3, true);
     } else {
         bg.allocate(vp, 3, true);
         sc.allocate(vp, 3, true);
@@ -201,8 +201,8 @@ ForwardOutput forward(const ForwardInput& in) {
             ctx
         );
 
-        bg.swap();
-        sc.swap();
+        bg.swap_pml();   // rotate u AND psi<->psin: race-free psi double-buffer
+        sc.swap_pml();
 
         checkpoint_runtime.save_forward(it, static_cast<int>(p.nt), bg.checkpoint_tensors());
     }

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/kernels.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/kernels.cu
@@ -8,7 +8,8 @@ __global__ void calculate_grad_lsrtm3d_mp(
     int B,
     int nx,
     int ny,
-    int nz
+    int nz,
+    float dt
 ) {
     int ix = blockIdx.x * blockDim.x + threadIdx.x;
     int iy = blockIdx.y * blockDim.y + threadIdx.y;
@@ -30,8 +31,10 @@ __global__ void calculate_grad_lsrtm3d_mp(
     const float* vp_b = vp + b * spatial_size;
     float* grad_b = grad_mp + b * spatial_size;
 
-    float v = vp_b[idx];
-    grad_b[idx] += (u_tt_b[idx] / (v * v)) * u_backward_b[idx];
+    // grad[mp] = sum_t adjoint_sc * d(sc_next)/d(mp) = sum_t u_back * dt^2 * bg_utt,
+    // where saved u_tt_bg == bg_utt (= vp^2 * bg_w_sum).  (Was u_tt_bg/vp^2, dropping
+    // dt^2*vp^2 -> grad ~1/(dt^2 vp^2) too small vs eager autograd.)
+    grad_b[idx] += dt * dt * u_tt_b[idx] * u_backward_b[idx];
 }
 
 __global__ void calculate_grad_lsrtm3d_mp_utt(
@@ -69,7 +72,7 @@ __global__ void calculate_grad_lsrtm3d_mp_utt(
     const float* vp_b = vp + b * spatial_size;
     float* grad_b = grad_mp + b * spatial_size;
 
+    // u_tt = d^2(bg)/dt^2 = bg_utt (= vp^2 * bg_w_sum); grad[mp] = sum_t u_back * dt^2 * bg_utt.
     float u_tt = (u_now_b[idx] - 2.0f * u_prev_b[idx] + u_next_b[idx]) / (dt * dt);
-    float v = vp_b[idx];
-    grad_b[idx] += (u_tt / (v * v)) * u_backward_b[idx];
+    grad_b[idx] += dt * dt * u_tt * u_backward_b[idx];
 }

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/kernels.cuh
@@ -271,7 +271,8 @@ __global__ void calculate_grad_lsrtm3d_mp(
     int B,
     int nx,
     int ny,
-    int nz
+    int nz,
+    float dt
 );
 
 __global__ void calculate_grad_lsrtm3d_mp_utt(

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/kernels.cuh
@@ -35,6 +35,16 @@
         else                   acoustic_lsrtm3d_coupled<-1><<<grid, block>>>(__VA_ARGS__); \
     } while (0)
 
+// Proper-adjoint (transpose) of the scattered-field propagation: L* = lap(v^2.l).
+#define ACOUSTIC_LSRTM3D_ADJOINT(order, grid, block, ...)                                  \
+    do {                                                                                    \
+        if      ((order) == 2) acoustic_lsrtm3d_adjoint<2><<<grid, block>>>(__VA_ARGS__);   \
+        else if ((order) == 4) acoustic_lsrtm3d_adjoint<4><<<grid, block>>>(__VA_ARGS__);   \
+        else if ((order) == 6) acoustic_lsrtm3d_adjoint<6><<<grid, block>>>(__VA_ARGS__);   \
+        else if ((order) == 8) acoustic_lsrtm3d_adjoint<8><<<grid, block>>>(__VA_ARGS__);   \
+        else                   acoustic_lsrtm3d_adjoint<-1><<<grid, block>>>(__VA_ARGS__);  \
+    } while (0)
+
 template <int Order>
 __device__ inline float acoustic_cpml_update_3d(
     AcousticWavefieldPointer f,
@@ -201,6 +211,83 @@ __global__ void acoustic3d_single_nopml(
     if (u_this_b != nullptr) {
         u_this_b[idx] = utt;
     }
+}
+
+// v2_lambda = vp^2 * lambda  (per-cell, race-free pre-pass for the L* adjoint).
+static __global__ void compute_v2_lambda_lsrtm3d(
+    const float* __restrict__ vp,
+    const float* __restrict__ lambda,
+    float* __restrict__ v2_lambda,
+    int nx, int ny, int nz, int B
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iy = blockIdx.y * blockDim.y + threadIdx.y;
+    int iz_global = blockIdx.z * blockDim.z + threadIdx.z;
+    int b = iz_global / nz; int iz = iz_global % nz;
+    if (b >= B || ix >= nx || iy >= ny || iz >= nz) return;
+    int sp = nx * ny * nz; int idx = b * sp + iz * (nx * ny) + iy * nx + ix;
+    float v = vp[idx];
+    v2_lambda[idx] = v * v * lambda[idx];
+}
+
+// Proper adjoint (transpose) of the lsrtm 3D scattered-field propagation:
+//   lambda_next = 2 lambda_now - lambda_pre + dt^2 * lap(v^2 * lambda_now)
+// in the non-PML interior -- transpose of forward v^2*lap(lambda) (non-self-
+// adjoint when vp varies).  PML band keeps forward CPML (acoustic_cpml_update_3d).
+// Mirrors the acoustic2d fix (5188031).  Requires v2_lambda = vp^2*lambda_now.
+template <int Order>
+__global__ void acoustic_lsrtm3d_adjoint(
+    AcousticWavefieldPointer wf,
+    const float* __restrict__ v2_lambda,
+    const float* __restrict__ vp,
+    LaplaceParam lap_ctx,
+    GradParam grad_ctx,
+    GradParam grad_ctx_x,
+    GradParam grad_ctx_y,
+    GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml,
+    SolverContext solver
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iy = blockIdx.y * blockDim.y + threadIdx.y;
+    int iz_global = blockIdx.z * blockDim.z + threadIdx.z;
+    int b = iz_global / solver.nz; int iz = iz_global % solver.nz;
+    if (b >= solver.B || ix >= solver.nx || iy >= solver.ny || iz >= solver.nz) return;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int M_static = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : M_static;
+    if (ix < halo || ix >= solver.nx - halo || iy < halo || iy >= solver.ny - halo ||
+        iz < halo || iz >= solver.nz - halo)
+        return;
+
+    int stride_z = solver.nx * solver.ny;
+    int spatial_size = stride_z * solver.nz;
+    int idx = iz * stride_z + iy * solver.nx + ix;
+    auto f = wf.offset(b, spatial_size);
+    const float* vp_b = vp + b * spatial_size;
+    const float* v2l_b = v2_lambda + b * spatial_size;
+    float dt2 = solver.dt * solver.dt;
+
+    bool in_pml = (ix < solver.abcn + halo) || (ix >= solver.nx - solver.abcn - halo) ||
+                  (iy < solver.abcn + halo) || (iy >= solver.ny - solver.abcn - halo) ||
+                  (iz < (solver.free_surface ? halo : solver.abcn + halo)) ||
+                  (iz >= solver.nz - solver.abcn - halo);
+
+    if (!in_pml) {
+        // L* = lap(v^2 . lambda)  (transpose of forward v^2 . lap(lambda))
+        float lap_x = laplace<3, Order, X>(v2l_b, ix, iy, iz, lap_ctx);
+        float lap_y = laplace<3, Order, Y>(v2l_b, ix, iy, iz, lap_ctx);
+        float lap_z = laplace<3, Order, Z>(v2l_b, ix, iy, iz, lap_ctx);
+        f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + dt2 * (lap_x + lap_y + lap_z);
+        return;
+    }
+
+    // PML band: keep the forward CPML formulation (shared lsrtm update).
+    float w_sum = acoustic_cpml_update_3d<Order>(
+        f, ix, iy, iz, idx, cpml, lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z, true, solver, halo);
+    float v = vp_b[idx];
+    f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + (v * v) * dt2 * w_sum;
 }
 
 template <int Order>

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/kernels.cuh
@@ -95,17 +95,17 @@ __device__ inline float acoustic_cpml_update_3d(
 
     float tmpx = ((1.0f + bx_) * lap_x + dbxdx_ * dudx) + ax_ * dpsixdx + daxdx * f.psix[idx];
     w_sum += (1.0f + bx_) * tmpx + ax_ * f.zetax[idx];
-    f.psix[idx] = bx_ * dudx + ax_ * f.psix[idx];
+    (f.psixn ? f.psixn : f.psix)[idx] = bx_ * dudx + ax_ * f.psix[idx];   // race-free fwd double-buffer
     f.zetax[idx] = bx_ * tmpx + ax_ * f.zetax[idx];
 
     float tmpy = ((1.0f + by_) * lap_y + dbydy_ * dudy) + ay_ * dpsiydy + daydy * f.psiy[idx];
     w_sum += (1.0f + by_) * tmpy + ay_ * f.zetay[idx];
-    f.psiy[idx] = by_ * dudy + ay_ * f.psiy[idx];
+    (f.psiyn ? f.psiyn : f.psiy)[idx] = by_ * dudy + ay_ * f.psiy[idx];   // race-free fwd double-buffer
     f.zetay[idx] = by_ * tmpy + ay_ * f.zetay[idx];
 
     float tmpz = ((1.0f + bz_) * lap_z + dbzdz_ * dudz) + az_ * dpsizdz + dazdz * f.psiz[idx];
     w_sum += (1.0f + bz_) * tmpz + az_ * f.zetaz[idx];
-    f.psiz[idx] = bz_ * dudz + az_ * f.psiz[idx];
+    (f.psizn ? f.psizn : f.psiz)[idx] = bz_ * dudz + az_ * f.psiz[idx];   // race-free fwd double-buffer
     f.zetaz[idx] = bz_ * tmpz + az_ * f.zetaz[idx];
 
     return w_sum;

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/forward.cu
@@ -171,7 +171,7 @@ ForwardOutput forward(const ForwardInput& in) {
             ctx
         );
 
-        wavefield.swap();
+        wavefield.swap_pml();   // rotate u AND psi<->psin: race-free psi double-buffer
 
         if (u_allt.defined()) {
             u_allt.select(0, it).select(0, 0).copy_(wavefield.u_now_t);

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/kernels.cuh
@@ -365,8 +365,8 @@ __global__ void acoustic_vrz2nd(
 
     float rhs = kappa * (beta * w_sum + dbdx * px + dbdz * pz);
 
-    f.psix[idx] = psixn;
-    f.psiz[idx] = psizn;
+    (f.psixn ? f.psixn : f.psix)[idx] = psixn;   // race-free forward psi double-buffer
+    (f.psizn ? f.psizn : f.psiz)[idx] = psizn;
     f.zetax[idx] = zetaxn;
     f.zetaz[idx] = zetazn;
 

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/forward.cu
@@ -174,7 +174,7 @@ ForwardOutput forward(const ForwardInput& in)
             ctx
         );
 
-        wavefield.swap();
+        wavefield.swap_pml();   // rotate u AND psi<->psin: race-free psi double-buffer
 
         if (u_allt.defined()) {
             u_allt.select(0, it).select(0, 0).copy_(wavefield.u_now_t.squeeze(1));

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/kernels.cuh
@@ -412,9 +412,9 @@ __global__ void acoustic_vrz3nd(
 
     float rhs = kappa * (beta * w_sum + dbdx * px + dbdy * py + dbdz * pz);
 
-    f.psix[idx] = psixn;
-    f.psiy[idx] = psiyn;
-    f.psiz[idx] = psizn;
+    (f.psixn ? f.psixn : f.psix)[idx] = psixn;   // race-free forward psi double-buffer
+    (f.psiyn ? f.psiyn : f.psiy)[idx] = psiyn;
+    (f.psizn ? f.psizn : f.psiz)[idx] = psizn;
     f.zetax[idx] = zetaxn;
     f.zetay[idx] = zetayn;
     f.zetaz[idx] = zetazn;

--- a/src/sweep/equations/acoustic.py
+++ b/src/sweep/equations/acoustic.py
@@ -151,7 +151,15 @@ class Acoustic(SecondOrderEquation):
     def cuda_layout(self):
         return CUDALayoutSpec(
             base_nvar=3,
-            pml_nvar=4,
+            # psix, psiz, zetax, zetaz (4) + psixn, psizn (2) for the race-free
+            # forward psi double-buffer: the forward reads psi at neighbours then
+            # writes the next psi to a SEPARATE buffer (no in-place RAW race).
+            # bind() detects the larger count (3 u + 6 pml = 9) and swap_pml()
+            # rotates psix<->psixn each step.
+            pml_nvar=6,
+            # Fused single-kernel adjoint also double-buffers zeta: the ADJOINT
+            # wavefield gets +2 (zetaxn, zetazn) -> 11 tensors; forward stays 9.
+            adjoint_extra_nvar=2,
             last_two_nvar=2,
             last_two_storage_nvar=1,
             checkpoint_nvar=6,

--- a/src/sweep/equations/acoustic3d.py
+++ b/src/sweep/equations/acoustic3d.py
@@ -154,7 +154,12 @@ class Acoustic3D(SecondOrderEquation):
     def cuda_layout(self):
         return CUDALayoutSpec(
             base_nvar=3,
-            pml_nvar=6,
+            # psix,psiy,psiz,zetax,zetay,zetaz (6) + psixn,psiyn,psizn (3) for the
+            # race-free forward psi double-buffer (read psi, write psi*n, swap_pml).
+            pml_nvar=9,
+            # Fused single-kernel adjoint also double-buffers zeta: the ADJOINT
+            # wavefield gets +3 (zetaxn, zetayn, zetazn) -> 15 tensors; fwd stays 12.
+            adjoint_extra_nvar=3,
             last_two_nvar=2,
             last_two_storage_nvar=1,
             checkpoint_nvar=8,

--- a/src/sweep/equations/acoustic_lsrtm.py
+++ b/src/sweep/equations/acoustic_lsrtm.py
@@ -164,7 +164,9 @@ class AcousticLSRTM(SecondOrderEquation):
     def cuda_layout(self):
         return CUDALayoutSpec(
             base_nvar=6,
-            pml_nvar=8,
+            # 2 wavefields (bg+sc); each: psix,psiz,zetax,zetaz (4) + psixn,psizn (2)
+            # for the race-free forward psi double-buffer -> 2*(4+2)=12.
+            pml_nvar=12,
             last_two_nvar=2,
             last_two_storage_nvar=1,
             checkpoint_nvar=6,

--- a/src/sweep/equations/acoustic_lsrtm3d.py
+++ b/src/sweep/equations/acoustic_lsrtm3d.py
@@ -220,7 +220,9 @@ class AcousticLSRTM3D(SecondOrderEquation):
     def cuda_layout(self):
         return CUDALayoutSpec(
             base_nvar=6,
-            pml_nvar=12,
+            # 2 wavefields (bg+sc); each: psix,psiy,psiz,zetax,zetay,zetaz (6) +
+            # psixn,psiyn,psizn (3) for the race-free forward double-buffer -> 2*9=18.
+            pml_nvar=18,
             last_two_nvar=2,
             last_two_storage_nvar=1,
             checkpoint_nvar=8,

--- a/src/sweep/equations/acoustic_vrz.py
+++ b/src/sweep/equations/acoustic_vrz.py
@@ -235,7 +235,9 @@ class AcousticVRZ(SecondOrderEquation):
     def cuda_layout(self):
         return CUDALayoutSpec(
             base_nvar=3,
-            pml_nvar=4,
+            # psix,psiz,zetax,zetaz (4) + psixn,psizn (2): race-free forward psi
+            # double-buffer (read psi, write psi*n, swap_pml).
+            pml_nvar=6,
             last_two_nvar=2,
             last_two_storage_nvar=1,
             checkpoint_nvar=6,
@@ -352,7 +354,9 @@ class AcousticVRZ3D(SecondOrderEquation):
     def cuda_layout(self):
         return CUDALayoutSpec(
             base_nvar=3,
-            pml_nvar=6,
+            # psix,psiy,psiz,zetax,zetay,zetaz (6) + psixn,psiyn,psizn (3): race-free
+            # forward psi double-buffer (read psi, write psi*n, swap_pml).
+            pml_nvar=9,
             last_two_nvar=2,
             last_two_storage_nvar=1,
             checkpoint_nvar=8,

--- a/src/sweep/equations/cuda_layout.py
+++ b/src/sweep/equations/cuda_layout.py
@@ -15,6 +15,11 @@ class CUDALayoutSpec:
     checkpoint_nvar: int | None = None
     backward_workspace_nvar: int = 0
     backward_workspace_shapes: Callable | None = None
+    # Extra wavefield buffers allocated for the ADJOINT only (not the forward).
+    # The fused single-kernel adjoint double-buffers zeta (the forward already
+    # double-buffers psi via pml_nvar): adjoint gets base+pml+adjoint_extra
+    # tensors, forward stays base+pml.  0 = equation has no fused-adjoint path.
+    adjoint_extra_nvar: int = 0
     boundary_tangent_pad: int = 0
     boundary_save_nvar: int | None = None
 

--- a/src/sweep/propagator/_c.py
+++ b/src/sweep/propagator/_c.py
@@ -915,6 +915,10 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         cuda_layout = self._cuda_layout()
         total_wavefields = cuda_layout.base_nvar + cuda_layout.pml_nvar
         wavefield_shapes = total_wavefields * [[self.B, 1, *self.shape_cuda]]
+        # The adjoint may need extra double-buffer tensors (fused single-kernel
+        # adjoint double-buffers zeta); the forward never does.
+        adjoint_wavefields_n = total_wavefields + int(getattr(cuda_layout, "adjoint_extra_nvar", 0))
+        adjoint_wavefield_shapes = adjoint_wavefields_n * [[self.B, 1, *self.shape_cuda]]
         if batch_size > (current_capacity or 0):
             self.forward_allocator = Allocator(self.dev)
             self.adjoint_allocator = Allocator(self.dev)
@@ -924,7 +928,7 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         if need_forward and not self.forward_wavefields:
             self.forward_wavefields = self.forward_allocator.zeros(wavefield_shapes)
         if need_adjoint and not self.adjoint_wavefields:
-            self.adjoint_wavefields = self.adjoint_allocator.zeros(wavefield_shapes)
+            self.adjoint_wavefields = self.adjoint_allocator.zeros(adjoint_wavefield_shapes)
         self._buffer_capacity_batch = target_capacity
         self._boundary_cache_batch = None
         self._boundary_cache_ring_buffers = None


### PR DESCRIPTION
Aligns `impl='c'` FWI gradients with the eager reference across the acoustic family.

## What
- **Race-free CPML forward** (psi double-buffer) on all 6 acoustic-family equations (acoustic 2D/3D, VRZ 2D/3D, LSRTM 2D/3D) — fixes 3D run-to-run non-determinism (a real bug in 3D, benign in 2D).
- **Fused single-kernel exact adjoint** for acoustic2d/3d, replacing the old PML forward-copy adjoint with the exact discrete transpose; backward cost 2× → ~1.2×.
- **LSRTM `grad[mp]`**: scale fix (was `/vp²`, now `dt²·vp²`) + L\* transpose adjoint (`∇²(v²·λ)`) for the non-self-adjoint operator.
- Net **−793 lines** of dead prepare/apply scaffolding the fused kernel superseded.

## Verification
- **Gradient suite 54/54** (`solver_gradient_mode_suite`): acoustic & lsrtm `cos=1.0` across interior / fd_edge / free_surface × full / bs_gpu / ckpt; vrz also clean (inherits the PR #21 adjoint).
- **eager↔c FWI fork eliminated** — `19_fwi_boundary_dtype` (Marmousi): `eager·gpu·fp32` and `c·gpu·fp32` converge identically (loss 3.117e-3 vs 3.118e-3, rmse 304.1).
- **Elastic / DAS CUDA unaffected** (source untouched; elastic2d/3d gradient 8/8 pass).
- Race audit: only the 6 acoustic-family eqs were exposed; the others never neighbour-read their CPML memory variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
