### PR TITLE
fix(cuda): race-free psi double-buffer on forward + adjoint paths

### DIFF
--- a/src/sweep/csrc/cuda/common/acoustic.h
+++ b/src/sweep/csrc/cuda/common/acoustic.h
@@ -182,10 +182,20 @@ struct AcousticWavefieldTensor {
     // =========================
     // Allocate (only once)
     // =========================
+    // double_buffer_psi_: pass true at call sites whose stepping pairs with
+    // swap_pml() (the forward time loops).  The stencil kernels neighbour-read
+    // psi* in the same launch that writes the new psi, so the write must land
+    // in psi*n (read-old/write-new, swap_pml() per step) — matching the
+    // Python-bound 9/12-tensor layout.  Without it the kernel falls back to
+    // the legacy in-place write, an intra-launch RAW race (nondeterministic
+    // at ulp level in 3-D).  Call sites that pair with the u-only swap()
+    // (checkpoint recompute, adjoint states) must keep the default: they
+    // never swap psi, so a psi*n write would be lost.
     void allocate(
         const torch::Tensor& vp,
         int dim_,
-        bool use_pml_ = true
+        bool use_pml_ = true,
+        bool double_buffer_psi_ = false
     )
     {
         if (allocated) return;
@@ -208,6 +218,13 @@ struct AcousticWavefieldTensor {
             if (dim == 3) {
                 psiy_t  = torch::zeros_like(vp);
                 zetay_t = torch::zeros_like(vp);
+            }
+
+            if (double_buffer_psi_) {
+                psixn_t = torch::zeros_like(vp);
+                psizn_t = torch::zeros_like(vp);
+                if (dim == 3) psiyn_t = torch::zeros_like(vp);
+                double_buffer_psi = true;
             }
         }
 

--- a/src/sweep/csrc/cuda/equations/acoustic2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/forward.cu
@@ -67,7 +67,7 @@ ForwardOutput forward(const ForwardInput& in) {
     if (!p.wavefields.empty())
         wavefield.bind(p.wavefields, 2, true);
     else
-        wavefield.allocate(vp, 2, true);
+        wavefield.allocate(vp, 2, true, /*double_buffer_psi=*/true);
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 2);

--- a/src/sweep/csrc/cuda/equations/acoustic3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/forward.cu
@@ -60,7 +60,7 @@ ForwardOutput forward(const ForwardInput& in)
     if (!p.wavefields.empty())
         wavefield.bind(p.wavefields, 3, true);
     else
-        wavefield.allocate(vp, 3, true);
+        wavefield.allocate(vp, 3, true, /*double_buffer_psi=*/true);
 
     // ----------------------------
     // PML parameters

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/backward.cu
@@ -170,7 +170,7 @@ void process_recursive_interval_2d(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         calculate_grad_lsrtm_mp<<<wave_grid, wave_block>>>(
             bg_utt.data_ptr<float>(),
@@ -284,9 +284,9 @@ void run_full_imaging(const BackwardInput& p, torch::Tensor& grad_mp)
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
-        adjoint.bind(std::vector<torch::Tensor>(p.adjoint_wavefields.begin(), p.adjoint_wavefields.begin() + 7), 2, true);
+        adjoint.bind(std::vector<torch::Tensor>(p.adjoint_wavefields.begin(), p.adjoint_wavefields.begin() + 9), 2, true);
     else
-        adjoint.allocate(vp, 2, true);
+        adjoint.allocate(vp, 2, true, /*double_buffer_psi=*/true);
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 2);
@@ -320,7 +320,7 @@ void run_full_imaging(const BackwardInput& p, torch::Tensor& grad_mp)
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         calculate_grad_lsrtm_mp<<<launch_config.grid, launch_config.block>>>(
             p.u_forward[it].data_ptr<float>(),
@@ -382,9 +382,9 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
-        adjoint.bind(std::vector<torch::Tensor>(p.adjoint_wavefields.begin(), p.adjoint_wavefields.begin() + 7), 2, true);
+        adjoint.bind(std::vector<torch::Tensor>(p.adjoint_wavefields.begin(), p.adjoint_wavefields.begin() + 9), 2, true);
     else
-        adjoint.allocate(vp, 2, true);
+        adjoint.allocate(vp, 2, true, /*double_buffer_psi=*/true);
 
     AcousticWavefieldTensor forward;
     if (!p.forward_wavefields.empty())
@@ -461,7 +461,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         ACOUSTIC_LSRTM2D_SINGLE_NOPML(
             order,
@@ -522,7 +522,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
     }
 
     out.grads = {grad_wavelet, grad_vp, grad_mp};
@@ -561,9 +561,9 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
-        adjoint.bind(std::vector<torch::Tensor>(p.adjoint_wavefields.begin(), p.adjoint_wavefields.begin() + 7), 2, true);
+        adjoint.bind(std::vector<torch::Tensor>(p.adjoint_wavefields.begin(), p.adjoint_wavefields.begin() + 9), 2, true);
     else
-        adjoint.allocate(vp, 2, true);
+        adjoint.allocate(vp, 2, true, /*double_buffer_psi=*/true);
 
     AcousticWavefieldTensor forward;
     if (!p.forward_wavefields.empty())
@@ -658,7 +658,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
                 ctx
             );
 
-            adjoint.swap();
+            adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
             calculate_grad_lsrtm_mp<<<launch_config.grid, launch_config.block>>>(
                 chunk_forward[it - start].data_ptr<float>(),
@@ -721,9 +721,9 @@ BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
-        adjoint.bind(std::vector<torch::Tensor>(p.adjoint_wavefields.begin(), p.adjoint_wavefields.begin() + 7), 2, true);
+        adjoint.bind(std::vector<torch::Tensor>(p.adjoint_wavefields.begin(), p.adjoint_wavefields.begin() + 9), 2, true);
     else
-        adjoint.allocate(vp, 2, true);
+        adjoint.allocate(vp, 2, true, /*double_buffer_psi=*/true);
     checkpoint_runtime.zero_state(adjoint.state_tensors());
 
     auto grad_wavelet = torch::zeros_like(p.forward_source);

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm2d/forward.cu
@@ -70,8 +70,8 @@ ForwardOutput forward(const ForwardInput& in) {
         bg.bind(slice_wavefields(p.wavefields, 0, 9), 2, true);
         sc.bind(slice_wavefields(p.wavefields, 9, 9), 2, true);
     } else {
-        bg.allocate(vp, 2, true);
-        sc.allocate(vp, 2, true);
+        bg.allocate(vp, 2, true, /*double_buffer_psi=*/true);
+        sc.allocate(vp, 2, true, /*double_buffer_psi=*/true);
     }
 
     AcousticCPMLTensor cpml_tensor;

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/backward.cu
@@ -337,7 +337,7 @@ void process_recursive_interval_3d(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         accumulate_source_gradient_3d(
             forward_source_grid,
@@ -490,9 +490,9 @@ void run_full_imaging(
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
-        adjoint.bind(slice_wavefields(p.adjoint_wavefields, 0, 9), 3, true);
+        adjoint.bind(slice_wavefields(p.adjoint_wavefields, 0, 12), 3, true);
     else
-        adjoint.allocate(vp, 3, true);
+        adjoint.allocate(vp, 3, true, /*double_buffer_psi=*/true);
 
     float* u_thist = nullptr;
 
@@ -532,7 +532,7 @@ void run_full_imaging(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         accumulate_source_gradient_3d(
             forward_source_config.grid,
@@ -610,9 +610,9 @@ void run_bs_imaging(
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
-        adjoint.bind(slice_wavefields(p.adjoint_wavefields, 0, 9), 3, true);
+        adjoint.bind(slice_wavefields(p.adjoint_wavefields, 0, 12), 3, true);
     else
-        adjoint.allocate(vp, 3, true);
+        adjoint.allocate(vp, 3, true, /*double_buffer_psi=*/true);
 
     AcousticWavefieldTensor forward;
     if (!p.forward_wavefields.empty())
@@ -690,7 +690,7 @@ void run_bs_imaging(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         accumulate_source_gradient_3d(
             fwd_source_config.grid,
@@ -771,7 +771,7 @@ void run_bs_imaging(
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         accumulate_source_gradient_3d(
             fwd_source_config.grid,
@@ -834,9 +834,9 @@ void run_ckpt_imaging(
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
-        adjoint.bind(slice_wavefields(p.adjoint_wavefields, 0, 9), 3, true);
+        adjoint.bind(slice_wavefields(p.adjoint_wavefields, 0, 12), 3, true);
     else
-        adjoint.allocate(vp, 3, true);
+        adjoint.allocate(vp, 3, true, /*double_buffer_psi=*/true);
 
     AcousticWavefieldTensor forward;
     if (!p.forward_wavefields.empty())
@@ -930,7 +930,7 @@ void run_ckpt_imaging(
                 ctx
             );
 
-            adjoint.swap();
+            adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
             accumulate_source_gradient_3d(
                 fwd_source_config.grid,
@@ -1023,9 +1023,9 @@ void run_recursive_imaging(
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
-        adjoint.bind(slice_wavefields(p.adjoint_wavefields, 0, 9), 3, true);
+        adjoint.bind(slice_wavefields(p.adjoint_wavefields, 0, 12), 3, true);
     else
-        adjoint.allocate(vp, 3, true);
+        adjoint.allocate(vp, 3, true, /*double_buffer_psi=*/true);
     checkpoint_runtime.zero_state(adjoint.state_tensors());
 
     AcousticCPMLTensor cpml_tensor;

--- a/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_lsrtm3d/forward.cu
@@ -71,8 +71,8 @@ ForwardOutput forward(const ForwardInput& in) {
         bg.bind(slice_wavefields(p.wavefields, 0, 12), 3, true);
         sc.bind(slice_wavefields(p.wavefields, 12, 12), 3, true);
     } else {
-        bg.allocate(vp, 3, true);
-        sc.allocate(vp, 3, true);
+        bg.allocate(vp, 3, true, /*double_buffer_psi=*/true);
+        sc.allocate(vp, 3, true, /*double_buffer_psi=*/true);
     }
 
     AcousticCPMLTensor cpml_tensor;

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/backward.cu
@@ -73,7 +73,7 @@ BackwardOutput backward(const BackwardInput& in)
     if (!in.adjoint_wavefields.empty())
         adjoint.bind(in.adjoint_wavefields, 2, true);
     else
-        adjoint.allocate(vp, 2, true);
+        adjoint.allocate(vp, 2, true, /*double_buffer_psi=*/true);
     zero_wavefield_state_vrz(adjoint);
 
     auto grad_vp = torch::zeros_like(vp);
@@ -143,7 +143,7 @@ BackwardOutput backward(const BackwardInput& in)
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         BUILD_VRZ_GRAD_FIELDS(
             order,
@@ -223,11 +223,14 @@ BackwardOutput backward_bs(const BackwardInput& in)
     if (!p.adjoint_wavefields.empty())
         adjoint.bind(p.adjoint_wavefields, 2, true);
     else
-        adjoint.allocate(vp, 2, true);
+        adjoint.allocate(vp, 2, true, /*double_buffer_psi=*/true);
     zero_wavefield_state_vrz(adjoint);
 
     AcousticWavefieldTensor forward;
-    forward.allocate(vp, 2, false);
+    if (!p.forward_wavefields.empty())
+        forward.bind(p.forward_wavefields, 2, false);
+    else
+        forward.allocate(vp, 2, false);
     forward.u_prev_t.copy_(p.u_last_two.select(1, 1).squeeze(0));
     forward.u_now_t.copy_(p.u_last_two.select(1, 0).squeeze(0));
     forward.u_next_t.zero_();
@@ -334,7 +337,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         ACOUSTIC_VRZ2D_NOPML(
             order,
@@ -451,7 +454,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
     if (!p.adjoint_wavefields.empty())
         adjoint.bind(p.adjoint_wavefields, 2, true);
     else
-        adjoint.allocate(vp, 2, true);
+        adjoint.allocate(vp, 2, true, /*double_buffer_psi=*/true);
     zero_wavefield_state_vrz(adjoint);
 
     AcousticWavefieldTensor forward;
@@ -627,7 +630,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
                 ctx
             );
 
-            adjoint.swap();
+            adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
             BUILD_VRZ_GRAD_FIELDS(
                 order,

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/forward.cu
@@ -53,7 +53,7 @@ ForwardOutput forward(const ForwardInput& in) {
     if (!p.wavefields.empty())
         wavefield.bind(p.wavefields, 2, true);
     else
-        wavefield.allocate(vp, 2, true);
+        wavefield.allocate(vp, 2, true, /*double_buffer_psi=*/true);
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 2);

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/kernels.cuh
@@ -591,8 +591,11 @@ __global__ void acoustic_vrz2nd_adjoint(
 
     float rhs = kappa * (beta * w_sum + dbdx * qx + dbdz * qz);
 
-    f.psix[idx] = psixn;
-    f.psiz[idx] = psizn;
+    // Race-free adjoint psi double-buffer: dpsi*d* above neighbour-reads psi
+    // in this same launch, so the new psi must land in psi*n (caller pairs
+    // with swap_pml()).  zeta is only ever read at idx — in-place is safe.
+    (f.psixn ? f.psixn : f.psix)[idx] = psixn;
+    (f.psizn ? f.psizn : f.psiz)[idx] = psizn;
     f.zetax[idx] = zetaxn;
     f.zetaz[idx] = zetazn;
 

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/backward.cu
@@ -72,7 +72,7 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
     if (!in.adjoint_wavefields.empty())
         adjoint.bind(in.adjoint_wavefields, 3, true);
     else
-        adjoint.allocate(vp, 3, true);
+        adjoint.allocate(vp, 3, true, /*double_buffer_psi=*/true);
     zero_wavefield_state_vrz3d(adjoint);
 
     auto grad_vp = torch::zeros_like(vp);
@@ -148,7 +148,7 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         BUILD_VRZ_GRAD_FIELDS_3D(
             order,
@@ -249,14 +249,16 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
     if (!p.adjoint_wavefields.empty())
         adjoint.bind(p.adjoint_wavefields, 3, true);
     else
-        adjoint.allocate(vp, 3, true);
+        adjoint.allocate(vp, 3, true, /*double_buffer_psi=*/true);
     zero_wavefield_state_vrz3d(adjoint);
 
     AcousticWavefieldTensor forward;
+    // Recon steps with the NOPML kernel — u triple buffer only; psi/zeta
+    // would be dead weight (use_pml=false, 3 tensors, like vrz2d/acoustic).
     if (!p.forward_wavefields.empty())
-        forward.bind(p.forward_wavefields, 3, true);
+        forward.bind(p.forward_wavefields, 3, false);
     else
-        forward.allocate(vp, 3, true);
+        forward.allocate(vp, 3, false);
 
     forward.u_prev_t.copy_(p.u_last_two.select(1, 1).squeeze(0));
     forward.u_now_t.copy_(p.u_last_two.select(1, 0).squeeze(0));
@@ -374,7 +376,7 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
             ctx
         );
 
-        adjoint.swap();
+        adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
         auto for_view = forward.view();
 
@@ -513,7 +515,7 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
     if (!p.adjoint_wavefields.empty())
         adjoint.bind(p.adjoint_wavefields, 3, true);
     else
-        adjoint.allocate(vp, 3, true);
+        adjoint.allocate(vp, 3, true, /*double_buffer_psi=*/true);
     zero_wavefield_state_vrz3d(adjoint);
 
     AcousticWavefieldTensor forward;
@@ -695,7 +697,7 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
                 ctx
             );
 
-            adjoint.swap();
+            adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
             BUILD_VRZ_GRAD_FIELDS_3D(
                 order,

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/forward.cu
@@ -54,7 +54,7 @@ ForwardOutput forward(const ForwardInput& in)
     if (!p.wavefields.empty())
         wavefield.bind(p.wavefields, 3, true);
     else
-        wavefield.allocate(vp, 3, true);
+        wavefield.allocate(vp, 3, true, /*double_buffer_psi=*/true);
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(p.pml_vals, 3);

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/kernels.cuh
@@ -713,9 +713,12 @@ __global__ void acoustic_vrz3nd_adjoint(
 
     float rhs = kappa * (beta * w_sum + dbdx * px + dbdy * py + dbdz * pz);
 
-    f.psix[idx] = psixn;
-    f.psiy[idx] = psiyn;
-    f.psiz[idx] = psizn;
+    // Race-free adjoint psi double-buffer: dpsi*d* above neighbour-reads psi
+    // in this same launch, so the new psi must land in psi*n (caller pairs
+    // with swap_pml()).  zeta is only ever read at idx — in-place is safe.
+    (f.psixn ? f.psixn : f.psix)[idx] = psixn;
+    (f.psiyn ? f.psiyn : f.psiy)[idx] = psiyn;
+    (f.psizn ? f.psizn : f.psiz)[idx] = psizn;
     f.zetax[idx] = zetaxn;
     f.zetay[idx] = zetayn;
     f.zetaz[idx] = zetazn;

--- a/src/sweep/propagator/_c.py
+++ b/src/sweep/propagator/_c.py
@@ -283,7 +283,12 @@ class Warpper(torch.autograd.Function):
             ctx.backward_ckpt_func = backward_ckpt_func
             ctx.backward_recursive_ckpt_func = backward_recursive_ckpt_func
             ctx.forward_source = wavelet
-            ctx.forward_wavefields = forward_wavefields
+            # save_all binds the propagator's persistent buffers; the other
+            # modes (BS/ckpt) pass per-call transient scratch that must NOT
+            # outlive the forward — and their backwards expect an empty list
+            # here (the ckpt recompute allocates its own legacy 7/9-slot
+            # state paired with the u-only swap()).
+            ctx.forward_wavefields = forward_wavefields if save_all_wavefields else ()
             ctx.adjoint_wavefields = adjoint_wavefields
             ctx.adjoint_workspace = adjoint_workspace
             ctx.source_illumination_buffer = source_illumination_buffer
@@ -891,12 +896,19 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
     def __del__(self):
         self._remove_boundary_disk_cache()
 
-    def _ensure_wavefield_buffers(self, batch_size, need_forward=False, need_adjoint=True):
+    def _ensure_wavefield_buffers(self, batch_size, persist_forward_state=False, need_adjoint=True):
+        # persist_forward_state: keep the forward propagation-state buffers
+        # (u_prev/now/next + psi/zeta, shape [B,1,*spatial]) as persistent,
+        # reused-across-calls tensors. True only in save_all (full) mode,
+        # whose backward replays from these. BS/ckpt/no-grad use per-call
+        # transient state instead (_transient_forward_wavefields) — they are
+        # NOT gated here. This is orthogonal to save_all_wavefields, which
+        # gates the big (nt,B,*spatial) u_allt history array, not this state.
         current_capacity = self._buffer_capacity_batch
         if (
             current_capacity is not None
             and batch_size <= current_capacity
-            and (not need_forward or self.forward_wavefields)
+            and (not persist_forward_state or self.forward_wavefields)
             and (not need_adjoint or self.adjoint_wavefields)
         ):
             return
@@ -925,7 +937,7 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
             self.forward_wavefields = ()
             self.adjoint_wavefields = ()
 
-        if need_forward and not self.forward_wavefields:
+        if persist_forward_state and not self.forward_wavefields:
             self.forward_wavefields = self.forward_allocator.zeros(wavefield_shapes)
         if need_adjoint and not self.adjoint_wavefields:
             self.adjoint_wavefields = self.adjoint_allocator.zeros(adjoint_wavefield_shapes)
@@ -936,6 +948,25 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
 
     def _slice_wavefield_buffers(self, batch_size):
         return tuple(t[:batch_size] for t in self.forward_wavefields), tuple(t[:batch_size] for t in self.adjoint_wavefields)
+
+    def _transient_forward_wavefields(self, batch_size):
+        """Per-call zeroed forward wavefields for the non-save_all modes
+        (boundary saving / checkpoint / no-grad forward).
+
+        All wavefield state is allocated Python-side so ``cuda_layout``
+        stays the single layout authority — the C++-internal ``allocate()``
+        once missed the psi double-buffer slots and silently re-enabled the
+        in-place psi RAW race.  Deliberately transient (not the persistent
+        Allocator): propagation scratch with one-call lifetime, exactly like
+        the C++ scratch it replaces, so boundary-saving backward peak memory
+        is unchanged.
+        """
+        cuda_layout = self._cuda_layout()
+        n_wavefields = cuda_layout.base_nvar + cuda_layout.pml_nvar
+        return tuple(
+            torch.zeros([batch_size, 1, *self.shape_cuda], device=self.dev)
+            for _ in range(n_wavefields)
+        )
 
     def _ensure_adjoint_workspace_buffers(self, batch_size):
         cuda_layout = self._cuda_layout()
@@ -1196,7 +1227,7 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         )
         checkpoint_on_cpu = bool(use_checkpoint and self.ckpt_storage == "cpu")
         save_all_wavefields = bool(requires_backward and not use_boundary_saving and not use_checkpoint)
-        self._ensure_wavefield_buffers(batch_size, need_forward=save_all_wavefields, need_adjoint=requires_backward)
+        self._ensure_wavefield_buffers(batch_size, persist_forward_state=save_all_wavefields, need_adjoint=requires_backward)
         self._ensure_adjoint_workspace_buffers(batch_size)
         if use_checkpoint:
             if use_recursive_checkpoint:
@@ -1205,6 +1236,8 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
             elif self.backward_ckpt_func is not None:
                 self._ensure_checkpoint_buffers(checkpoint_interval=self.ckpt_chunks, batch_size=batch_size)
         forward_wavefields, adjoint_wavefields = self._slice_wavefield_buffers(batch_size)
+        if not forward_wavefields:
+            forward_wavefields = self._transient_forward_wavefields(batch_size)
         adjoint_workspace = self._slice_adjoint_workspace_buffers(batch_size)
         checkpoint_buffers = self._slice_checkpoint_buffers(batch_size) if use_checkpoint else ()
 
@@ -1506,7 +1539,7 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         models = [m[None, None, ...].repeat(batch_size, *([1] * (m.ndim + 1))) for m in self.models_padded]
         requires_model_grad = any(m.requires_grad for m in models)
         save_all_wavefields = bool(self.ndim == 2 or (requires_model_grad and not use_boundary_saving and not use_ckpt))
-        self._ensure_wavefield_buffers(batch_size, need_forward=save_all_wavefields, need_adjoint=requires_model_grad)
+        self._ensure_wavefield_buffers(batch_size, persist_forward_state=save_all_wavefields, need_adjoint=requires_model_grad)
         self._ensure_adjoint_workspace_buffers(batch_size)
         if use_ckpt:
             if use_recursive_checkpoint:
@@ -1546,7 +1579,10 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
 
         _C = _get_C()
         fwd = _C.ForwardInput()
-        fwd.wavefields = list(forward_wavefields) if save_all_wavefields else []
+        fwd.wavefields = (
+            list(forward_wavefields) if save_all_wavefields
+            else list(self._transient_forward_wavefields(batch_size))
+        )
         fwd.last_two = last_two
         if boundary_on_disk and use_boundary_saving:
             fwd.boundary_cpu = [b.zero_() for b in boundary_cpu]
@@ -1601,6 +1637,7 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         fwd.checkpoint_count = int(checkpoint_steps.numel()) if use_recursive_checkpoint else self.ckpt_num
 
         u_forward, u_last_two, syn = self.forward_func(fwd)
+        fwd.wavefields = []  # release per-call scratch before the backward half
         # Permute to canonical (B, nt, nrec, nfield) for the user-facing
         # output; RTM is currently single-channel acoustic-only so this
         # always lands as (B, nt, nrec, 1).


### PR DESCRIPTION
## Problem

The race-free CPML psi double-buffer (PR #41) is engaged only by the *shape*
of the bound wavefield list. Several paths never provided the `psi*n` slots,
so the stencil kernels fell back to writing psi **in place** in the same
launch that neighbour-reads psi via `gradient<>(psi)` — the intra-launch RAW
race PR #41 was meant to remove. In 3-D this is live run-to-run
nondeterminism (~1e-5 abs on wavefield strips, ~3e-9 in grad_vp); 2-D at
small grids never trips it, so it masqueraded as a benign quirk.

Affected paths:
- **Forward**: every public boundary-saving / no-grad forward left
  `ForwardInput.wavefields` empty → C++ `allocate()` (no `psi*n`).
- **Adjoint**: vrz adjoint kernels wrote psi in place unconditionally;
  lsrtm adjoint bound a 7/9-slot legacy list so the shared CPML helper's
  conditional `psi*n` write degraded to in-place.

## Fix

**C1 — forward path.** Allocate forward wavefields python-side (`cuda_layout`
is the single layout authority) so the layout-blind C++ fallback is
unreachable from public paths; `allocate()` also gains an opt-in
`double_buffer_psi` for raw callers. Rename `_ensure_wavefield_buffers`
`need_forward` → `persist_forward_state` (it gates persistent-vs-transient
propagation state, orthogonal to the `u_allt` history switch).

**C2 — adjoint path.** vrz: conditional `psi*n` write + `swap_pml()` per
adjoint step + dbuf at allocate fallbacks. lsrtm: widen the bound adjoint
slices 7/9 → 9/12 + `swap_pml()` + dbuf (no kernel change). Also vrz3d recon
`use_pml=false` (drops 6 dead PML fields, bs_gpu peak 111→96 MB) and vrz2d
recon gains the bind-else-allocate branch.

## Verification

- **Value-preserving**: 2-D gradients **bitwise identical** to pristine dev
  (acoustic2d/vrz2d/lsrtm2d), where the race never fires — the commits change
  nothing except removing the race.
- **Determinism**: 3-D public forward and vrz/lsrtm backward now bitwise
  reproducible run-to-run (were ulp-nondeterministic on dev).
- **Correctness**: gradient consistency suite c-vs-eager **144/144**
  (6 eqs × {interior, fd_edge, free_surface} × 8 modes); finite-difference
  gradient check acoustic2d median 2.6%; cross-equation memory profile shows
  the expected full > ckpt > bs hierarchy with no leak.

Known orthogonal item (pre-existing, not from this PR): int8 boundary storage
is location-dependent (gpu vs cpu/disk) because the int8 scale is computed
per transfer-chunk; fp32/fp16/bf16 are location-invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
