### PR TITLE
fix(lsrtm2d): rename acoustic2nd -> acoustic2d_single

### DIFF
--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/backward.cu
@@ -21,7 +21,7 @@ namespace {
 
 // Proper transpose adjoint step for the lsrtm scattered field: v2_lambda =
 // vp^2 * lambda_now, then L* = lap(v2_lambda) (interior) / forward CPML (PML).
-// Replaces the old forward-operator adjoint (acoustic2nd = vp^2*lap), which is
+// Replaces the old forward-operator adjoint (acoustic2d_single = vp^2*lap), which is
 // non-self-adjoint when vp varies (~15% grad[mp] error in variable velocity).
 static inline void run_lsrtm2d_adjoint_step(
     int order, dim3 grid, dim3 block,

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/kernels.cuh
@@ -10,20 +10,20 @@
 
 #define ACOUSTIC_LSRTM2D_SINGLE(order, grid, block, ...)                         \
     do {                                                                         \
-        if      ((order) == 2) acoustic2nd<2><<<grid, block>>>(__VA_ARGS__);    \
-        else if ((order) == 4) acoustic2nd<4><<<grid, block>>>(__VA_ARGS__);    \
-        else if ((order) == 6) acoustic2nd<6><<<grid, block>>>(__VA_ARGS__);    \
-        else if ((order) == 8) acoustic2nd<8><<<grid, block>>>(__VA_ARGS__);    \
-        else                   acoustic2nd<-1><<<grid, block>>>(__VA_ARGS__);   \
+        if      ((order) == 2) acoustic2d_single<2><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 4) acoustic2d_single<4><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 6) acoustic2d_single<6><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 8) acoustic2d_single<8><<<grid, block>>>(__VA_ARGS__);    \
+        else                   acoustic2d_single<-1><<<grid, block>>>(__VA_ARGS__);   \
     } while (0)
 
 #define ACOUSTIC_LSRTM2D_SINGLE_NOPML(order, grid, block, ...)                   \
     do {                                                                         \
-        if      ((order) == 2) acoustic2nd_nopml<2><<<grid, block>>>(__VA_ARGS__); \
-        else if ((order) == 4) acoustic2nd_nopml<4><<<grid, block>>>(__VA_ARGS__); \
-        else if ((order) == 6) acoustic2nd_nopml<6><<<grid, block>>>(__VA_ARGS__); \
-        else if ((order) == 8) acoustic2nd_nopml<8><<<grid, block>>>(__VA_ARGS__); \
-        else                   acoustic2nd_nopml<-1><<<grid, block>>>(__VA_ARGS__); \
+        if      ((order) == 2) acoustic2d_single_nopml<2><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 4) acoustic2d_single_nopml<4><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 6) acoustic2d_single_nopml<6><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 8) acoustic2d_single_nopml<8><<<grid, block>>>(__VA_ARGS__); \
+        else                   acoustic2d_single_nopml<-1><<<grid, block>>>(__VA_ARGS__); \
     } while (0)
 
 #define ACOUSTIC_LSRTM2D_COUPLED(order, grid, block, ...)                        \
@@ -101,7 +101,7 @@ __device__ inline float acoustic_cpml_update_2d(
 }
 
 template <int Order>
-__global__ void acoustic2nd(
+__global__ void acoustic2d_single(
     AcousticWavefieldPointer wf,
     bool save_all_wavefields,
     float* __restrict__ u_this,
@@ -143,7 +143,7 @@ __global__ void acoustic2nd(
 }
 
 template <int Order>
-__global__ void acoustic2nd_nopml(
+__global__ void acoustic2d_single_nopml(
     AcousticWavefieldPointer wf,
     const float* __restrict__ vp,
     LaplaceParam lap_ctx,


### PR DESCRIPTION
## Summary
`acoustic_lsrtm2d/kernels.cuh` defined `template<int Order> __global__ acoustic2nd / acoustic2nd_nopml` with the same mangled names as acoustic2d's kernels but different bodies (FP multiply association; `u_this` gating/content). All TUs link into one `_C` extension, the weak host stubs collapse, and the CUDA runtime resolves the winner per process — acoustic2d `impl='c'` forward output is cross-process bimodal at 1 ULP, and the `u_this` semantics are a per-process roulette. This is what previously masqueraded as "cross-GPU ulp differences" (two bit-groups of ranks) and flaky bitwise tests.

Rename the LSRTM-private copies to `acoustic2d_single / acoustic2d_single_nopml`, mirroring lsrtm3d's collision-free `acoustic3d_single*` convention. Only the `ACOUSTIC_LSRTM2D_SINGLE*` macros in the same header reference them.

## Verification (KW60443, RTX 6000 Ada, CUDA 12.9, sm_89)
- cuobjdump SASS audit (whitespace-normalized, grouped by mangled name across cubins): dev@0ecb13e shows exactly 10 real duplicate-name/different-SASS kernels — this family; after the rename: **0** across the whole extension.
- 10 fresh-process tiny acoustic2d `impl='c'` forward: before = two bit-patterns (7/3 split); after = identical hash in all 10 processes.
- `test/solver_gradient_mode_suite.py --solvers acoustic2d,lsrtm2d` (3 scenarios x 8 modes): **48/48 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)