### PR TITLE
fix(acoustic): honor compute_illumination in bs/ckpt backward

### DIFF
--- a/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
@@ -470,14 +470,20 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
         boundary_runtime.prefetch_next_backward_chunk_if_needed(it, p.nt);
 
-        accumulate_rtm_image_2d<<<launch_config.grid, launch_config.block>>>(
-            forward.u_now_t.data_ptr<float>(),
-            adjoint.u_now_t.data_ptr<float>(),
-            illumination.image.data_ptr<float>(),
-            illumination.source_illumination.data_ptr<float>(),
-            illumination.receiver_illumination.data_ptr<float>(),
-            nx, nz
-        );
+        // Gate illumination on compute_illumination (mirror FULL path). When off,
+        // skip the per-step RTM pass entirely; the FWI vp-gradient is produced by
+        // calculate_grad_utt above and is unaffected. Previously this BS path ran
+        // it every step regardless, so the flag was ignored (no time saved).
+        if (in.compute_illumination) {
+            accumulate_rtm_image_2d<<<launch_config.grid, launch_config.block>>>(
+                forward.u_now_t.data_ptr<float>(),
+                adjoint.u_now_t.data_ptr<float>(),
+                illumination.image.data_ptr<float>(),
+                illumination.source_illumination.data_ptr<float>(),
+                illumination.receiver_illumination.data_ptr<float>(),
+                nx, nz
+            );
+        }
 
     }
 
@@ -947,7 +953,9 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
                 adjoint.u_now_t.data_ptr<float>(),
                 vp,
                 &grad,
-                &illumination,
+                // Gate illumination on compute_illumination (mirror FULL path);
+                // accumulate_imaging_2d skips the RTM kernel when rtm_out==nullptr.
+                in.compute_illumination ? &illumination : nullptr,
                 nx,
                 nz,
                 dt
@@ -1079,7 +1087,8 @@ BackwardOutput backward_recursive_ckpt(const BackwardInput& in)
             vp,
             &grad,
             &grad_wavelet,
-            &illumination,
+            // Gate illumination on compute_illumination (see BS path above).
+            in.compute_illumination ? &illumination : nullptr,
             order,
             launch_config.grid,
             launch_config.block,

--- a/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
@@ -856,7 +856,13 @@ BackwardOutput backward_bs_imaging_impl(const BackwardInput& p)
     auto grad_wavelet = torch::zeros_like(p.forward_source);
     RTMOutput illumination;
     init_rtm_output_3d(illumination, p.models[0]);
-    run_bs_imaging(p, &grad, &grad_wavelet, &illumination);
+    // Gate illumination on compute_illumination (mirror the FULL path). When
+    // off, accumulate_imaging_utt_3d skips the per-step RTM kernel because
+    // rtm_out==nullptr; the buffer stays zero. Previously this BS path passed
+    // &illumination unconditionally, so the RTM pass ran every step and the
+    // flag was ignored (no time saved, illumination computed then discarded).
+    run_bs_imaging(p, &grad, &grad_wavelet,
+                   p.compute_illumination ? &illumination : nullptr);
     out.grads = {grad_wavelet, grad};
     out.source_illumination = illumination.source_illumination;
     out.receiver_illumination = illumination.receiver_illumination;
@@ -1039,7 +1045,9 @@ BackwardOutput backward_ckpt_imaging_impl(const BackwardInput& p)
     auto grad_wavelet = torch::zeros_like(p.forward_source);
     RTMOutput illumination;
     init_rtm_output_3d(illumination, p.models[0]);
-    run_ckpt_imaging(p, &grad, &grad_wavelet, &illumination);
+    // Gate illumination on compute_illumination (see BS path above).
+    run_ckpt_imaging(p, &grad, &grad_wavelet,
+                     p.compute_illumination ? &illumination : nullptr);
     out.grads = {grad_wavelet, grad};
     out.source_illumination = illumination.source_illumination;
     out.receiver_illumination = illumination.receiver_illumination;
@@ -1200,7 +1208,9 @@ BackwardOutput backward_recursive_imaging_impl(const BackwardInput& p)
     auto grad_wavelet = torch::zeros_like(p.forward_source);
     RTMOutput illumination;
     init_rtm_output_3d(illumination, p.models[0]);
-    run_recursive_imaging(p, &grad, &grad_wavelet, &illumination);
+    // Gate illumination on compute_illumination (see BS path above).
+    run_recursive_imaging(p, &grad, &grad_wavelet,
+                          p.compute_illumination ? &illumination : nullptr);
     out.grads = {grad_wavelet, grad};
     out.source_illumination = illumination.source_illumination;
     out.receiver_illumination = illumination.receiver_illumination;


### PR DESCRIPTION
## Bug

`compute_illumination` (default `False`) was only gated on the **store-all** backward path. The **boundary-saving**, **checkpoint**, and **recursive-checkpoint** paths (both 2D and 3D) passed `&illumination` unconditionally, so the per-timestep RTM-image / source-receiver-illumination accumulation ran every step regardless of the flag. For the default pure-FWI case the illumination was computed and then discarded — wasted work.

Introduced when illumination was made opt-in: the `compute_illumination ? &illumination : nullptr` guard was added to the store-all path only; the other backward drivers were missed.

## Fix

Gate every 2D/3D backward path on `compute_illumination` (mirrors the store-all path). Where the imaging goes through a helper (`accumulate_imaging_2d` / `run_bs_imaging` / `run_ckpt_imaging` / `run_recursive_imaging`), passing `nullptr` makes the existing `rtm_out != nullptr` guard skip the RTM kernel; the boundary-saving 2D path wraps the direct `accumulate_rtm_image_2d` launch in `if (in.compute_illumination)`.

## Correctness

FWI vp-gradient is produced by `calculate_grad_utt` and is **unaffected** — illumination is a separate output. Verified on RTX 6000 Ada, acoustic 2D & 3D:

- gradient-consistency suite: boundary/ckpt vs full `rel_l2 <= 1e-7`, full vs eager `cos = 1.0` — **bit-identical**.
- flag functional test: `compute_illumination=False` → RTM kernel runs 0×, illumination returned `None`; `=True` → kernel runs every step, illumination populated (non-zero); gradient identical ON vs OFF (`rel_l2 = 0`).

## Speedup (default FWI, boundary-saving)

- acoustic2d: 2048²×1 `420 → 246 ms` (~1.7×), 1024²×8 `1290 → 912 ms` (~1.4×)
- acoustic3d: 192³×1 `1189 → 917 ms` (~1.3×)

No behavior change when illumination is explicitly requested.