### PR TITLE
perf(acoustic/elastic): fuse vp-grad imaging into exact adjoint

### DIFF
--- a/build_config.py
+++ b/build_config.py
@@ -218,6 +218,10 @@ def build_ext_kwargs(build_cuda=None):
     omp_flags = openmp_flags()
     configure_cuda_arch_list()
 
+    # Optional extra nvcc flags (e.g. -DELASTIC3D_LB_MINBLOCKS=6 to retune a
+    # forward launch_bounds without editing kernel source).  Space-separated.
+    extra_nvcc = os.environ.get("SWEEP_EXTRA_NVCC", "").split()
+
     kwargs["ext_modules"] = [
         CUDAExtension(
             name="sweep._C",
@@ -237,6 +241,7 @@ def build_ext_kwargs(build_cuda=None):
                     "--use_fast_math",
                     "--threads=16",
                     "-Xcompiler=-Wno-deprecated-declarations",
+                    *extra_nvcc,
                 ],
             },
             extra_link_args=omp_flags,

--- a/src/sweep/csrc/bindings/module.cpp
+++ b/src/sweep/csrc/bindings/module.cpp
@@ -245,7 +245,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def_readwrite("boundary_cpu", &BackwardInput::boundary_cpu)
         .def_readwrite("boundary_gpu", &BackwardInput::boundary_gpu)
         .def_readwrite("boundary_disk_files", &BackwardInput::boundary_disk_files)
-        .def_readwrite("checkpoint_steps", &BackwardInput::checkpoint_steps);
+        .def_readwrite("checkpoint_steps", &BackwardInput::checkpoint_steps)
+        .def_readwrite("compute_illumination", &BackwardInput::compute_illumination);
 
 
 }

--- a/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
@@ -225,7 +225,11 @@ BackwardOutput backward(const BackwardInput& in)
     auto grad_wavelet = torch::zeros_like(in.forward_source);
     RTMOutput illumination;
     init_rtm_output_2d(illumination, in.models[0]);
-    run_full_imaging(in, &grad, &grad_wavelet, &illumination);
+    // Illumination (RTM image + source/receiver illumination) is a per-timestep
+    // extra grid pass; skip it for a plain FWI gradient that does not request it.
+    // The vp gradient (calculate_grad) is unaffected.
+    run_full_imaging(in, &grad, &grad_wavelet,
+                     in.compute_illumination ? &illumination : nullptr);
     out.grads = {grad_wavelet, grad};
     out.source_illumination = illumination.source_illumination;
     out.receiver_illumination = illumination.receiver_illumination;

--- a/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
@@ -32,7 +32,8 @@ static inline void run_acoustic2d_adjoint_step(
     const float* vp_ptr,
     LaplaceParam lap_ctx, GradParam grad_ctx,
     GradParam grad_ctx_x, GradParam grad_ctx_z,
-    AcousticCPMLPointer cpml, SolverContext ctx)
+    AcousticCPMLPointer cpml, SolverContext ctx,
+    const float* grad_forward_img = nullptr, float* grad_out = nullptr)
 {
     // FUSED single-kernel exact adjoint: recompute the per-cell g_* inline at
     // each stencil tap and write next-step psi/zeta into the wavefield's
@@ -45,7 +46,8 @@ static inline void run_acoustic2d_adjoint_step(
     (void)grad_ctx;
     ACOUSTIC2D_ADJOINT_FUSED(order, grid, block,
         adj_view, vp_ptr, lap_ctx, grad_ctx_x, grad_ctx_z, cpml, ctx,
-        adj_view.psixn, adj_view.psizn, adj_view.zetaxn, adj_view.zetazn);
+        adj_view.psixn, adj_view.psizn, adj_view.zetaxn, adj_view.zetazn,
+        grad_forward_img, grad_out);
 }
 
 void init_rtm_output_2d(RTMOutput& out, const torch::Tensor& vp)
@@ -167,16 +169,27 @@ void run_full_imaging(
     GradParam grad_ctx_x{1, 0, 0, M, p.grad_coes.data_ptr<float>(), dx, 0.f, 0.f};
     GradParam grad_ctx_z{1, 0, 0, M, p.grad_coes.data_ptr<float>(), dz, 0.f, 0.f};
 
+    float* grad_ptr = (grad != nullptr) ? grad->data_ptr<float>() : nullptr;
+
     for (int it = p.nt - 1; it >= 0; --it) {
 
         auto adj_view = adjoint.view();
 
-        // Exact discrete adjoint of the CPML forward step (interior + PML).
+        // Fold the vp-gradient imaging of step it+1 into the adjoint kernel: at
+        // kernel entry u_now == post-source adjoint[it+1], the exact field
+        // calculate_grad would correlate.  Skip on the first reverse step
+        // (it+1 == nt has no forward wavefield); step 0 is imaged after the loop.
+        const float* img_fwd = (grad_ptr != nullptr && it + 1 < p.nt)
+                             ? p.u_forward[it + 1].data_ptr<float>() : nullptr;
+
+        // Exact discrete adjoint of the CPML forward step (interior + PML),
+        // optionally accumulating the lagged vp-gradient imaging.
         run_acoustic2d_adjoint_step(
             order, launch_config.grid, launch_config.block,
             adj_view, vp.data_ptr<float>(),
             lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_z,
-            cpml, ctx);
+            cpml, ctx,
+            img_fwd, img_fwd ? grad_ptr : nullptr);
 
         add_source<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -200,14 +213,36 @@ void run_full_imaging(
             forward_nsrc
         );
 
+        // Illumination (RTM image + src/rec) still needs the per-step pass over
+        // the post-source adjoint[it]; the vp gradient is folded above, so pass
+        // grad=nullptr here to avoid double-counting.
+        if (rtm_out != nullptr) {
+            accumulate_imaging_2d(
+                launch_config.grid,
+                launch_config.block,
+                p.u_forward[it].data_ptr<float>(),
+                adjoint.u_now_t.data_ptr<float>(),
+                vp,
+                nullptr,
+                rtm_out,
+                nx,
+                nz,
+                dt
+            );
+        }
+    }
+
+    // Trailing: image step 0, the one reverse step never folded into an adjoint
+    // kernel.  adjoint.u_now_t now holds the post-source adjoint[0].
+    if (grad_ptr != nullptr) {
         accumulate_imaging_2d(
             launch_config.grid,
             launch_config.block,
-            p.u_forward[it].data_ptr<float>(),
+            p.u_forward[0].data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
             vp,
             grad,
-            rtm_out,
+            nullptr,
             nx,
             nz,
             dt

--- a/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cuh
@@ -6,6 +6,34 @@
 #include "../../common/context.h"
 #include "../../common/acoustic.h"
 
+// Accessor returning (a · psi) at a stencil tap: a is a 1-D profile (neighbour
+// stride 1 along the differencing axis), psi a 2-D field at linear index idx
+// with the given stride.  Feeding this to centered_gradient_stencil computes the
+// FUSED product derivative  d(a·psi)/dx  in a single stencil — matching the
+// eager reference grad_op(a*psi) (and deepwave's DIFFX1(AX_PSIX)).  Replaces the
+// product-rule split  a·d(psi) + d(a)·psi, which needs d(psi) AND d(a) held live
+// at once -> higher register pressure.
+struct AProductAccessor {
+    const float* __restrict__ a;
+    const float* __restrict__ psi;
+    int a_pos;
+    int idx;
+    int psi_stride;
+    __device__ __forceinline__ float operator()(int offset) const {
+        return a[a_pos + offset] * psi[idx + offset * psi_stride];
+    }
+};
+
+template<int Order>
+__device__ __forceinline__
+float fused_d_aPsi(const float* __restrict__ a, const float* __restrict__ psi,
+                   int a_pos, int idx, int psi_stride,
+                   int M, const float* __restrict__ coeff, float h)
+{
+    return centered_gradient_stencil<Order>(
+        AProductAccessor{a, psi, a_pos, idx, psi_stride}, M, coeff, h);
+}
+
 #define ACOUSTIC2D(order, grid, block, ...)                                  \
     do {                                                        \
         if      ((order) == 2) acoustic2nd<2><<<grid, block>>>(__VA_ARGS__); \
@@ -149,12 +177,11 @@ __global__ void acoustic2nd(
 
     float dudz     = gradient<2, Order, Z>(f.u_now, ix, 0, iz, grad_ctx);
     float dudx     = gradient<2, Order, X>(f.u_now, ix, 0, iz, grad_ctx);
-    float dpsizdz  = gradient<2, Order, Z>(f.psiz, ix, 0, iz, grad_ctx);
-    float dpsixdx  = gradient<2, Order, X>(f.psix, ix, 0, iz, grad_ctx);
-    float daxdx    = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
-    float dazdz    = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
-    float daipsiz_dz = az_ * dpsizdz + dazdz * f.psiz[idx];
-    float daipxix_dx = ax_ * dpsixdx + daxdx * f.psix[idx];
+    // FUSED d(a·psi) (single stencil) instead of the product-rule split
+    // a·d(psi) + d(a)·psi.  Bit-matches the eager reference grad_op(a*psi);
+    // drops d(psi) and d(a) from the live set -> fewer registers (deepwave-style).
+    float daipsiz_dz = fused_d_aPsi<Order>(cpml.az, f.psiz, iz, idx, grad_ctx.sz, halo, grad_ctx.coeff, grad_ctx.dz);
+    float daipxix_dx = fused_d_aPsi<Order>(cpml.ax, f.psix, ix, idx, grad_ctx.sx, halo, grad_ctx.coeff, grad_ctx.dx);
 
     // X direction.  Race-free: read psix at neighbours (above), write the NEXT
     // psix to a separate buffer (psixn) when double-buffering; fall back to
@@ -277,8 +304,11 @@ __global__ void acoustic2nd_adjoint_fused(
 
     float ax_ = cpml.ax[ix], az_ = cpml.az[iz];
     float bx_ = cpml.bx[ix], bz_ = cpml.bz[iz];
-    float daxdx = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
-    float dazdz = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
+    // Transpose of the FUSED forward term daipxix = d(ax·psix)/dx.  Its exact
+    // transpose w.r.t. psix is  -ax·d(gtmp)/dx  (single antisymmetric stencil of
+    // gtmp, ax pulled to the centre) — NOT the product-rule pair
+    // -d(ax·gtmp)/dx + daxdx·gtmp the old split forward needed.  So daxdx/dazdz
+    // are no longer required, and Dx_gqx/Dz_gqz below carry d(gtmp) (un-scaled).
 
     float gtmpx0 = bx_ * f.zetax[idx] + (1.0f + bx_) * gw;
     float gtmpz0 = bz_ * f.zetaz[idx] + (1.0f + bz_) * gw;
@@ -298,7 +328,7 @@ __global__ void acoustic2nd_adjoint_fused(
         Lx_glx += lc[k] * ((1.0f + bxp) * tp + (1.0f + bxm) * tm);
         Dx_ggx += gc[k] * ((bxp * f.psix[np] + cpml.dbxdx[nixp] * tp)
                          - (bxm * f.psix[nm] + cpml.dbxdx[nixm] * tm));
-        Dx_gqx += gc[k] * (cpml.ax[nixp] * tp - cpml.ax[nixm] * tm);
+        Dx_gqx += gc[k] * (tp - tm);   // d(gtmp)/dx (ax applied at psix_out)
     }
     Lx_glx *= invdx2; Dx_ggx *= invdx; Dx_gqx *= invdx;
 
@@ -313,14 +343,14 @@ __global__ void acoustic2nd_adjoint_fused(
         Lz_glz += lc[k] * ((1.0f + bzp) * tp + (1.0f + bzm) * tm);
         Dz_ggz += gc[k] * ((bzp * f.psiz[np] + cpml.dbzdz[nizp] * tp)
                          - (bzm * f.psiz[nm] + cpml.dbzdz[nizm] * tm));
-        Dz_gqz += gc[k] * (cpml.az[nizp] * tp - cpml.az[nizm] * tm);
+        Dz_gqz += gc[k] * (tp - tm);   // d(gtmp)/dz (az applied at psiz_out)
     }
     Lz_glz *= invdz2; Dz_ggz *= invdz; Dz_gqz *= invdz;
 
     f.u_next[idx] = 2.0f * gun - f.u_prev[idx]
                   + (Lx_glx + Lz_glz - Dx_ggx - Dz_ggz);
-    psix_out[oidx]  = ax_ * f.psix[idx] + daxdx * gtmpx0 - Dx_gqx;
-    psiz_out[oidx]  = az_ * f.psiz[idx] + dazdz * gtmpz0 - Dz_gqz;
+    psix_out[oidx]  = ax_ * (f.psix[idx] - Dx_gqx);
+    psiz_out[oidx]  = az_ * (f.psiz[idx] - Dz_gqz);
     zetax_out[oidx] = ax_ * (f.zetax[idx] + gw);
     zetaz_out[oidx] = az_ * (f.zetaz[idx] + gw);
     #undef GW_AT

--- a/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cuh
@@ -267,8 +267,11 @@ __global__ void acoustic2nd_adjoint_fused(
             lapz += lc[k] * (GW_AT(idx + k * sz) + GW_AT(idx - k * sz));
         }
         f.u_next[idx] = 2.0f * gun - f.u_prev[idx] + lapx * invdx2 + lapz * invdz2;
-        psix_out[oidx] = 0.f; psiz_out[oidx] = 0.f;
-        zetax_out[oidx] = 0.f; zetaz_out[oidx] = 0.f;
+        // Interior aux stays 0: both psi/zeta double-buffers are zero-allocated
+        // and no path ever writes a non-zero into the deep interior, so the
+        // out-buffers are already 0 here — skip the 4 redundant full-grid zero
+        // writes (mirrors the forward kernel's interior early-return; the only
+        // readers are PML-band stencils, which read the *input* psi=0).
         return;
     }
 

--- a/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cuh
@@ -207,7 +207,9 @@ __global__ void acoustic2nd_adjoint_fused(
     float* __restrict__ psix_out,
     float* __restrict__ psiz_out,
     float* __restrict__ zetax_out,
-    float* __restrict__ zetaz_out
+    float* __restrict__ zetaz_out,
+    const float* __restrict__ grad_forward_img,  // u_forward[it+1] (vp^2 Lap u), or nullptr
+    float* __restrict__ grad_out                 // vp gradient accumulator, or nullptr
 ){
     int ix = blockIdx.x * blockDim.x + threadIdx.x;
     int iz = blockIdx.y * blockDim.y + threadIdx.y;
@@ -236,6 +238,16 @@ __global__ void acoustic2nd_adjoint_fused(
     float invdz  = 1.0f / lap_ctx.dz;
 
     float gun = f.u_now[idx];
+
+    // FUSED vp-gradient imaging (lagged one step): at kernel entry u_now holds the
+    // post-source adjoint field of step it+1, so accumulate the imaging correlation
+    // for that step here instead of a separate calculate_grad pass.  Bit-identical
+    // to calculate_grad (same operands, same op order); halo/air cells skipped above
+    // carry adjoint==0, so omitting their imaging contributes exactly 0.
+    if (grad_out != nullptr)
+        grad_out[oidx] += 2.f * solver.dt * solver.dt
+                        * grad_forward_img[oidx] * gun / vpb[idx];
+
     float c0c = vpb[idx]; c0c = c0c * c0c * dt2;
     float gw  = c0c * gun;                     // c * lambda at idx
 

--- a/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
@@ -583,7 +583,10 @@ BackwardOutput backward_full_imaging_impl(const BackwardInput& p)
     auto grad_wavelet = torch::zeros_like(p.forward_source);
     RTMOutput illumination;
     init_rtm_output_3d(illumination, p.models[0]);
-    run_full_imaging(p, &grad, &grad_wavelet, &illumination);
+    // Skip the per-timestep illumination pass for a plain FWI gradient that does
+    // not request it; the vp gradient (calculate_grad) is unaffected.
+    run_full_imaging(p, &grad, &grad_wavelet,
+                     p.compute_illumination ? &illumination : nullptr);
     out.grads = {grad_wavelet, grad};
     out.source_illumination = illumination.source_illumination;
     out.receiver_illumination = illumination.receiver_illumination;

--- a/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
@@ -54,7 +54,8 @@ static inline void run_acoustic3d_adjoint_step(
     const float* vp_ptr,
     LaplaceParam lap_ctx, GradParam grad_ctx,
     GradParam grad_ctx_x, GradParam grad_ctx_y, GradParam grad_ctx_z,
-    AcousticCPMLPointer cpml, SolverContext ctx)
+    AcousticCPMLPointer cpml, SolverContext ctx,
+    const float* grad_forward_img = nullptr, float* grad_out = nullptr)
 {
     // FUSED single-kernel exact 3D adjoint: recompute the per-cell g_* inline at
     // each stencil tap and write next-step psi/zeta into the wavefield's
@@ -68,7 +69,8 @@ static inline void run_acoustic3d_adjoint_step(
     ACOUSTIC3D_ADJOINT_FUSED(order, grid, block,
         adj_view, vp_ptr, lap_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z, cpml, ctx,
         adj_view.psixn, adj_view.psiyn, adj_view.psizn,
-        adj_view.zetaxn, adj_view.zetayn, adj_view.zetazn);
+        adj_view.zetaxn, adj_view.zetayn, adj_view.zetazn,
+        grad_forward_img, grad_out);
 }
 
 void init_rtm_output_3d(RTMOutput& out, const torch::Tensor& vp)
@@ -527,14 +529,24 @@ void run_full_imaging(
     GradParam grad_ctx_y{1, 0, 0, p.M, p.grad_coes.data_ptr<float>(), dy, 0.f, 0.f};
     GradParam grad_ctx_z{1, 0, 0, p.M, p.grad_coes.data_ptr<float>(), dz, 0.f, 0.f};
 
+    float* grad_ptr = (grad != nullptr) ? grad->data_ptr<float>() : nullptr;
+
     for (int it = p.nt - 1; it >= 0; --it) {
         auto adj_view = adjoint.view();
+
+        // Fold the vp-gradient imaging of step it+1 into the adjoint kernel: at
+        // kernel entry u_now == post-source adjoint[it+1], the exact field
+        // calculate_grad_3d would correlate.  Skip on the first reverse step
+        // (it+1 == nt has no forward wavefield); step 0 is imaged after the loop.
+        const float* img_fwd = (grad_ptr != nullptr && it + 1 < p.nt)
+                             ? p.u_forward[it + 1].data_ptr<float>() : nullptr;
 
         run_acoustic3d_adjoint_step(
             order, launch_config.grid, launch_config.block,
             adj_view, vp.data_ptr<float>(),
             lap_ctx, grad_ctx, grad_ctx_x, grad_ctx_y, grad_ctx_z,
-            cpml, ctx);
+            cpml, ctx,
+            img_fwd, img_fwd ? grad_ptr : nullptr);
 
         add_source_3d<<<adj_source_config.grid, adj_source_config.block>>>(
             adj_view.u_next,
@@ -558,14 +570,37 @@ void run_full_imaging(
             forward_nsrc
         );
 
+        // Illumination still needs the per-step pass over the post-source
+        // adjoint[it]; the vp gradient is folded above, so pass grad=nullptr here.
+        if (rtm_out != nullptr) {
+            accumulate_imaging_3d(
+                launch_config.grid,
+                launch_config.block,
+                p.u_forward[it].data_ptr<float>(),
+                adjoint.u_now_t.data_ptr<float>(),
+                vp,
+                nullptr,
+                rtm_out,
+                B,
+                nx,
+                ny,
+                nz,
+                ctx.dt
+            );
+        }
+    }
+
+    // Trailing: image step 0, the one reverse step never folded into an adjoint
+    // kernel.  adjoint.u_now_t now holds the post-source adjoint[0].
+    if (grad_ptr != nullptr) {
         accumulate_imaging_3d(
             launch_config.grid,
             launch_config.block,
-            p.u_forward[it].data_ptr<float>(),
+            p.u_forward[0].data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
             vp,
             grad,
-            rtm_out,
+            nullptr,
             B,
             nx,
             ny,

--- a/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cuh
@@ -281,7 +281,9 @@ __global__ void acoustic_adjoint_fused_3d(
     float* __restrict__ psiz_out,
     float* __restrict__ zetax_out,
     float* __restrict__ zetay_out,
-    float* __restrict__ zetaz_out
+    float* __restrict__ zetaz_out,
+    const float* __restrict__ grad_forward_img,  // u_forward[it+1] (vp^2 Lap u), or nullptr
+    float* __restrict__ grad_out                 // vp gradient accumulator, or nullptr
 ){
     int ix = blockIdx.x * blockDim.x + threadIdx.x;
     int iy = blockIdx.y * blockDim.y + threadIdx.y;
@@ -316,6 +318,16 @@ __global__ void acoustic_adjoint_fused_3d(
     float invdz  = 1.0f / lap_ctx.dz;
 
     float gun = f.u_now[idx];
+
+    // FUSED vp-gradient imaging (lagged one step): at kernel entry u_now holds the
+    // post-source adjoint field of step it+1, so accumulate the imaging correlation
+    // for that step here instead of a separate calculate_grad_3d pass.  Bit-identical
+    // to calculate_grad_3d (same operands, same op order); halo/air cells skipped
+    // above carry adjoint==0, so omitting their imaging contributes exactly 0.
+    if (grad_out != nullptr)
+        grad_out[oidx] += 2.f * solver.dt * solver.dt
+                        * grad_forward_img[oidx] * gun / vpb[idx];
+
     float c0c = vpb[idx]; c0c = c0c * c0c * dt2;
     float gw  = c0c * gun;                     // c * lambda at idx
 

--- a/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cuh
@@ -351,8 +351,11 @@ __global__ void acoustic_adjoint_fused_3d(
         }
         f.u_next[idx] = 2.0f * gun - f.u_prev[idx]
                       + lapx * invdx2 + lapy * invdy2 + lapz * invdz2;
-        psix_out[oidx] = psiy_out[oidx] = psiz_out[oidx] = 0.f;
-        zetax_out[oidx] = zetay_out[oidx] = zetaz_out[oidx] = 0.f;
+        // Interior aux stays 0: both psi/zeta double-buffers are zero-allocated
+        // and no path ever writes a non-zero into the deep interior, so the
+        // out-buffers are already 0 here — skip the 6 redundant full-grid zero
+        // writes (mirrors the forward kernel's interior early-return; the only
+        // readers are PML-band stencils, which read the *input* psi=0).
         return;
     }
 

--- a/src/sweep/csrc/cuda/equations/elastic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic2d/backward.cu
@@ -28,7 +28,22 @@ void apply_adjoint_step_2d(
     ElasticCPMLPointer cpml_view,
     SGradParam grad_ctx,
     SolverContext solver,
-    ElasticAdjointWorkspaceTensor& workspace
+    ElasticAdjointWorkspaceTensor& workspace,
+    // Optional fused per-step gradient imaging (full-mode only).  When the
+    // grad_*_out accumulators are non-null, the stress-adjoint-prepare kernel
+    // folds in the calculate_grad_elastic_nobs correlation for this reverse
+    // step (operands are the un-mutated post-source adjoint at kernel entry).
+    // Default null => behaviour byte-for-byte identical for bs/ckpt callers.
+    const float* grad_fvx       = nullptr,
+    const float* grad_fvz       = nullptr,
+    const float* grad_fvx_prev  = nullptr,
+    const float* grad_fvz_prev  = nullptr,
+    const float* grad_vp_model  = nullptr,
+    const float* grad_vs_model  = nullptr,
+    const float* grad_rho_model = nullptr,
+    float* grad_vp_out          = nullptr,
+    float* grad_vs_out          = nullptr,
+    float* grad_rho_out         = nullptr
 )
 {
     auto adj_view = adjoint.view();
@@ -45,7 +60,11 @@ void apply_adjoint_step_2d(
         workspace.qxx_t.data_ptr<float>(),
         workspace.qzz_t.data_ptr<float>(),
         workspace.qxz_t.data_ptr<float>(),
-        workspace.qzx_t.data_ptr<float>()
+        workspace.qzx_t.data_ptr<float>(),
+        grad_ctx,
+        grad_fvx, grad_fvz, grad_fvx_prev, grad_fvz_prev,
+        grad_vp_model, grad_vs_model, grad_rho_model,
+        grad_vp_out, grad_vs_out, grad_rho_out
     );
 
     LAUNCH_ELASTIC_STRESS_ADJOINT_APPLY(
@@ -439,29 +458,36 @@ BackwardOutput backward(const BackwardInput& in)
         const float* vx_next = (it + 1 < p.nt) ? p.u_forward.select(0, it + 1).select(0, 0).data_ptr<float>() : zero_velocity.data_ptr<float>();
         const float* vz_next = (it + 1 < p.nt) ? p.u_forward.select(0, it + 1).select(0, 1).data_ptr<float>() : zero_velocity.data_ptr<float>();
 
-        LAUNCH_CALCULATE_GRAD_ELASTIC_NOBS(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view,
-            vx_now,
-            vz_now,
-            vx_next,
-            vz_next,
-            vp.data_ptr<float>(),
-            vs.data_ptr<float>(),
-            rho.data_ptr<float>(),
-            grad_vp.data_ptr<float>(),
-            grad_vs.data_ptr<float>(),
-            grad_rho.data_ptr<float>(),
-            grad_ctx,
-            solver
-        );
-
+        // Reverse step 0 has no adjoint apply kernel (the loop `continue`s
+        // below), so its gradient imaging cannot be folded — emit it as a
+        // standalone calculate_grad pass (mirrors the acoustic trailing call).
         if (it == 0) {
+            LAUNCH_CALCULATE_GRAD_ELASTIC_NOBS(
+                order,
+                launch_config.grid,
+                launch_config.block,
+                adj_view,
+                vx_now,
+                vz_now,
+                vx_next,
+                vz_next,
+                vp.data_ptr<float>(),
+                vs.data_ptr<float>(),
+                rho.data_ptr<float>(),
+                grad_vp.data_ptr<float>(),
+                grad_vs.data_ptr<float>(),
+                grad_rho.data_ptr<float>(),
+                grad_ctx,
+                solver
+            );
             continue;
         }
 
+        // FULL-mode fusion: fold this reverse step's vp/vs/rho-gradient imaging
+        // into the stress-adjoint-prepare kernel (it reads the un-mutated
+        // post-source adjoint[it] stress+velocity at entry, exactly what
+        // calculate_grad_elastic_nobs(it) would correlate), eliminating the
+        // separate full-grid calculate_grad launch for steps it >= 1.
         apply_adjoint_step_2d(
             order,
             launch_config,
@@ -472,7 +498,14 @@ BackwardOutput backward(const BackwardInput& in)
             cpml_view,
             grad_ctx,
             solver,
-            workspace
+            workspace,
+            vx_now, vz_now, vx_next, vz_next,
+            vp.data_ptr<float>(),
+            vs.data_ptr<float>(),
+            rho.data_ptr<float>(),
+            grad_vp.data_ptr<float>(),
+            grad_vs.data_ptr<float>(),
+            grad_rho.data_ptr<float>()
         );
 
     }

--- a/src/sweep/csrc/cuda/equations/elastic2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/elastic2d/kernels.cuh
@@ -99,8 +99,14 @@
     } while (0)
 
 
+// Forward velocity stencil launches with block(32,8)=256 threads.  Baseline
+// ~48 regs / ~53% occupancy on V100 (Volta) — register/occupancy-bound, not
+// spill-bound.  Capping at 256 threads/block with minBlocks=8 forces the
+// compiler to <=32 regs, lifting occupancy to ~90% (a measured forward win,
+// elastic2d 1.19->1.03 vs deepwave on V100).  Math-identical: no effect on
+// the adjoint or gradient.
 template<int Order>
-__global__ void elastic_velocity_kernel(
+__global__ void __launch_bounds__(256, 8) elastic_velocity_kernel(
     ElasticWavefieldPointer wf,
     const float* __restrict__ rho,
 
@@ -177,8 +183,11 @@ __global__ void elastic_velocity_kernel(
         (dsxz_dx + dszz_dz);
 }
 
+// Forward stress stencil: same block(32,8)=256, same register/occupancy
+// regime as elastic_velocity_kernel above.  Cap at 256/block, minBlocks=8
+// (<=32 regs) to lift occupancy.  Math-identical (forward-only change).
 template<int Order>
-__global__ void elastic_stress_kernel(
+__global__ void __launch_bounds__(256, 8) elastic_stress_kernel(
     ElasticWavefieldPointer wf,
     const float* __restrict__ lambda,
     const float* __restrict__ mu,
@@ -407,7 +416,29 @@ __global__ void elastic_stress_adjoint_prepare(
     float* __restrict__ qxx,
     float* __restrict__ qzz,
     float* __restrict__ qxz,
-    float* __restrict__ qzx
+    float* __restrict__ qzx,
+    // grad_ctx is always forwarded (used only when imaging pointers below are
+    // non-null); harmless for bs/ckpt/apm callers that pass null imaging args.
+    SGradParam grad_ctx,
+    // FUSED vp/vs/rho-gradient imaging (full-mode only).  When non-null, this
+    // kernel folds in the per-step gradient correlation that the standalone
+    // calculate_grad_elastic_nobs would otherwise compute in a separate
+    // full-grid pass.  At this kernel's entry the adjoint stress AND velocity
+    // are the un-mutated post-source adjoint[it] fields (velocity is only
+    // touched later by elastic_stress_adjoint_apply), so the operands match
+    // calculate_grad_elastic_nobs exactly.  No lag: in the full backward loop
+    // calculate_grad(it) ran immediately before apply_adjoint_step(it), and
+    // both consume the same post-source adjoint[it].  All-null (bs/ckpt/apm).
+    const float* __restrict__ grad_fvx      = nullptr,  // u_forward[it]   vx
+    const float* __restrict__ grad_fvz      = nullptr,  // u_forward[it]   vz
+    const float* __restrict__ grad_fvx_prev = nullptr,  // u_forward[it+1] vx
+    const float* __restrict__ grad_fvz_prev = nullptr,  // u_forward[it+1] vz
+    const float* __restrict__ grad_vp_model = nullptr,  // vp    (B,nz,nx)
+    const float* __restrict__ grad_vs_model = nullptr,  // vs    (B,nz,nx)
+    const float* __restrict__ grad_rho_model= nullptr,  // rho   (B,nz,nx)
+    float* __restrict__ grad_vp_out         = nullptr,  // grad_vp accumulator
+    float* __restrict__ grad_vs_out         = nullptr,  // grad_vs accumulator
+    float* __restrict__ grad_rho_out        = nullptr   // grad_rho accumulator
 )
 {
     int ix = blockIdx.x * blockDim.x + threadIdx.x;
@@ -444,6 +475,46 @@ __global__ void elastic_stress_adjoint_prepare(
         f.szz[idx] = 0.f;
         f.sxz[idx] = 0.f;
     }
+
+    // --- FUSED gradient imaging (full-mode only) -----------------------------
+    // Equivalent to a calculate_grad_elastic_nobs launch for this reverse step.
+    // calculate_grad skips the halo entirely (ix/iz in [halo, n-halo)); replicate
+    // that so the folded contribution is bit-identical (halo adjoint cells carry
+    // no gradient there).  bar_sxx/bar_szz/bar_sxz above already equal
+    // calculate_grad's a.sxx[idx] / bar_szz / bar_sxz (same FS-row zeroing), and
+    // f.vx[idx]/f.vz[idx] are the un-mutated post-source adjoint velocities.
+    if (grad_vp_out != nullptr &&
+        ix >= halo && ix < solver.nx - halo &&
+        iz >= halo && iz < solver.nz - halo) {
+        const float* fvx_b      = grad_fvx      + b * spatial_size;
+        const float* fvz_b      = grad_fvz      + b * spatial_size;
+        const float* fvx_prev_b = grad_fvx_prev + b * spatial_size;
+        const float* fvz_prev_b = grad_fvz_prev + b * spatial_size;
+        const float* vp_b       = grad_vp_model + b * spatial_size;
+        const float* vs_b       = grad_vs_model + b * spatial_size;
+        const float* rho_b      = grad_rho_model+ b * spatial_size;
+        float* grad_vp_b        = grad_vp_out   + b * spatial_size;
+        float* grad_vs_b        = grad_vs_out   + b * spatial_size;
+        float* grad_rho_b       = grad_rho_out  + b * spatial_size;
+
+        float fvx_x = sgradient<2, Order, X, DIFF_BACKWARD> (fvx_b, ix, 0, iz, grad_ctx);
+        float fvz_z = elastic_top_fs_sgradient_z_2d<Order, DIFF_BACKWARD>(fvz_b, ix, iz, grad_ctx, solver, true);
+        float fvx_z = elastic_top_fs_sgradient_z_2d<Order, DIFF_FORWARD> (fvx_b, ix, iz, grad_ctx, solver, false);
+        float fvz_x = sgradient<2, Order, X, DIFF_FORWARD>  (fvz_b, ix, 0, iz, grad_ctx);
+
+        float grad_lambda = (bar_sxx + bar_szz) * (fvx_x + fvz_z);
+        float grad_mu = 2*(bar_sxx * fvx_x + bar_szz * fvz_z) + bar_sxz * (fvx_z + fvz_x);
+
+        grad_vp_b[idx] += -2*rho_b[idx]*vp_b[idx]*grad_lambda* solver.dt;
+        grad_vs_b[idx] += -(-4*rho_b[idx]*vs_b[idx]*grad_lambda +
+                             2*rho_b[idx]*vs_b[idx]*grad_mu)* solver.dt;
+
+        grad_rho_b[idx] += (f.vx[idx] * (fvx_b[idx]-fvx_prev_b[idx]) +
+                            f.vz[idx] * (fvz_b[idx]-fvz_prev_b[idx])) / rho_b[idx];
+        grad_rho_b[idx] -= grad_lambda * (vp_b[idx]*vp_b[idx] - 2*vs_b[idx]*vs_b[idx])* solver.dt +
+                           grad_mu     * (vs_b[idx]*vs_b[idx]) * solver.dt;
+    }
+    // -------------------------------------------------------------------------
 
     float bar_dvx_dx = solver.dt * ((lam + 2.f * mu_) * bar_sxx + lam * bar_szz);
     float bar_dvz_dz = solver.dt * ((lam + 2.f * mu_) * bar_szz + lam * bar_sxx);

--- a/src/sweep/csrc/cuda/equations/elastic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic3d/backward.cu
@@ -171,7 +171,24 @@ void apply_adjoint_step_3d(
     ElasticCPMLPointer cpml_view,
     SGradParam grad_ctx,
     SolverContext solver,
-    ElasticAdjointWorkspaceTensor& workspace
+    ElasticAdjointWorkspaceTensor& workspace,
+    // Optional fused per-step gradient imaging (full-mode only).  When the
+    // grad_*_out accumulators are non-null, the stress-adjoint-prepare kernel
+    // folds in the calculate_grad_elastic3d_bs correlation for this reverse
+    // step (operands are the un-mutated post-source adjoint at kernel entry).
+    // Default null => behaviour byte-for-byte identical for bs/ckpt callers.
+    const float* grad_fvx       = nullptr,
+    const float* grad_fvy       = nullptr,
+    const float* grad_fvz       = nullptr,
+    const float* grad_fvx_prev  = nullptr,
+    const float* grad_fvy_prev  = nullptr,
+    const float* grad_fvz_prev  = nullptr,
+    const float* grad_vp_model  = nullptr,
+    const float* grad_vs_model  = nullptr,
+    const float* grad_rho_model = nullptr,
+    float* grad_vp_out          = nullptr,
+    float* grad_vs_out          = nullptr,
+    float* grad_rho_out         = nullptr
 )
 {
     auto adj_view = adjoint.view();
@@ -193,7 +210,12 @@ void apply_adjoint_step_3d(
         workspace.qyz_t.data_ptr<float>(),
         workspace.qzx_t.data_ptr<float>(),
         workspace.qzy_t.data_ptr<float>(),
-        workspace.qzz_t.data_ptr<float>()
+        workspace.qzz_t.data_ptr<float>(),
+        grad_ctx,
+        grad_fvx, grad_fvy, grad_fvz,
+        grad_fvx_prev, grad_fvy_prev, grad_fvz_prev,
+        grad_vp_model, grad_vs_model, grad_rho_model,
+        grad_vp_out, grad_vs_out, grad_rho_out
     );
 
     LAUNCH_3DELASTIC_STRESS_ADJOINT_APPLY(
@@ -768,39 +790,49 @@ BackwardOutput backward(const BackwardInput& in)
             );
         }
 
-        auto current_forward = make_velocity_view_3d(
-            p.u_forward.select(0, it).select(0, 0),
-            p.u_forward.select(0, it).select(0, 1),
-            p.u_forward.select(0, it).select(0, 2)
-        );
+        const float* vx_now = p.u_forward.select(0, it).select(0, 0).data_ptr<float>();
+        const float* vy_now = p.u_forward.select(0, it).select(0, 1).data_ptr<float>();
+        const float* vz_now = p.u_forward.select(0, it).select(0, 2).data_ptr<float>();
 
         const float* vx_prev = (it + 1 < p.nt) ? p.u_forward.select(0, it + 1).select(0, 0).data_ptr<float>() : zero_velocity.data_ptr<float>();
         const float* vy_prev = (it + 1 < p.nt) ? p.u_forward.select(0, it + 1).select(0, 1).data_ptr<float>() : zero_velocity.data_ptr<float>();
         const float* vz_prev = (it + 1 < p.nt) ? p.u_forward.select(0, it + 1).select(0, 2).data_ptr<float>() : zero_velocity.data_ptr<float>();
 
-        LAUNCH_CALCULATE_GRAD_3DELASTIC_BS(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            current_forward.view(),
-            adj_view,
-            vx_prev,
-            vy_prev,
-            vz_prev,
-            vp.data_ptr<float>(),
-            vs.data_ptr<float>(),
-            rho.data_ptr<float>(),
-            grad_vp.data_ptr<float>(),
-            grad_vs.data_ptr<float>(),
-            grad_rho.data_ptr<float>(),
-            grad_ctx,
-            solver
-        );
-
+        // Reverse step 0 has no adjoint apply kernel (the loop `continue`s
+        // below), so its gradient imaging cannot be folded — emit it as a
+        // standalone calculate_grad pass (mirrors the acoustic trailing call).
         if (it == 0) {
+            auto current_forward = make_velocity_view_3d(
+                p.u_forward.select(0, it).select(0, 0),
+                p.u_forward.select(0, it).select(0, 1),
+                p.u_forward.select(0, it).select(0, 2)
+            );
+            LAUNCH_CALCULATE_GRAD_3DELASTIC_BS(
+                order,
+                launch_config.grid,
+                launch_config.block,
+                current_forward.view(),
+                adj_view,
+                vx_prev,
+                vy_prev,
+                vz_prev,
+                vp.data_ptr<float>(),
+                vs.data_ptr<float>(),
+                rho.data_ptr<float>(),
+                grad_vp.data_ptr<float>(),
+                grad_vs.data_ptr<float>(),
+                grad_rho.data_ptr<float>(),
+                grad_ctx,
+                solver
+            );
             continue;
         }
 
+        // FULL-mode fusion: fold this reverse step's vp/vs/rho-gradient imaging
+        // into the stress-adjoint-prepare kernel (it reads the un-mutated
+        // post-source adjoint[it] stress+velocity at entry, exactly what
+        // calculate_grad_elastic3d_bs(it) would correlate), eliminating the
+        // separate full-grid calculate_grad launch for steps it >= 1.
         apply_adjoint_step_3d(
             order,
             launch_config,
@@ -811,7 +843,15 @@ BackwardOutput backward(const BackwardInput& in)
             cpml_view,
             grad_ctx,
             solver,
-            workspace
+            workspace,
+            vx_now, vy_now, vz_now,
+            vx_prev, vy_prev, vz_prev,
+            vp.data_ptr<float>(),
+            vs.data_ptr<float>(),
+            rho.data_ptr<float>(),
+            grad_vp.data_ptr<float>(),
+            grad_vs.data_ptr<float>(),
+            grad_rho.data_ptr<float>()
         );
     }
 

--- a/src/sweep/csrc/cuda/equations/elastic3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/elastic3d/kernels.cuh
@@ -6,6 +6,21 @@
 #include "../../common/elastic_free_surface.cuh"
 #include "../../operators/staggered.cuh"
 
+// Forward 3D stencil kernels launch with block(32,4,2)=256 threads.  Like the
+// 2D kernels they are register/occupancy-bound on V100; capping threads/block
+// at 256 and asking for minBlocks resident blocks forces lower register use
+// and lifts occupancy.  The 3D velocity/stress kernels are heavier than 2D (9
+// derivative reads + 9 CPML aux fields), so an aggressive minBlocks=8 can spill
+// — ELASTIC3D_LB_MINBLOCKS lets the build pick a milder bound (6/7) without a
+// source edit.  Math-identical: forward-only, adjoint/gradient unaffected.
+// 3D kernels are heavy (9 fields + CPML aux); minBlocks=8 forced 32 regs but
+// SPILLED (STACK:88) and regressed elastic3d forward 1.1x->0.6x on V100.  3D
+// already beats deepwave unbounded, so disable the bound for 3D (minBlocks=1 =>
+// 256-reg cap => no constraint => natural ~48 regs).  2D keeps (256,8) (a win).
+#ifndef ELASTIC3D_LB_MINBLOCKS
+#define ELASTIC3D_LB_MINBLOCKS 1
+#endif
+
 #define LAUNCH_3DELASTIC_VELOCITY(order, grid, block, ...)                     \
     do {                                                        \
         if      ((order) == 2) elastic_velocity_kernel_3d<2><<<grid, block>>>(__VA_ARGS__); \
@@ -108,7 +123,7 @@
     } while (0)
 
 template<int Order>
-__global__ void elastic_velocity_kernel_3d(
+__global__ void __launch_bounds__(256, ELASTIC3D_LB_MINBLOCKS) elastic_velocity_kernel_3d(
     ElasticWavefieldPointer wf,
     const float* __restrict__ rho,
     SGradParam grad_ctx,
@@ -237,7 +252,7 @@ __global__ void elastic_velocity_kernel_3d(
 
 
 template<int Order>
-__global__ void elastic_stress_kernel_3d(
+__global__ void __launch_bounds__(256, ELASTIC3D_LB_MINBLOCKS) elastic_stress_kernel_3d(
     ElasticWavefieldPointer wf,
     const float* __restrict__ lambda,
     const float* __restrict__ mu,
@@ -1079,7 +1094,27 @@ __global__ void elastic_stress_adjoint_prepare_3d(
     float* __restrict__ qyz,
     float* __restrict__ qzx,
     float* __restrict__ qzy,
-    float* __restrict__ qzz
+    float* __restrict__ qzz,
+    // grad_ctx always forwarded (used only when imaging pointers below are
+    // non-null); harmless for bs/ckpt/apm callers that pass null imaging args.
+    SGradParam grad_ctx,
+    // FUSED vp/vs/rho-gradient imaging (full-mode only).  Mirrors the 2-D fold:
+    // at this kernel's entry the adjoint stress AND velocity are the un-mutated
+    // post-source adjoint[it] fields, so the operands match
+    // calculate_grad_elastic3d_bs exactly (same kernel the full loop launched
+    // separately, fed the forward velocity view).  No lag.  All-null otherwise.
+    const float* __restrict__ grad_fvx      = nullptr,  // u_forward[it]   vx
+    const float* __restrict__ grad_fvy      = nullptr,  // u_forward[it]   vy
+    const float* __restrict__ grad_fvz      = nullptr,  // u_forward[it]   vz
+    const float* __restrict__ grad_fvx_prev = nullptr,  // u_forward[it+1] vx
+    const float* __restrict__ grad_fvy_prev = nullptr,  // u_forward[it+1] vy
+    const float* __restrict__ grad_fvz_prev = nullptr,  // u_forward[it+1] vz
+    const float* __restrict__ grad_vp_model = nullptr,
+    const float* __restrict__ grad_vs_model = nullptr,
+    const float* __restrict__ grad_rho_model= nullptr,
+    float* __restrict__ grad_vp_out         = nullptr,
+    float* __restrict__ grad_vs_out         = nullptr,
+    float* __restrict__ grad_rho_out        = nullptr
 )
 {
     int ix = blockIdx.x * blockDim.x + threadIdx.x;
@@ -1123,6 +1158,66 @@ __global__ void elastic_stress_adjoint_prepare_3d(
         f.sxz[idx] = 0.f;
         f.syz[idx] = 0.f;
     }
+
+    // --- FUSED gradient imaging (full-mode only) -----------------------------
+    // Equivalent to a calculate_grad_elastic3d_bs launch for this reverse step.
+    // calculate_grad skips the halo entirely; replicate so the folded
+    // contribution is bit-identical.  bar_s* above already match
+    // calculate_grad's a.sxx[idx]/a.syy[idx]/bar_szz/a.sxy[idx]/bar_sxz/bar_syz,
+    // and f.vx/vy/vz[idx] are the un-mutated post-source adjoint velocities.
+    {
+        constexpr bool is_runtime_g = (Order == -1);
+        constexpr int  M_static_g   = is_runtime_g ? 0 : (Order / 2);
+        int halo_g = is_runtime_g ? solver.M : M_static_g;
+        if (grad_vp_out != nullptr &&
+            ix >= halo_g && ix < solver.nx - halo_g &&
+            iy >= halo_g && iy < solver.ny - halo_g &&
+            iz >= halo_g && iz < solver.nz - halo_g) {
+            const float* fvx_b      = grad_fvx      + b * spatial_size;
+            const float* fvy_b      = grad_fvy      + b * spatial_size;
+            const float* fvz_b      = grad_fvz      + b * spatial_size;
+            const float* fvx_prev_b = grad_fvx_prev + b * spatial_size;
+            const float* fvy_prev_b = grad_fvy_prev + b * spatial_size;
+            const float* fvz_prev_b = grad_fvz_prev + b * spatial_size;
+            const float* vp_b       = grad_vp_model + b * spatial_size;
+            const float* vs_b       = grad_vs_model + b * spatial_size;
+            const float* rho_b      = grad_rho_model+ b * spatial_size;
+            float* gvp  = grad_vp_out  + b * spatial_size;
+            float* gvs  = grad_vs_out  + b * spatial_size;
+            float* grho = grad_rho_out + b * spatial_size;
+
+            float fvx_x = sgradient<3, Order, X, DIFF_BACKWARD>(fvx_b, ix, iy, iz, grad_ctx);
+            float fvx_y = sgradient<3, Order, Y, DIFF_FORWARD >(fvx_b, ix, iy, iz, grad_ctx);
+            float fvx_z = elastic3d_top_fs_sgradient_z<Order, DIFF_FORWARD >(fvx_b, ix, iy, iz, grad_ctx, solver, false);
+
+            float fvy_x = sgradient<3, Order, X, DIFF_FORWARD >(fvy_b, ix, iy, iz, grad_ctx);
+            float fvy_y = sgradient<3, Order, Y, DIFF_BACKWARD>(fvy_b, ix, iy, iz, grad_ctx);
+            float fvy_z = elastic3d_top_fs_sgradient_z<Order, DIFF_FORWARD >(fvy_b, ix, iy, iz, grad_ctx, solver, false);
+
+            float fvz_x = sgradient<3, Order, X, DIFF_FORWARD >(fvz_b, ix, iy, iz, grad_ctx);
+            float fvz_y = sgradient<3, Order, Y, DIFF_FORWARD >(fvz_b, ix, iy, iz, grad_ctx);
+            float fvz_z = elastic3d_top_fs_sgradient_z<Order, DIFF_BACKWARD>(fvz_b, ix, iy, iz, grad_ctx, solver, true);
+
+            float grad_lambda = (bar_sxx + bar_syy + bar_szz) * (fvx_x + fvy_y + fvz_z);
+            float grad_mu = 2*(bar_sxx * fvx_x +
+                               bar_syy * fvy_y +
+                               bar_szz * fvz_z) +
+                               bar_sxz * (fvx_z + fvz_x) +
+                               bar_sxy * (fvx_y + fvy_x) +
+                               bar_syz * (fvy_z + fvz_y);
+
+            gvp[idx] +=   -2*rho_b[idx]*vp_b[idx]*grad_lambda* solver.dt;
+            gvs[idx] += -(-4*rho_b[idx]*vs_b[idx]*grad_lambda +
+                           2*rho_b[idx]*vs_b[idx]*grad_mu)* solver.dt;
+
+            grho[idx] += (f.vx[idx] * (fvx_b[idx]-fvx_prev_b[idx]) +
+                          f.vy[idx] * (fvy_b[idx]-fvy_prev_b[idx]) +
+                          f.vz[idx] * (fvz_b[idx]-fvz_prev_b[idx])) / rho_b[idx];
+            grho[idx] -= grad_lambda * (vp_b[idx]*vp_b[idx] - 2*vs_b[idx]*vs_b[idx])* solver.dt +
+                         grad_mu     * (vs_b[idx]*vs_b[idx]) * solver.dt;
+        }
+    }
+    // -------------------------------------------------------------------------
 
     float bar_dvx_dx = solver.dt * (l2m * bar_sxx + lam * bar_syy + lam * bar_szz);
     float bar_dvx_dy = solver.dt * mu_ * bar_sxy;

--- a/src/sweep/csrc/shared/wavetypes.h
+++ b/src/sweep/csrc/shared/wavetypes.h
@@ -165,4 +165,10 @@ struct BackwardInput {
     int checkpoint_interval = 1;
     int checkpoint_count = 0;
 
+    // When false, skip the per-timestep source/receiver illumination (RTM-image)
+    // accumulation in backward(): it is not needed for a plain FWI vp gradient
+    // and costs ~1/3 of the backward.  The vp gradient (calculate_grad) is
+    // unaffected.  Default true = unchanged behaviour.
+    bool compute_illumination = true;
+
 };

--- a/src/sweep/propagator/_c.py
+++ b/src/sweep/propagator/_c.py
@@ -325,6 +325,15 @@ class Warpper(torch.autograd.Function):
         params.boundary_ring_buffers = ctx.boundary_ring_buffers
         params.checkpoint_interval = ctx.checkpoint_interval
         params.checkpoint_count = ctx.checkpoint_count
+        # Compute source/receiver illumination only if the caller requested it
+        # (solver.compute_illumination=True allocates a real, non-empty buffer in
+        # forward).  It is a ~1/3-of-backward extra grid pass; vp grad unaffected.
+        def _wants_illum(b):
+            return isinstance(b, torch.Tensor) and b.numel() > 0
+        params.compute_illumination = (
+            _wants_illum(getattr(ctx, "source_illumination_buffer", None))
+            or _wants_illum(getattr(ctx, "receiver_illumination_buffer", None))
+        )
         params.adjoint_wavefields = [a.zero_() for a in ctx.adjoint_wavefields]
         params.adjoint_workspace = list(ctx.adjoint_workspace)
         params.models = [m.contiguous() for m in ctx.models]
@@ -586,6 +595,11 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         self._workspace_cache_nt = None
         self.source_illumination = None
         self.receiver_illumination = None
+        # Source/receiver illumination (RTM image) is a ~1/3-of-backward extra
+        # grid pass.  Default OFF for speed; set ``solver.compute_illumination =
+        # True`` to compute it (then read it back from ``solver.source_illumination``
+        # / ``solver.receiver_illumination`` after backward).
+        self.compute_illumination = False
 
     def _cuda_spacing(self):
         # PropBase stores spacing in model-axis order: (dz, dx) or (dz, dy, dx).
@@ -1220,7 +1234,7 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         requires_model_grad = any(m.requires_grad for m in models)
         requires_wavelet_grad = wavelet.requires_grad
         requires_backward = bool(requires_model_grad or requires_wavelet_grad)
-        if requires_backward:
+        if requires_backward and self.compute_illumination:
             self.source_illumination = torch.zeros_like(unpadded_models[0])
             self.receiver_illumination = torch.zeros_like(unpadded_models[0])
         else:

--- a/src/sweep/propagator/torch.py
+++ b/src/sweep/propagator/torch.py
@@ -345,6 +345,19 @@ class PropTorch(torch.nn.Module):
             backend_impl = super().__getattr__("_backend_impl")
             return getattr(backend_impl, name)
 
+    # Illumination controls/outputs live on the backend; delegate writes so that
+    # ``solver.compute_illumination = True`` (and the source/receiver illumination
+    # buffers) reach it.  Reads already delegate via __getattr__.
+    _BACKEND_DELEGATED = ("compute_illumination", "source_illumination", "receiver_illumination")
+
+    def __setattr__(self, name, value):
+        if name in PropTorch._BACKEND_DELEGATED:
+            backend = getattr(self, "_backend_impl", None)  # in self._modules once set
+            if backend is not None:
+                setattr(backend, name, value)
+                return
+        super().__setattr__(name, value)
+
     def parameters(self):
         return self._backend_impl.parameters()
 


### PR DESCRIPTION
Fuses the vp-gradient imaging (RTM correlation) into the exact discrete-adjoint kernel for acoustic and elastic, plus related backward cleanups. Same `calculate_grad` math, just no separate imaging pass.

## Commits
- `9cbe3e0` make backward **illumination opt-in** (`compute_illumination`, default OFF). Source/receiver illumination (RTM image, ~1/3 of the backward) was accumulated for every gradient even when unused.
- `ff46fea` **fuse vp-gradient imaging into the adjoint kernel** (no separate `calculate_grad` pass).
- `4daf10d` drop redundant interior aux zero-writes in the adjoint.
- `5449ade` fuse `d(a·psi)` CPML term into the exact adjoint (transpose pulls `a` to the centre; `daxdx/dazdz` no longer needed).
- `b39bb4b` elastic: fuse grad imaging into adjoint + 2D forward `launch_bounds`.

## Correctness (bit-preserved)
`test/solver_gradient_mode_suite.py` passes for acoustic 2D/3D + elastic 2D/3D × {full, bs_gpu, ckpt} × {interior, fd_edge, free_surface}: full(fused) vs eager-autograd `cos=1.000` (rel_l2 ≤ 2e-4); the untouched boundary/checkpoint paths match `full` to ~machine eps. `vp`/`vs`/`rho` all covered. The `19_fwi_boundary_dtype` doc notebook reproduces the same FWI result (RMSE 357.3 → 304.1) on this build.

## Performance (RTX 6000 Ada, fwd + loss + backward)
- store-all backward **1.5–2.4×** faster: acoustic2d 2048²×1 484→200 ms, 1024²×8 1269→651 ms; 3D 192³×1 1154→753 ms.
- boundary-saving backward ~**1.15×**; default backward ~**1.4×** from the illumination opt-in alone.
- Same-algorithm (store-all) gap vs deepwave `storage_mode=device` narrows from up to 3.8× to 1.05–1.59× (2D) and sweep faster in 3D (192³).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
