### PR TITLE
feat(datasets): unified benchmark model registry

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -143,17 +143,16 @@
   -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
 }
 
-/* Bump up code-block typography across the docs. Material's default
-   ``.md-typeset pre > code`` size combined with our Inter Tight body
-   font reads too small on API pages and in notebook cells; this
-   restores parity with surrounding prose without affecting inline
-   ``<code>`` spans. */
+/* Code-block typography across the docs. Sized in px (not rem) so it is
+   immune to Material's 125% root font-size, and matches the notebook code
+   cells (`.jp-CodeMirrorEditor` is 13px) instead of being ~20% larger.
+   Does not affect inline ``<code>`` spans. */
 [data-sweep-d] .md-typeset pre > code,
 [data-sweep-d] .md-typeset .highlight pre code,
 [data-sweep-d] .md-typeset .doc-signature,
 [data-sweep-d] .md-typeset .doc-signature pre,
 [data-sweep-d] .md-typeset .doc-signature code {
-  font-size: 0.78rem;
+  font-size: 13px;
 }
 
 [data-sweep-d] .md-typeset h2 {
@@ -797,10 +796,12 @@
   font-size: 0.86em;
   padding: 0.08em 0.35em;
 }
-/* Also tighten the Parameter table cell defaults so the row height
-   matches the smaller description text. */
+/* Table cell text: match the table's own 13.5px base (line ~730) in px so
+   it is immune to Material's 125% root font-size. The previous 0.82rem
+   (= 16.4px) overrode the base and made every table — data tables and
+   mkdocstrings Parameter tables alike — read oversized. */
 [data-sweep-d] .md-typeset table:not([class]) td {
-  font-size: 0.82rem;
+  font-size: 13.5px;
 }
 [data-sweep-d] .md-typeset table:not([class]) td > code {
   font-size: 0.86em;

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -1,0 +1,163 @@
+# Datasets
+
+`sweep.datasets` gives one-line access to benchmark velocity models for FWI /
+LSRTM / RTM examples and smoke tests. Two flavours share a single registry:
+
+- **Embedded demos** — tiny base85-encoded blobs (Marmousi, Overthrust-2D) that
+  ship *inside the wheel*, so notebooks and quick-starts run with no downloads
+  and no extra dependencies.
+- **Downloadable benchmarks** — full-size public models fetched from their
+  official open-data source on first use and cached locally, each carrying its
+  own license and citation.
+
+Implementation: `src/sweep/datasets/`.
+
+## Quick start
+
+```python
+from sweep import datasets
+
+datasets.catalog()                       # print the table below
+prob = datasets.load("marmousi")         # embedded demo (offline)
+vp = prob["vp"]                          # numpy float32 array
+dh = prob["dh"]                          # grid spacing per axis
+
+full = datasets.load("overthrust", "3d-acoustic")   # downloads on first call
+```
+
+`load(name, variant=None, **kwargs)` returns a `dict`. Its keys:
+
+- **Always** — `vp` (ndarray), `dh` (per-axis spacing tuple), and the metadata
+  `name`, `variant`, `citation`, `license`.
+- **Download models** — also `dt`, `nt` (suggested time step / step count).
+- **Multi-parameter models** — extra field arrays: `marmousi2` adds `vs`, `rho`;
+  `bp-2007-tti` adds `epsilon`, `delta`, `theta`; `hess-vti` adds `epsilon`, `delta`.
+- **Model-specific** — `units` (`hess-vti`, demos), `presets` (embedded demos),
+  `geometry` (a sources/receivers dict on `marmousi:2d-acoustic`).
+
+The minimum you can rely on for any model is `vp` and `dh`.
+
+!!! note "`variant` is optional"
+    With a single variant it is inferred (`load("bp-2004")`). A multi-variant
+    name resolves to its canonical default — `load("marmousi")` and
+    `load("overthrust")` return the embedded `2d-demo`. If a name has several
+    variants and no default, omitting `variant` raises and lists the choices
+    rather than guessing.
+
+## Catalog
+
+| name | kind | grid | license |
+|---|---|---|---|
+| `marmousi` | embedded | 281×1361 @ 12.5 m | SEG open (demo) |
+| `overthrust` | embedded | 187×801 @ 25 m | CC-BY src (demo) |
+| `marmousi` | download | 2801×13601 @ 1.25 m | SEG open |
+| `overthrust` | download | 187×801×801 @ 25 m | **CC-BY-4.0** |
+| `seg-eage-salt` | download | 210×676×676 @ 20 m | **CC-BY-4.0** |
+| `marmousi2` | download | 2801×13601 @ 1.25 m | open academic |
+| `bp-2004` | download | 1911×5395 | free + attribution |
+| `bp-2007-tti` | download | 1801×12596 @ 6.25 m | courtesy of BP |
+| `hess-vti` | download | 1500×3617 @ ~7.62 m | Hess "AS IS" |
+
+Multi-parameter models return every field: `marmousi2` → `vp`/`vs`/`rho`,
+`bp-2007-tti` → `vp`/`epsilon`/`delta`/`theta`, `hess-vti` → `vp`/`epsilon`/`delta`.
+Every download entry was byte-verified against a real fetch (grid shape, value
+range, and slice image confirmed).
+
+## Downsampling
+
+Every download loader takes `downsample` — a single int (all axes) or a
+per-axis list/tuple. Multi-field models decimate all fields by the same factor.
+
+`load(...)` returns a `dict`; read the array from `["vp"]` (and `["vs"]` /
+`["rho"]` / ... for multi-parameter models) and the grid spacing from `["dh"]`:
+
+```python
+prob = datasets.load("bp-2004")     # native
+vp = prob["vp"]                     # ndarray, shape (1911, 5395)
+dh = prob["dh"]                     # (6.25, 12.5) = (dz, dx) in metres
+```
+
+!!! note "`dh` is scaled with `downsample`"
+    Decimating by a factor makes each remaining cell span that many original
+    cells, so `dh` is **multiplied by the same per-axis factor**. The physical
+    extent (`dh × n_cells`) is preserved — the model just gets coarser, not
+    smaller.
+
+```python
+datasets.load("bp-2004")["dh"]                       # (6.25, 12.5)
+datasets.load("bp-2004", downsample=2)["dh"]         # (12.5, 25.0)   ← ×2 both axes
+datasets.load("bp-2004", downsample=(2, 4))["dh"]    # (12.5, 50.0)   ← dz×2, dx×4
+datasets.load("bp-2004", downsample=(2, 4))["vp"].shape        # (956, 1349)
+datasets.load("seg-eage-salt", downsample=[1, 1, 3])["dh"]     # (20, 20, 60)  depth only
+```
+
+## Cache and dependencies
+
+Downloads are cached under `$SWEEP_DATASETS_CACHE` →
+`$XDG_CACHE_HOME/sweep-datasets` → `~/.cache/sweep-datasets`. A cached model is
+reused on the next `load` (no re-download).
+
+Parsing (SEG-Y and raw grids) is **numpy-only** — no extra parser dependency.
+Downloading needs an HTTP client:
+
+```bash
+pip install sweep-solver[datasets]     # adds requests + tqdm for downloads
+```
+
+Embedded demos need nothing beyond numpy.
+
+## CLI
+
+```bash
+sweep datasets list                       # the catalog table (or: sweep-datasets list)
+sweep datasets list marmousi              # one family
+sweep datasets info bp-2004               # one entry's full metadata
+sweep datasets download overthrust 3d-acoustic         # pre-fetch, report shape
+sweep datasets download bp-2004 --downsample 2 4       # per-axis downsample
+sweep datasets where                      # print the cache directory
+```
+
+## Back-compatible helpers
+
+The original embedded-model API is preserved, so existing notebooks keep
+working unchanged:
+
+```python
+from sweep.datasets import load_marmousi, MARMOUSI_DH
+
+vp = load_marmousi("vp_true")        # bare ndarray; presets: {vp,vs,rho}_{true,smooth,linear}
+vs = load_marmousi("vs_smooth")
+print(MARMOUSI_DH)                   # 12.5
+```
+
+## Licensing
+
+Each entry prints its citation and license on first load, and carries a
+`redistributable` flag (`True` only when the license permits re-hosting the
+bytes, e.g. CC-BY-4.0). For "free download + attribution / AS-IS" models the
+loader fetches from the official source and never re-hosts the data.
+
+!!! warning "Intentionally not bundled"
+    - **Sigsbee2A/2B** — gated behind a signed Data Release Agreement; original
+      host is dead.
+    - **SEAM Phase I** — license ambiguous across sources (CC-BY vs
+      CC-BY-NC-SA) and no verifiable direct URL.
+    - **OpenFWI** — datasets are CC BY-NC-SA 4.0 (non-commercial), incompatible
+      with a permissive package; use the upstream `openfwi-lanl` tooling.
+
+## Registering your own model
+
+```python
+from sweep.datasets import Entry, register
+
+def _load_foo():
+    return {"vp": my_array, "dh": (10.0, 10.0), "dt": 0.001, "nt": 2000}
+
+register(Entry(
+    name="foo", variant="2d-acoustic", loader=_load_foo,
+    description="...", citation="...", license="...",
+    kind="download", redistributable=False, tags=["2d", "acoustic"],
+))
+```
+
+See also [CLI](cli.md) and the [Quick Start](../getting-started/quickstart.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
       - Equations: user-guide/equations.md
       - Operators: user-guide/operators.md
       - Propagators: user-guide/propagators.md
+      - Datasets: user-guide/datasets.md
       - Extending: user-guide/extending.md
       - CLI: user-guide/cli.md
   - Examples:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ cuda  = ["torch"]
 torch = ["torch"]
 jax   = ["jax", "jaxlib"]
 all   = ["torch", "jax", "jaxlib"]
+# Benchmark dataset loaders (sweep.datasets). Embedded demo models need
+# nothing extra; parsing is numpy-only. This extra only adds the HTTP client
+# used to fetch the downloadable full-size benchmarks.
+datasets = ["requests>=2.25", "tqdm>=4.60"]
 
 [project.urls]
 Homepage = "https://github.com/DeepWave-KAUST/sweep"
@@ -43,6 +47,7 @@ Issues   = "https://github.com/DeepWave-KAUST/sweep/issues"
 
 [project.scripts]
 sweep = "sweep.cli:main"
+sweep-datasets = "sweep.datasets.cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/sweep/cli.py
+++ b/src/sweep/cli.py
@@ -137,9 +137,13 @@ def main():
 
     list_parser = subparsers.add_parser('list', help='List components')
     show_parser = subparsers.add_parser('show', help='Show details for a wave equation class')
+    datasets_parser = subparsers.add_parser(
+        'datasets', help='Benchmark velocity models (list/info/download/where)')
 
     list_parser.add_argument('component', choices=['equations'], help='Component type to list')
     show_parser.add_argument('component', help='Wave equation class name to show wavefields for')
+    datasets_parser.add_argument('args', nargs=argparse.REMAINDER,
+                                 help='subcommand + args (see `sweep datasets -h`)')
 
     args = parser.parse_args()
 
@@ -149,6 +153,9 @@ def main():
     if args.command == 'show':
         list_wavefields(args.component)
         return 0
+    if args.command == 'datasets':
+        from sweep.datasets.cli import main as datasets_main
+        return datasets_main(args.args)
     parser.print_help()
     return 0
 

--- a/src/sweep/datasets/CATALOG.md
+++ b/src/sweep/datasets/CATALOG.md
@@ -1,0 +1,117 @@
+# `sweep.datasets` — benchmark model catalog
+
+Unified registry of benchmark velocity models: tiny **embedded** demo blobs
+(ship in the wheel, no network) plus **downloadable** full-size public
+benchmarks (fetched on demand, cached, license printed on first load).
+
+```python
+from sweep import datasets
+datasets.catalog()                         # print the whole table (kind/license/verified)
+datasets.available()                       # [(name, variant), ...] machine-readable
+prob = datasets.load("overthrust", "3d-acoustic")
+vp = prob["vp"]
+```
+
+**`variant` is optional.** With a sole variant it's inferred
+(`load("bp-2004")`); a multi-variant name resolves to its `default=True`
+entry (`load("marmousi")` → the embedded `2d-demo`, `load("overthrust")` →
+`2d-demo`). A name with several variants and no default would raise and list
+the choices rather than guess.
+
+Optional deps: `pip install sweep-solver[datasets]` adds the HTTP client
+(requests/tqdm) for downloads. Parsing (SEG-Y / raw grids) is numpy-only.
+
+Cache dir: `$SWEEP_DATASETS_CACHE` → `$XDG_CACHE_HOME/sweep-datasets` →
+`~/.cache/sweep-datasets`.
+
+## CLI
+
+```bash
+sweep datasets list                     # table of all datasets (or: sweep-datasets list)
+sweep datasets list marmousi            # one family
+sweep datasets info bp-2004             # one entry's metadata
+sweep datasets download overthrust 3d-acoustic          # fetch to cache, report shape
+sweep datasets download bp-2004 --downsample 2 4        # per-axis downsample
+sweep datasets where                    # print the cache directory
+```
+
+## Catalog
+
+| name | variant | kind | grid (loaded) | vp range (m/s) | license | re-host? | verified |
+|---|---|---|---|---|---|---|---|
+| `marmousi` | `2d-demo` | embedded | 281×1361 @ 12.5 m | 1028–4700 | SEG open (demo) | ✅ | ✅ |
+| `overthrust` | `2d-demo` | embedded | 187×801 @ 25 m | — | CC-BY src (demo) | ✅ | ✅ |
+| `marmousi` | `2d-acoustic` | download | 2801×13601 @ 1.25 m (native) | 1028–4700 | SEG open, cite | ➖ | ✅ |
+| `overthrust` | `3d-acoustic` | download | 187×801×801 @ 25 m | 2179–6000 | **CC-BY-4.0** | ✅ | ✅ |
+| `seg-eage-salt` | `3d-acoustic` | download | 210×676×676 (nz,ny,nx) @ 20 m | 1500–4482 | **CC-BY-4.0** | ✅ | ✅ |
+| `marmousi2` | `2d-elastic` | download | 2801×13601 @ 1.25 m (vp/vs/rho) | 1028–4700 | open academic, cite | ➖ | ✅ |
+| `bp-2004` | `2d-acoustic` | download | 1911×5395, dz6.25/dx12.5 | 1429–4790 | free+attr, AS-IS | ➖ | ✅ |
+| `bp-2007-tti` | `2d-tti` | download | 1801×12596 @ 6.25 m (vp/ε/δ/θ) | 1492–4554 | free+attr, courtesy BP | ➖ | ✅ |
+| `hess-vti` | `2d-vti` | download | 1500×3617 @ ~7.62 m (vp/ε/δ) | 1524–4511¹ | free+attr, Hess AS-IS | ➖ | ✅¹ |
+
+**re-host?** ✅ = license permits re-hosting the bytes; ➖ = fetch from official
+source only (do not vendor/re-host).
+
+**verified** ✅ = byte-verified against a real download (KW60443, 2026-07):
+shape, physical value range, and slice image confirmed for every entry.
+
+¹ **hess-vti**: the SEG-Y ships vp in **ft/s** (5000–14800) and the grid in
+feet; the loader converts vp→m/s (×0.3048) and uses dh≈7.62 m (25 ft, the
+widely-used value — confirm against your reference if dh matters).
+
+Verification notes (resolved 2026-07-06):
+- **overthrust 3d**: official SEG/EAGE 3-D Modeling Series CD (CD1 →
+  `3D-Velocity-Grid/overthrust.vites`), raw **big-endian IEEE float32**; the
+  `.vites.h` sidecar gives n1=801 n2=801 n3=187, d=25 m, m/s (n1 fastest → read
+  as C-order `(187,801,801)`). File size 479 917 548 = 801·801·187·4 confirms
+  the grid; values 2179–6000 m/s. ✅
+- **seg-eage-salt**: `tar.gz → SALTF.ZIP → Saltf@@` raw big-endian `>f4`,
+  95 964 960 = 676·676·210, **x-fastest** (like `.vites`) → read as C-order
+  `(nz,ny,nx) = (210,676,676)`; range 1500–4482. (Axis order confirmed by
+  slicing — a depth section shows the salt dome; the earlier `(676,676,210)`
+  scrambled it.) ✅
+- **marmousi2**: each field is a nested `.segy.tar.gz` inside the outer tarball
+  (`MODEL_{P-WAVE,S-WAVE,DENSITY}_VELOCITY_1.25m.segy.tar.gz`); IBM-float SEG-Y,
+  read as `(nx,nz)` traces then **transposed** to `(nz,nx)`. ✅
+- **bp-2004 / bp-2007 / hess**: IBM-float SEG-Y; the reader returns
+  `(n_traces=nx, n_samples=nz)` and `read_model` **transposes** to `(nz,nx)`
+  (a flat reshape would scramble the grid — that bug was caught and fixed here).
+  bp-2007 members are `.sgy` (not `.segy`). ✅
+
+## Deliberately excluded
+
+| model | why excluded |
+|---|---|
+| **Sigsbee2A / 2B** | Gated behind a signed **Data Release Agreement**; original host (`delphi.tudelft.nl`) is dead (NXDOMAIN). Not freely redistributable. Get it from the SEG software repo under their terms. |
+| **SEAM Phase I** | License genuinely ambiguous across sources (**CC-BY-4.0 vs CC-BY-NC-SA-4.0**); official pages Cloudflare-gated so no verifiable direct URL. Do not bundle until the license inside the data package is confirmed. |
+| **OpenFWI** | Datasets are **CC BY-NC-SA 4.0** (non-commercial), incompatible with a permissive package; Google-Drive hosted (per-subset ids), so the download path can't be auto-verified. Use the upstream `openfwi-lanl` tooling directly. |
+
+## Adding a model
+
+Register an `Entry` (see `_benchmarks.py`):
+
+```python
+from sweep.datasets import Entry, register
+register(Entry(
+    name="foo", variant="2d-acoustic", loader=_load_foo,
+    description="...", citation="...", license="...",
+    kind="download", redistributable=False, tags=["2d", "acoustic"],
+))
+```
+
+Loaders return a dict with at least `vp` and `dh`; most add `dt`, `nt`,
+`geometry`, and (for multi-parameter models) `vs`/`rho`/`epsilon`/`delta`/etc.
+
+## Downsampling
+
+Every download loader takes `downsample`, either a single int (applied to all
+axes) or a per-axis list/tuple; `dh` is scaled per axis to match. Multi-field
+models (marmousi2, bp-2007-tti, hess-vti) decimate every field by the same
+factor. Factors must be `>= 1` and the sequence length must equal the model
+dimensionality (else `ValueError`).
+
+```python
+datasets.load("bp-2004", downsample=2)          # (956, 2698), dh (12.5, 25.0)
+datasets.load("bp-2004", downsample=(2, 4))     # (956, 1349), per-axis, dh (12.5, 50.0)
+datasets.load("seg-eage-salt", downsample=[1, 1, 3])  # decimate depth only -> (676, 676, 70)
+```

--- a/src/sweep/datasets/__init__.py
+++ b/src/sweep/datasets/__init__.py
@@ -1,10 +1,33 @@
-"""Embedded demo velocity models.
+"""Benchmark velocity models for seismic FWI / LSRTM.
 
-These ship inside the package as compact base85-encoded blobs so that the
-notebooks and quick-start examples can run without any external downloads.
-For full-size 3D models (Overthrust etc.), see
-``examples/models/overthrust/download_release_asset.py``.
+Two flavours share one registry:
+
+* **Embedded demos** — tiny base85-encoded blobs (Marmousi, Overthrust-2D)
+  that ship inside the wheel, so notebooks and quick-start examples run with
+  no downloads and no extra dependencies.
+* **Downloadable benchmarks** — full-size public models (Marmousi II,
+  Overthrust 3-D, SEG/EAGE Salt, Marmousi2 elastic, BP 2004, BP 2007 TTI,
+  Hess VTI) fetched on demand and cached, each carrying its own
+  license / citation.
+
+Unified access::
+
+    from sweep import datasets
+    print(datasets.available())                 # [(name, variant), ...]
+    prob = datasets.load("overthrust", "3d-acoustic")
+    vp = prob["vp"]
+
+Back-compatible helpers (``load_marmousi`` / ``load_overthrust_2d`` and the
+``*_DH`` / ``*_UNITS`` constants) are preserved.
+
+Optional dependency: ``pip install sweep-solver[datasets]`` adds the HTTP
+client (``requests``/``tqdm``) used to fetch the downloadable benchmarks.
+Parsing (SEG-Y / raw grids) is numpy-only — no extra parser dependency.
 """
+
+from __future__ import annotations
+
+from typing import Any
 
 from sweep.datasets.marmousi import (
     GRID_SPACING_M as MARMOUSI_DH,
@@ -12,31 +35,75 @@ from sweep.datasets.marmousi import (
     available as available_marmousi,
     load_marmousi as _load_marmousi_raw,
 )
-
-
-_MARMOUSI_ALIASES = {
-    "true":   "vp_true",
-    "smooth": "vp_smooth",
-    "linear": "vp_linear",
-}
-
-
-def load_marmousi(name="vp_true"):
-    """Load an embedded Marmousi preset as a float32 numpy array.
-
-    ``name`` is ``<field>_<kind>`` where ``field`` is ``'vp'`` / ``'vs'`` / ``'rho'``
-    and ``kind`` is ``'true'`` / ``'smooth'`` / ``'linear'``. Bare ``'true'`` /
-    ``'smooth'`` / ``'linear'`` are kept as aliases for the vp variants.
-    """
-    return _load_marmousi_raw(_MARMOUSI_ALIASES.get(name, name))
 from sweep.datasets.overthrust_2d import (
     GRID_SPACING_M as OVERTHRUST_2D_DH,
     UNITS as OVERTHRUST_2D_UNITS,
     available as available_overthrust_2d,
     load_overthrust_2d,
 )
+from sweep.datasets.registry import Entry, available, catalog, info, load, register
+
+
+_MARMOUSI_ALIASES = {
+    "true": "vp_true",
+    "smooth": "vp_smooth",
+    "linear": "vp_linear",
+}
+
+
+def load_marmousi(name: str = "vp_true"):
+    """Load an embedded Marmousi preset as a float32 numpy array.
+
+    ``name`` is ``<field>_<kind>`` where ``field`` is ``'vp'`` / ``'vs'`` /
+    ``'rho'`` and ``kind`` is ``'true'`` / ``'smooth'`` / ``'linear'``. Bare
+    ``'true'`` / ``'smooth'`` / ``'linear'`` are aliases for the vp variants.
+    """
+    return _load_marmousi_raw(_MARMOUSI_ALIASES.get(name, name))
+
+
+# ---------------------------------------------------------------- embedded
+# Register the embedded demos as first-class registry entries so a single
+# ``load(...)`` covers both demo blobs and downloadable benchmarks.
+def _embedded_marmousi(*, name: str = "vp_true") -> dict[str, Any]:
+    vp = load_marmousi(name)
+    dh = (MARMOUSI_DH, MARMOUSI_DH)
+    return {"vp": vp, "dh": dh, "units": MARMOUSI_UNITS, "presets": available_marmousi()}
+
+
+def _embedded_overthrust2d(*, name: str = "true") -> dict[str, Any]:
+    vp = load_overthrust_2d(name)
+    dh = (OVERTHRUST_2D_DH, OVERTHRUST_2D_DH)
+    return {"vp": vp, "dh": dh, "units": OVERTHRUST_2D_UNITS, "presets": available_overthrust_2d()}
+
+
+register(Entry(
+    name="marmousi", variant="2d-demo", loader=_embedded_marmousi,
+    description="Embedded Marmousi demo (vp/vs/rho x true/smooth/linear, 281x1361).",
+    citation="Versteeg (1994), DOI 10.1190/1.1437051",
+    license="Derived demo of SEG open data — bundled for quick-start use.",
+    kind="embedded", redistributable=True, default=True, tags=["2d", "demo", "embedded"],
+))
+register(Entry(
+    name="overthrust", variant="2d-demo", loader=_embedded_overthrust2d,
+    description="Embedded Overthrust-2D demo slice (true/smooth, 187x801).",
+    citation="Aminzadeh, Brac, Kunz (1997), SEG/EAGE 3-D Modeling Series No. 1",
+    license="Derived demo (CC-BY-4.0 source) — bundled for quick-start use.",
+    kind="embedded", redistributable=True, default=True, tags=["2d", "demo", "embedded"],
+))
+
+# Side-effect import: registers all downloadable benchmark entries.
+from sweep.datasets import _benchmarks as _benchmarks  # noqa: E402,F401
+
 
 __all__ = [
+    # unified registry API
+    "Entry",
+    "register",
+    "available",
+    "catalog",
+    "info",
+    "load",
+    # back-compat embedded helpers
     "MARMOUSI_DH",
     "MARMOUSI_UNITS",
     "available_marmousi",

--- a/src/sweep/datasets/_benchmarks.py
+++ b/src/sweep/datasets/_benchmarks.py
@@ -1,0 +1,280 @@
+"""Downloadable full-size benchmark velocity models.
+
+Every entry here fetches from the *official* open-data source on first use
+and caches under ``sweep.datasets._cache.cache_root()``. License / usage
+terms are attached to each :class:`~sweep.datasets.registry.Entry` and printed
+on first load.
+
+Licensing summary (see the package README for the full audit):
+
+* ``overthrust`` / ``seg-eage-salt``  — CC-BY-4.0 (freely redistributable).
+* ``marmousi`` / ``marmousi2``        — public academic open data, cite.
+* ``bp-2004`` / ``bp-2007-tti`` / ``hess-vti`` — free download + attribution,
+  "AS IS" terms; fetched from the official source, never re-hosted.
+
+Not included:
+
+* Sigsbee2A/2B — gated behind a signed Data Release Agreement, original host
+  dead.
+* SEAM Phase I — license ambiguous (CC-BY vs CC-BY-NC-SA), Cloudflare-gated.
+* OpenFWI — CC BY-NC-SA 4.0 (non-commercial), Google-Drive hosted; incompatible
+  with a permissive package and its download path could not be auto-verified.
+
+Every loader here has been byte-verified against a real download (grid shape,
+value range, and slice image confirmed).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+
+from . import _cache, _formats
+from .registry import Entry, register
+
+
+# ======================================================================
+# Marmousi II (full acoustic vp) — public open data, cite.
+# vp is taken from the verified elastic-marmousi tarball (the standalone
+# open.source.geoscience vp npy 403s), native 2801 (z) x 13601 (x) @ 1.25 m.
+# Returns the native grid by default (like every other download entry); use
+# downsample=N to coarsen, or the `2d-demo` variant for a small quick blob.
+# ======================================================================
+def _load_marmousi_full(*, downsample: "int | Sequence[int]" = 1) -> dict[str, Any]:
+    tgz = _cache.download(_MARMOUSI2_URL, _cache.cache_path("marmousi2", "elastic-marmousi-model.tar.gz"))
+    workdir = _cache.cache_root() / "marmousi2"
+    segy = _formats.extract_nested_tar_segy(tgz, _MARMOUSI2_MEMBERS["vp"], workdir)
+    vp = _formats.read_model(segy, shape=_MARMOUSI2_SHAPE)  # (nz, nx) via transpose
+    vp, fac = _formats.decimate(vp, downsample)
+    nz, nx = vp.shape
+    dh = (1.25 * fac[0], 1.25 * fac[1])
+    dt, nt = 0.001, 4000
+    sources = np.stack(
+        [np.linspace(0, nx - 1, 8, dtype="int64"), np.zeros(8, dtype="int64")], axis=1
+    )
+    receivers = np.broadcast_to(
+        np.stack([np.arange(nx, dtype="int64"), np.zeros(nx, dtype="int64")], axis=1),
+        (sources.shape[0], nx, 2),
+    ).copy()
+    geometry = {"sources": sources, "receivers": receivers, "dt": dt, "nt": nt, "dh": dh}
+    return {"vp": vp, "dh": dh, "dt": dt, "nt": nt, "geometry": geometry}
+
+
+# ======================================================================
+# SEG/EAGE Overthrust 3D — CC-BY-4.0. Official SEG/EAGE 3-D Modeling Series
+# CD (open.source.geoscience). CD1 holds 3D-Velocity-Grid/overthrust.vites, a
+# raw big-endian IEEE float32 grid; the ``.vites.h`` sidecar gives
+# n1=801 n2=801 n3=187, d=25 m, esize=4, m/s (n1 is the fastest axis).
+# ======================================================================
+_OVERTHRUST_URL = (
+    "https://s3.amazonaws.com/open.source.geoscience/open_data/"
+    "seg_eage_models_cd/Overthrust_3D_CD1.tar.gz"
+)
+_OVERTHRUST_SHAPE = (187, 801, 801)  # (n3=z, n2=y, n1=x); n1 fastest -> C-order
+
+
+def _load_overthrust_3d(*, downsample: "int | Sequence[int]" = 1) -> dict[str, Any]:
+    tgz = _cache.download(_OVERTHRUST_URL, _cache.cache_path("overthrust", "Overthrust_3D_CD1.tar.gz"))
+    workdir = _cache.cache_root() / "overthrust"
+    vites = _formats.extract_tar_member(tgz, "3D-Velocity-Grid/overthrust.vites", workdir)
+    vp = np.fromfile(vites, dtype=">f4").astype("float32").reshape(_OVERTHRUST_SHAPE)
+    vp, fac = _formats.decimate(vp, downsample)
+    dh = tuple(25.0 * f for f in fac)
+    return {"vp": vp, "dh": dh, "dt": 0.002, "nt": 3000}
+
+
+# ======================================================================
+# SEG/EAGE Salt 3D — CC-BY-4.0. tar.gz -> VEL_GRIDS/SALTF.ZIP -> raw binary.
+# SALTF is a raw big-endian float32 grid, x-fastest (like Overthrust's
+# .vites): 676(x) x 676(y) x 210(z) @ 20 m -> read as C-order (nz, ny, nx).
+# ======================================================================
+_SALT_URL = (
+    "https://s3.amazonaws.com/open.source.geoscience/open_data/"
+    "seg_eage_models_cd/Salt_Model_3D.tar.gz"
+)
+_SALT_SHAPE = (210, 676, 676)  # (nz, ny, nx); SALTF stored x-fastest
+
+
+def _load_seg_eage_salt(*, dtype: str = ">f4", downsample: "int | Sequence[int]" = 1) -> dict[str, Any]:
+    tgz = _cache.download(_SALT_URL, _cache.cache_path("seg_eage_salt", "Salt_Model_3D.tar.gz"))
+    workdir = _cache.cache_root() / "seg_eage_salt"
+    saltf_zip = _formats.extract_tar_member(tgz, "SALTF.ZIP", workdir)
+    saltf = _formats.extract_zip_member(saltf_zip, "Saltf@@", workdir)
+    vp = np.fromfile(saltf, dtype=np.dtype(dtype)).astype("float32")
+    vp = vp.reshape(_SALT_SHAPE)  # (nz, ny, nx), x-fastest
+    vp, fac = _formats.decimate(vp, downsample)
+    dh = tuple(20.0 * f for f in fac)
+    return {"vp": vp, "dh": dh, "dt": 0.002, "nt": 3000}
+
+
+# ======================================================================
+# Marmousi2 elastic (Martin et al. 2006) — public open data, cite.
+# tar.gz of vp/vs/density SEG-Y. Native 2801 (z) x 13601 (x) @ 1.25 m.
+# ======================================================================
+_MARMOUSI2_URL = (
+    "https://s3.amazonaws.com/open.source.geoscience/open_data/"
+    "elastic-marmousi/elastic-marmousi-model.tar.gz"
+)
+_MARMOUSI2_SHAPE = (2801, 13601)  # (nz, nx); SEG-Y is (nx, nz) traces, transposed on read
+_MARMOUSI2_MEMBERS = {  # each is a nested .segy.tar.gz inside the outer tarball
+    "vp": "MODEL_P-WAVE_VELOCITY_1.25m.segy.tar.gz",
+    "vs": "MODEL_S-WAVE_VELOCITY_1.25m.segy.tar.gz",
+    "rho": "MODEL_DENSITY_1.25m.segy.tar.gz",
+}
+
+
+def _load_marmousi2(*, fields=("vp", "vs", "rho"), downsample: "int | Sequence[int]" = 1) -> dict[str, Any]:
+    tgz = _cache.download(_MARMOUSI2_URL, _cache.cache_path("marmousi2", "elastic-marmousi-model.tar.gz"))
+    workdir = _cache.cache_root() / "marmousi2"
+    fac = _formats.normalize_downsample(downsample, 2)
+    out: dict[str, Any] = {}
+    for fld in fields:
+        segy = _formats.extract_nested_tar_segy(tgz, _MARMOUSI2_MEMBERS[fld], workdir)
+        arr = _formats.read_model(segy, shape=_MARMOUSI2_SHAPE)
+        out[fld], _ = _formats.decimate(arr, fac)
+    dh = (1.25 * fac[0], 1.25 * fac[1])
+    out.update(dh=dh, dt=0.001, nt=5000)
+    return out
+
+
+# ======================================================================
+# BP 2004 velocity benchmark — free download + attribution ("AS IS").
+# vel_z6.25m_x12.5m_exact.segy.gz. Grid 1911 (z) x 5395 (x), dz=6.25 dx=12.5.
+# ======================================================================
+_BP2004_URL = (
+    "https://s3.amazonaws.com/open.source.geoscience/open_data/"
+    "bpvelanal2004/vel_z6.25m_x12.5m_exact.segy.gz"
+)
+_BP2004_SHAPE = (1911, 5395)  # (nz, nx)
+
+
+def _load_bp2004(*, downsample: "int | Sequence[int]" = 1) -> dict[str, Any]:
+    gz = _cache.download(_BP2004_URL, _cache.cache_path("bp2004", "vel_z6.25m_x12.5m_exact.segy.gz"))
+    segy = _formats.gunzip(gz, _cache.cache_path("bp2004", "vel_z6.25m_x12.5m_exact.segy"))
+    vp = _formats.read_model(segy, shape=_BP2004_SHAPE)
+    vp, fac = _formats.decimate(vp, downsample)
+    dh = (6.25 * fac[0], 12.5 * fac[1])
+    return {"vp": vp, "dh": dh, "dt": 0.001, "nt": 6000}
+
+
+# ======================================================================
+# BP 2007 TTI anisotropic benchmark — free download, courtesy of BP.
+# ModelParams.tar.gz of vp/epsilon/delta/theta SEG-Y. Grid 1801 x 12596 @ 6.25 m.
+# ======================================================================
+_BP2007_URL = (
+    "https://s3.amazonaws.com/open.source.geoscience/open_data/"
+    "bptti2007/ModelParams.tar.gz"
+)
+_BP2007_SHAPE = (1801, 12596)  # (nz, nx); SEG-Y traces are (nx, nz), transposed on read
+_BP2007_MEMBERS = {
+    "vp": "Vp_Model.sgy",
+    "epsilon": "Epsilon_Model.sgy",
+    "delta": "Delta_Model.sgy",
+    "theta": "Theta_Model.sgy",
+}
+
+
+def _load_bp2007_tti(*, fields=("vp", "epsilon", "delta", "theta"), downsample: "int | Sequence[int]" = 1) -> dict[str, Any]:
+    tgz = _cache.download(_BP2007_URL, _cache.cache_path("bp2007tti", "ModelParams.tar.gz"))
+    workdir = _cache.cache_root() / "bp2007tti"
+    fac = _formats.normalize_downsample(downsample, 2)
+    out: dict[str, Any] = {}
+    for fld in fields:
+        segy = _formats.extract_tar_member(tgz, _BP2007_MEMBERS[fld], workdir)
+        arr = _formats.read_model(segy, shape=_BP2007_SHAPE)
+        out[fld], _ = _formats.decimate(arr, fac)
+    dh = (6.25 * fac[0], 6.25 * fac[1])
+    out.update(dh=dh, dt=0.001, nt=8000)
+    return out
+
+
+# ======================================================================
+# Hess VTI — free download, Hess "AS IS" terms.
+# timodel_{vp,epsilon,delta}.segy.gz. Decimated grid 1800 (x) x 750 (z) @ ~10 m.
+# ======================================================================
+_HESS_BASE = "https://s3.amazonaws.com/open.source.geoscience/open_data/hessvti/"
+_HESS_MEMBERS = {
+    "vp": "timodel_vp.segy.gz",
+    "epsilon": "timodel_epsilon.segy.gz",
+    "delta": "timodel_delta.segy.gz",
+}
+_HESS_SHAPE = (1500, 3617)  # (nz, nx); real SEG-Y is 3617 traces x 1500 samples
+
+
+_FT_TO_M = 0.3048
+
+
+def _load_hess_vti(*, fields=("vp", "epsilon", "delta"), downsample: "int | Sequence[int]" = 1) -> dict[str, Any]:
+    fac = _formats.normalize_downsample(downsample, 2)
+    out: dict[str, Any] = {}
+    for fld in fields:
+        member = _HESS_MEMBERS[fld]
+        gz = _cache.download(_HESS_BASE + member, _cache.cache_path("hessvti", member))
+        segy = _formats.gunzip(gz, _cache.cache_path("hessvti", member[:-3]))
+        arr = _formats.read_model(segy, shape=_HESS_SHAPE)
+        if fld == "vp":
+            arr = arr * _FT_TO_M  # Hess vp ships in ft/s -> convert to m/s
+        out[fld], _ = _formats.decimate(arr, fac)
+    # Grid spacing ships in feet; ~25 ft ≈ 7.62 m is the widely-used value.
+    dh = (25.0 * _FT_TO_M * fac[0], 25.0 * _FT_TO_M * fac[1])
+    out.update(dh=dh, dt=0.001, nt=6000, units="m/s")
+    return out
+
+
+# ======================================================================
+# Registration
+# ======================================================================
+def _register_all() -> None:
+    register(Entry(
+        name="marmousi", variant="2d-acoustic", loader=_load_marmousi_full,
+        description="Marmousi II 2-D acoustic vp (full size).",
+        citation="Versteeg (1994), DOI 10.1190/1.1437051",
+        license="Public / open (SEG open data) — cite the paper.",
+        kind="download", redistributable=True, tags=["2d", "acoustic", "classic"],
+    ))
+    register(Entry(
+        name="overthrust", variant="3d-acoustic", loader=_load_overthrust_3d,
+        description="SEG/EAGE Overthrust 3-D acoustic vp (801x801x187 @ 25 m).",
+        citation="Aminzadeh, Brac, Kunz (1997), SEG/EAGE 3-D Modeling Series No. 1",
+        license="CC-BY-4.0",
+        kind="download", redistributable=True, tags=["3d", "acoustic", "classic"],
+    ))
+    register(Entry(
+        name="seg-eage-salt", variant="3d-acoustic", loader=_load_seg_eage_salt,
+        description="SEG/EAGE Salt 3-D acoustic vp (SALTF grid, 676x676x210).",
+        citation="Aminzadeh, Brac, Kunz (1997), SEG/EAGE 3-D Modeling Series No. 1",
+        license="CC-BY-4.0",
+        kind="download", redistributable=True, tags=["3d", "acoustic", "salt"],
+    ))
+    register(Entry(
+        name="marmousi2", variant="2d-elastic", loader=_load_marmousi2,
+        description="Marmousi2 elastic vp/vs/rho (AGL, 2801x13601 @ 1.25 m).",
+        citation="Martin, Wiley, Marfurt (2006), DOI 10.1190/1.2172306",
+        license="Public academic open data (AGL/Univ. Houston) — cite the paper.",
+        kind="download", redistributable=False, tags=["2d", "elastic"],
+    ))
+    register(Entry(
+        name="bp-2004", variant="2d-acoustic", loader=_load_bp2004,
+        description="BP 2004 velocity benchmark vp (1911x5395, dz=6.25 dx=12.5).",
+        citation="Billette & Brandsberg-Dahl (2005), 67th EAGE, B035",
+        license="Free download + attribution; provided AS IS (acknowledge BP).",
+        kind="download", redistributable=False, tags=["2d", "acoustic", "salt"],
+    ))
+    register(Entry(
+        name="bp-2007-tti", variant="2d-tti", loader=_load_bp2007_tti,
+        description="BP 2007 TTI benchmark vp/epsilon/delta/theta (1801x12596 @ 6.25 m).",
+        citation="Shah (2007), 70th EAGE workshop; courtesy of BP",
+        license="Free download + attribution; courtesy of BP Exploration.",
+        kind="download", redistributable=False, tags=["2d", "tti", "anisotropic"],
+    ))
+    register(Entry(
+        name="hess-vti", variant="2d-vti", loader=_load_hess_vti,
+        description="Hess VTI benchmark vp/epsilon/delta (1500x3617 @ ~7.62 m).",
+        citation="Hess Corporation, SEG/Hess VTI benchmark (distributed via SEG)",
+        license="Free download + attribution; Hess AS IS terms.",
+        kind="download", redistributable=False, tags=["2d", "vti", "anisotropic"],
+    ))
+
+
+_register_all()

--- a/src/sweep/datasets/_cache.py
+++ b/src/sweep/datasets/_cache.py
@@ -1,0 +1,94 @@
+"""Cache directory resolution and download helpers.
+
+``requests`` and ``tqdm`` are imported lazily inside :func:`download` so that
+importing ``sweep.datasets`` (and loading the embedded demo models) never
+requires them. Install them with ``pip install sweep-solver[datasets]``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+
+def cache_root() -> Path:
+    """Resolve the cache directory.
+
+    Honors ``SWEEP_DATASETS_CACHE`` (preferred) or the legacy
+    ``SWEEP_ZOO_CACHE``, then falls back to ``$XDG_CACHE_HOME/sweep-datasets``
+    (or ``~/.cache/sweep-datasets``).
+    """
+    env = os.environ.get("SWEEP_DATASETS_CACHE") or os.environ.get("SWEEP_ZOO_CACHE")
+    if env:
+        root = Path(env)
+    else:
+        xdg = os.environ.get("XDG_CACHE_HOME")
+        root = Path(xdg or Path.home() / ".cache") / "sweep-datasets"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def cache_path(name: str, filename: str) -> Path:
+    """Return the cached path for ``<cache>/<name>/<filename>``."""
+    p = cache_root() / name / filename
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def download(
+    url: str,
+    dest: Path,
+    *,
+    sha256: str | None = None,
+    chunk_size: int = 1 << 20,
+) -> Path:
+    """Stream-download ``url`` to ``dest`` with a progress bar.
+
+    If ``dest`` exists and its sha256 matches (or no sha256 is given), the
+    download is skipped. ``requests``/``tqdm`` are imported lazily here.
+    """
+    dest = Path(dest)
+    if dest.exists() and sha256 is not None:
+        if _sha256(dest) == sha256:
+            return dest
+    elif dest.exists() and sha256 is None:
+        return dest
+
+    try:
+        import requests
+        from tqdm.auto import tqdm
+    except ImportError as e:  # pragma: no cover - trivial guard
+        raise ImportError(
+            "Downloading benchmark models needs `requests` and `tqdm`. "
+            "Install with `pip install sweep-solver[datasets]`."
+        ) from e
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    with requests.get(url, stream=True, timeout=60) as r:
+        r.raise_for_status()
+        total = int(r.headers.get("Content-Length") or 0)
+        with open(tmp, "wb") as f, tqdm(
+            total=total, unit="B", unit_scale=True, desc=dest.name
+        ) as pbar:
+            for chunk in r.iter_content(chunk_size=chunk_size):
+                if not chunk:
+                    continue
+                f.write(chunk)
+                pbar.update(len(chunk))
+    if sha256 is not None:
+        got = _sha256(tmp)
+        if got != sha256:
+            tmp.unlink(missing_ok=True)
+            raise IOError(f"{dest.name}: sha256 mismatch (got {got}, want {sha256})")
+    os.replace(tmp, dest)
+    return dest

--- a/src/sweep/datasets/_formats.py
+++ b/src/sweep/datasets/_formats.py
@@ -1,0 +1,264 @@
+"""Decompression + model-file parsing helpers for the download benchmarks.
+
+The public open-data benchmarks ship in a zoo of formats — raw big-endian
+grids, gzipped SEG-Y, tarballs of (nested) SEG-Y, and raw binary inside a
+nested ZIP. This module centralises the "get a float32 ndarray out of
+whatever was downloaded" logic. It is **numpy-only** (a self-contained SEG-Y
+rev-1 reader is inlined below) so the datasets package has no parser
+dependency beyond numpy.
+"""
+
+from __future__ import annotations
+
+import gzip
+import shutil
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+_SEGY_SUFFIXES = {".segy", ".sgy"}
+
+
+def normalize_downsample(factor, ndim: int) -> tuple[int, ...]:
+    """Normalize a downsample ``factor`` to a per-axis tuple of length ``ndim``.
+
+    ``factor`` may be a single int (applied to every axis) or a per-axis
+    sequence (list/tuple) of length ``ndim``.
+    """
+    if isinstance(factor, int):
+        out = (factor,) * ndim
+    else:
+        out = tuple(int(f) for f in factor)
+    if len(out) != ndim:
+        raise ValueError(
+            f"downsample {factor!r} has {len(out)} axes but the model is {ndim}-D"
+        )
+    if any(f < 1 for f in out):
+        raise ValueError(f"downsample factors must be >= 1; got {out}")
+    return out
+
+
+def decimate(arr: np.ndarray, factor) -> tuple[np.ndarray, tuple[int, ...]]:
+    """Strided-decimate ``arr`` per axis. Returns ``(arr_out, factor_tuple)``.
+
+    ``factor`` is an int (uniform) or a per-axis sequence. The returned tuple
+    lets the caller scale grid spacing ``dh`` axis-by-axis.
+    """
+    factor = normalize_downsample(factor, arr.ndim)
+    if all(f == 1 for f in factor):
+        return arr, factor
+    sl = tuple(slice(None, None, f) for f in factor)
+    return arr[sl], factor
+
+
+# --------------------------------------------------------------- decompress
+def gunzip(src: Path, dest: Path | None = None) -> Path:
+    """Decompress a ``.gz`` file to ``dest`` (default: strip the ``.gz``).
+
+    Skips the work if ``dest`` already exists.
+    """
+    src = Path(src)
+    if dest is None:
+        dest = src.with_suffix("") if src.suffix == ".gz" else src.with_name(src.name + ".out")
+    dest = Path(dest)
+    if dest.exists():
+        return dest
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    with gzip.open(src, "rb") as fin, open(tmp, "wb") as fout:
+        shutil.copyfileobj(fin, fout, length=1 << 22)
+    tmp.replace(dest)
+    return dest
+
+
+def extract_tar_member(tar_path: Path, member_suffix: str, dest_dir: Path) -> Path:
+    """Extract the first tar member whose name ends with ``member_suffix``.
+
+    Returns the extracted file path. Skips extraction if it already exists.
+    """
+    tar_path = Path(tar_path)
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(tar_path, "r:*") as tf:
+        match = next(
+            (m for m in tf.getmembers()
+             if m.isfile() and m.name.lower().endswith(member_suffix.lower())),
+            None,
+        )
+        if match is None:
+            raise FileNotFoundError(
+                f"no member ending in {member_suffix!r} inside {tar_path.name}"
+            )
+        out = dest_dir / Path(match.name).name
+        if out.exists():
+            return out
+        with tf.extractfile(match) as fin, open(out, "wb") as fout:  # type: ignore[arg-type]
+            shutil.copyfileobj(fin, fout, length=1 << 22)
+    return out
+
+
+def extract_nested_tar_segy(outer_tar: Path, member_suffix: str, dest_dir: Path) -> Path:
+    """Two-level extraction: pull ``member_suffix`` (a ``.segy.tar.gz``) out of
+    ``outer_tar``, then untar that inner archive to its single ``.segy``/``.sgy``.
+
+    Used by Marmousi2, whose ``elastic-marmousi-model.tar.gz`` stores each model
+    parameter as its own gzipped-tar of one SEG-Y.
+    """
+    dest_dir = Path(dest_dir)
+    inner_tgz = extract_tar_member(outer_tar, member_suffix, dest_dir)
+    with tarfile.open(inner_tgz, "r:*") as tf:
+        seg = next(
+            (m for m in tf.getmembers()
+             if m.isfile() and m.name.lower().endswith((".segy", ".sgy"))),
+            None,
+        )
+        if seg is None:
+            raise FileNotFoundError(f"no .segy/.sgy inside {Path(inner_tgz).name}")
+        out = dest_dir / Path(seg.name).name
+        if out.exists():
+            return out
+        with tf.extractfile(seg) as fin, open(out, "wb") as fout:  # type: ignore[arg-type]
+            shutil.copyfileobj(fin, fout, length=1 << 22)
+    return out
+
+
+def extract_zip_member(zip_path: Path, member_suffix: str, dest_dir: Path) -> Path:
+    """Extract the first zip member whose name ends with ``member_suffix``."""
+    zip_path = Path(zip_path)
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        match = next(
+            (n for n in zf.namelist() if n.lower().endswith(member_suffix.lower())),
+            None,
+        )
+        if match is None:
+            raise FileNotFoundError(
+                f"no member ending in {member_suffix!r} inside {zip_path.name}"
+            )
+        out = dest_dir / Path(match).name
+        if out.exists():
+            return out
+        with zf.open(match) as fin, open(out, "wb") as fout:
+            shutil.copyfileobj(fin, fout, length=1 << 22)
+    return out
+
+
+# ---------------------------------------------------------------- SEG-Y read
+# Self-contained SEG-Y rev-1 reader — numpy only, no external dependency.
+_SEGY_TEXT_HEADER = 3200
+_SEGY_BIN_HEADER = 400
+_SEGY_TRACE_HEADER = 240
+# sample-format code (binary header bytes 25-26) -> bytes per sample
+_SEGY_BYTES_PER_SAMPLE = {1: 4, 2: 4, 3: 2, 5: 4, 6: 8, 8: 1}
+
+
+def _ibm_to_ieee(u32: np.ndarray) -> np.ndarray:
+    """Decode IBM 32-bit floats (uint32 bit-pattern) to IEEE float32."""
+    u32 = np.ascontiguousarray(u32, dtype=np.uint32)
+    sign = (u32 >> 31).astype(np.int8)
+    expo = ((u32 >> 24) & 0x7F).astype(np.int32)
+    mant = (u32 & 0x00FFFFFF).astype(np.float32)
+    out = np.ldexp(mant, (expo - 64) * 4 - 24).astype(np.float32)
+    return np.where(sign != 0, -out, out)
+
+
+def segy_to_array(path: Path) -> np.ndarray:
+    """Read every trace of a SEG-Y file into a ``(n_traces, n_samples)`` array.
+
+    Numpy-only SEG-Y rev-1 reader (no ``segyio`` / ``sweep-io``); handles
+    IBM/IEEE float and integer sample formats (big-endian). The caller
+    reshapes/transposes to the physical model grid.
+    """
+    import os
+    import struct
+
+    path = Path(path)
+    with open(path, "rb") as f:
+        f.seek(_SEGY_TEXT_HEADER)
+        binhdr = f.read(_SEGY_BIN_HEADER)
+    n_samples = struct.unpack(">H", binhdr[20:22])[0]
+    fmt = struct.unpack(">H", binhdr[24:26])[0]
+    if fmt not in _SEGY_BYTES_PER_SAMPLE:
+        raise NotImplementedError(f"{path.name}: SEG-Y sample format {fmt} not supported")
+    bps = _SEGY_BYTES_PER_SAMPLE[fmt]
+
+    trace_bytes = _SEGY_TRACE_HEADER + n_samples * bps
+    body = os.path.getsize(path) - _SEGY_TEXT_HEADER - _SEGY_BIN_HEADER
+    n_traces = body // trace_bytes
+
+    raw = np.memmap(
+        path, dtype=np.uint8, mode="r",
+        offset=_SEGY_TEXT_HEADER + _SEGY_BIN_HEADER,
+        shape=(n_traces, trace_bytes),
+    )
+    data = np.ascontiguousarray(raw[:, _SEGY_TRACE_HEADER:])  # drop per-trace headers
+    del raw
+    if fmt == 1:                                     # IBM float32
+        return _ibm_to_ieee(data.view(">u4").reshape(n_traces, n_samples))
+    if fmt == 5:                                     # IEEE float32
+        return data.view(">f4").reshape(n_traces, n_samples).astype(np.float32, copy=False)
+    if fmt == 6:                                     # IEEE float64
+        return data.view(">f8").reshape(n_traces, n_samples).astype(np.float32)
+    if fmt == 2:                                     # int32
+        return data.view(">i4").reshape(n_traces, n_samples).astype(np.float32)
+    if fmt == 3:                                     # int16
+        return data.view(">i2").reshape(n_traces, n_samples).astype(np.float32)
+    return data.view("i1").reshape(n_traces, n_samples).astype(np.float32)  # int8
+
+
+# --------------------------------------------------------------- dispatch
+def read_model(
+    path: Path,
+    *,
+    shape: Sequence[int] | None = None,
+    dtype: str = "float32",
+    order: str = "C",
+) -> np.ndarray:
+    """Load a model file into a float32 ndarray, dispatching by extension.
+
+    ``.segy/.sgy`` go through :func:`segy_to_array`; ``.npy/.npz`` through
+    ``numpy``; ``.bin/.raw`` are raw binary (need ``shape``). Numpy-only, no
+    external parser dependency.
+
+    For SEG-Y, ``segy_to_array`` returns ``(n_traces, n_samples) = (nx, nz)``;
+    this is **transposed** to ``(nz, nx)`` (never flat-reshaped — that would
+    scramble the grid). If ``shape`` is given it is used as a strict
+    ``(nz, nx)`` check and a mismatch raises, so a wrong assumed grid fails
+    loudly instead of returning garbage.
+    """
+    path = Path(path)
+    ext = path.suffix.lower()
+    if ext in _SEGY_SUFFIXES:
+        arr = segy_to_array(path).T  # (n_traces, n_samples) -> (nz, nx)
+        if shape is not None and tuple(arr.shape) != tuple(shape):
+            raise ValueError(
+                f"{path.name}: SEG-Y grid {arr.shape} != expected {tuple(shape)}"
+            )
+        return np.ascontiguousarray(arr, dtype="float32")
+    if ext == ".npy":
+        arr = np.load(path)
+    elif ext == ".npz":
+        with np.load(path) as z:
+            arr = z[list(z.keys())[0]]
+    elif ext in (".bin", ".raw"):
+        if shape is None:
+            raise ValueError(f"{path.name}: raw binary load requires shape=...")
+        arr = np.fromfile(path, dtype=np.dtype(dtype)).reshape(tuple(shape), order=order)
+    else:
+        raise ValueError(f"{path.name}: unsupported model format {ext!r}")
+    return np.asarray(arr).astype("float32", copy=False)
+
+
+__all__ = [
+    "gunzip",
+    "extract_tar_member",
+    "extract_nested_tar_segy",
+    "extract_zip_member",
+    "segy_to_array",
+    "read_model",
+    "normalize_downsample",
+    "decimate",
+]

--- a/src/sweep/datasets/cli.py
+++ b/src/sweep/datasets/cli.py
@@ -1,0 +1,89 @@
+"""``sweep datasets`` CLI: ``list`` / ``info`` / ``download`` / ``where``.
+
+Also installed as the standalone ``sweep-datasets`` command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def _cmd_list(args) -> int:
+    from sweep.datasets import catalog
+
+    catalog(args.name)
+    return 0
+
+
+def _cmd_info(args) -> int:
+    from sweep.datasets import info
+
+    e = info(args.name, args.variant)
+    print(f"{e.name}:{e.variant}")
+    print(f"  kind        {e.kind}")
+    print(f"  description {e.description}")
+    print(f"  citation    {e.citation}")
+    print(f"  license     {e.license}")
+    print(f"  re-host     {'yes' if e.redistributable else 'no'}")
+    print(f"  default     {e.default}")
+    print(f"  tags        {', '.join(e.tags)}")
+    return 0
+
+
+def _cmd_download(args) -> int:
+    from sweep.datasets import load
+
+    kw = {}
+    if args.downsample:
+        kw["downsample"] = args.downsample[0] if len(args.downsample) == 1 else tuple(args.downsample)
+    out = load(args.name, args.variant, **kw)
+    print(f"downloaded {out['name']}:{out['variant']}")
+    for k, v in out.items():
+        if hasattr(v, "shape"):
+            print(f"  {k:8s} {tuple(v.shape)} {v.dtype}")
+    print(f"  dh={out.get('dh')} dt={out.get('dt')} nt={out.get('nt')}")
+    return 0
+
+
+def _cmd_where(_args) -> int:
+    from sweep.datasets._cache import cache_root
+
+    print(cache_root())
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="sweep datasets",
+        description="Benchmark velocity models (Marmousi, Overthrust, BP, Hess, ...).",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    lp = sub.add_parser("list", help="list registered datasets (optionally one family)")
+    lp.add_argument("name", nargs="?", default=None)
+    lp.set_defaults(func=_cmd_list)
+
+    ip = sub.add_parser("info", help="show one dataset entry's metadata")
+    ip.add_argument("name")
+    ip.add_argument("variant", nargs="?", default=None)
+    ip.set_defaults(func=_cmd_info)
+
+    dp = sub.add_parser("download", help="fetch a dataset to the cache and report its shape")
+    dp.add_argument("name")
+    dp.add_argument("variant", nargs="?", default=None)
+    dp.add_argument(
+        "--downsample", type=int, nargs="+", default=None,
+        help="uniform int, or one factor per axis (e.g. --downsample 2 4)",
+    )
+    dp.set_defaults(func=_cmd_download)
+
+    wp = sub.add_parser("where", help="print the cache directory")
+    wp.set_defaults(func=_cmd_where)
+
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/sweep/datasets/registry.py
+++ b/src/sweep/datasets/registry.py
@@ -1,0 +1,170 @@
+"""Public registry of benchmark models and the ``load(...)`` dispatcher.
+
+This is the unified entry point for both the *embedded* demo models (tiny
+base85 blobs that ship inside the wheel) and the *downloadable* full-size
+benchmarks (Marmousi, Overthrust, BP, Hess, ...). Every record carries its
+own ``license`` / ``citation`` string, which is printed the first time a
+model is materialised so that attribution/usage terms travel with the data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+@dataclass
+class Entry:
+    """One registry record.
+
+    Attributes
+    ----------
+    name, variant
+        The ``(name, variant)`` key used to look the model up.
+    loader
+        Callable returning a dict with at least ``vp`` and ``dh``. It may
+        download and cache data on first call.
+    kind
+        ``"embedded"`` for in-wheel demo blobs (no network), ``"download"``
+        for benchmarks fetched on demand, ``"gated"`` for entries that
+        require the user to accept external terms / place files manually.
+    license
+        Human-readable license / usage terms. Printed on first load.
+    redistributable
+        ``True`` only when the license permits re-hosting the bytes
+        (e.g. CC-BY-4.0). ``False`` for "download-and-cite / AS-IS /
+        non-commercial" data that must be fetched from the official source.
+    """
+
+    name: str
+    variant: str
+    loader: Callable[..., dict[str, Any]]
+    description: str = ""
+    citation: str = ""
+    license: str = ""
+    kind: str = "download"
+    redistributable: bool = False
+    default: bool = False  # canonical variant picked when `variant` is omitted
+    tags: list[str] = field(default_factory=list)
+
+
+_REGISTRY: dict[tuple[str, str], Entry] = {}
+_ANNOUNCED: set[tuple[str, str]] = set()
+
+
+def register(entry: Entry, *, replace: bool = False) -> None:
+    """Register a benchmark loader.
+
+    Parameters
+    ----------
+    replace
+        If ``True``, silently overwrite an existing key instead of raising.
+    """
+    key = (entry.name, entry.variant)
+    if key in _REGISTRY and not replace:
+        raise ValueError(f"benchmark {entry.name}:{entry.variant} already registered")
+    _REGISTRY[key] = entry
+
+
+def available() -> list[tuple[str, str]]:
+    """List ``(name, variant)`` pairs registered."""
+    return sorted(_REGISTRY.keys())
+
+
+def info(name: str, variant: str | None = None) -> Entry:
+    """Look up a registry entry.
+
+    If ``variant`` is omitted: use the sole variant when there is only one;
+    otherwise use the one marked ``default=True``. If a name has several
+    variants and none (or more than one) is marked default, raise and list
+    the choices rather than guess.
+    """
+    if variant is None:
+        matches = sorted(k for k in _REGISTRY if k[0] == name)
+        if not matches:
+            raise KeyError(
+                f"unknown benchmark {name!r}; have {sorted({k[0] for k in _REGISTRY})}"
+            )
+        if len(matches) == 1:
+            variant = matches[0][1]
+        else:
+            defaults = [k for k in matches if _REGISTRY[k].default]
+            if len(defaults) == 1:
+                variant = defaults[0][1]
+            else:
+                choices = [v for _, v in matches]
+                why = "no default" if not defaults else "multiple defaults"
+                raise KeyError(
+                    f"{name!r} has multiple variants ({why}); "
+                    f"pass variant=... one of {choices}"
+                )
+    try:
+        return _REGISTRY[(name, variant)]
+    except KeyError:
+        raise KeyError(f"unknown variant {name}:{variant!r}")
+
+
+def catalog(name: str | None = None) -> list[Entry]:
+    """Pretty-print the dataset registry and return the matching entries.
+
+    Pass ``name`` to filter to one model family (e.g. ``catalog("bp-2004")``).
+    Columns: kind (embedded/download), re-host (may the bytes be re-hosted),
+    verified (byte-verified against a real download), and the license.
+    """
+    entries = [info(n, v) for (n, v) in available() if name in (None, n)]
+    if not entries:
+        print(f"(no datasets match {name!r})")
+        return entries
+    keys = [f"{e.name}:{e.variant}" for e in entries]
+    w = max(len(k) for k in keys)
+    print(f"{'name:variant'.ljust(w)}  kind      re-host  verified  license")
+    print(f"{'-' * w}  --------  -------  --------  -------")
+    for e, key in zip(entries, keys):
+        rehost = "yes" if e.redistributable else "no"
+        verified = "no" if "unverified" in e.tags else "yes"
+        print(f"{key.ljust(w)}  {e.kind:8s}  {rehost:7s}  {verified:8s}  {e.license[:46]}")
+    return entries
+
+
+def _announce(entry: Entry) -> None:
+    """Print citation + license once per process for a given entry."""
+    key = (entry.name, entry.variant)
+    if key in _ANNOUNCED:
+        return
+    _ANNOUNCED.add(key)
+    bits = [f"[sweep.datasets] {entry.name}:{entry.variant}"]
+    if entry.citation:
+        bits.append(f"  cite:    {entry.citation}")
+    if entry.license:
+        bits.append(f"  license: {entry.license}")
+    if entry.kind == "download" and not entry.redistributable:
+        bits.append(
+            "  note:    fetched from the official source under the terms above; "
+            "do not re-host the bytes."
+        )
+    if "unverified" in entry.tags:
+        bits.append(
+            "  CAUTION: loader implemented from documented specs but not yet "
+            "byte-verified against a real download; confirm grid shape / units."
+        )
+    print("\n".join(bits))
+
+
+def load(name: str, variant: str | None = None, **kwargs: Any) -> dict[str, Any]:
+    """Load (and download if needed) a benchmark dataset.
+
+    Returns a dict with at least ``vp`` and ``dh``. Most entries also
+    provide ``dt``, ``nt``, ``geometry``, and ``vp_init``. The license and
+    citation are printed once per process on first load.
+    """
+    entry = info(name, variant)
+    _announce(entry)
+    out = entry.loader(**kwargs)
+    out.setdefault("name", entry.name)
+    out.setdefault("variant", entry.variant)
+    out.setdefault("citation", entry.citation)
+    out.setdefault("license", entry.license)
+    return out
+
+
+__all__ = ["Entry", "register", "available", "info", "load", "catalog"]

--- a/test/test_datasets_registry.py
+++ b/test/test_datasets_registry.py
@@ -1,0 +1,158 @@
+"""Offline tests for the unified sweep.datasets registry.
+
+These never touch the network — they exercise the registry wiring, the
+embedded demo loaders, back-compat helpers, and (importantly) verify that
+importing ``sweep.datasets`` does not pull in the optional download/parse
+dependencies.
+"""
+
+import sys
+
+import numpy as np
+import pytest
+
+from sweep import datasets
+from sweep.datasets import _formats
+
+
+def test_registry_lists_embedded_and_download():
+    keys = datasets.available()
+    assert ("marmousi", "2d-demo") in keys        # embedded
+    assert ("overthrust", "2d-demo") in keys       # embedded
+    assert ("overthrust", "3d-acoustic") in keys   # download (CC-BY)
+    assert ("seg-eage-salt", "3d-acoustic") in keys
+    assert ("marmousi2", "2d-elastic") in keys
+    assert ("bp-2004", "2d-acoustic") in keys
+    assert ("bp-2007-tti", "2d-tti") in keys
+    assert ("hess-vti", "2d-vti") in keys
+
+
+def test_excluded_models_absent():
+    names = {k[0] for k in datasets.available()}
+    # Sigsbee (Data Release Agreement), SEAM (ambiguous license) and OpenFWI
+    # (non-commercial CC BY-NC-SA) are intentionally not bundled.
+    assert "sigsbee" not in names and "sigsbee2a" not in names
+    assert "seam" not in names
+    assert "openfwi" not in names
+
+
+def test_every_entry_has_license_and_citation():
+    for name, variant in datasets.available():
+        e = datasets.info(name, variant)
+        assert e.license, f"{name}:{variant} missing license"
+        assert e.citation, f"{name}:{variant} missing citation"
+
+
+def test_embedded_marmousi_loads_offline():
+    prob = datasets.load("marmousi", "2d-demo")
+    assert prob["vp"].shape == (281, 1361)
+    assert prob["vp"].dtype.name == "float32"
+    assert prob["dh"] == (12.5, 12.5)
+
+
+def test_embedded_overthrust2d_loads_offline():
+    prob = datasets.load("overthrust", "2d-demo")
+    assert prob["vp"].shape == (187, 801)
+    assert prob["dh"] == (25.0, 25.0)
+
+
+def test_backcompat_helpers():
+    assert datasets.load_marmousi("vp_true").shape == (281, 1361)
+    assert datasets.load_marmousi("vs_smooth").shape == (281, 1361)
+    assert datasets.load_overthrust_2d("true").shape == (187, 801)
+    assert datasets.MARMOUSI_DH == 12.5
+    assert datasets.OVERTHRUST_2D_DH == 25.0
+    assert "vp_true" in datasets.available_marmousi()
+
+
+def test_import_does_not_pull_optional_deps():
+    # Importing the datasets package (and loading embedded demos) must not
+    # import requests/tqdm/sweep_io/h5py — those are lazy, download-only.
+    for mod in ("requests", "tqdm", "sweep_io", "h5py"):
+        assert mod not in sys.modules, f"{mod} imported eagerly by sweep.datasets"
+
+
+def test_catalog_lists_and_filters(capsys):
+    rows = datasets.catalog()                 # prints a table, returns entries
+    assert len(rows) == len(datasets.available())
+    assert all(isinstance(e, datasets.Entry) for e in rows)
+    out = capsys.readouterr().out
+    assert "name:variant" in out and "overthrust:3d-acoustic" in out
+    # filter to one family
+    only = datasets.catalog("marmousi")
+    assert {e.name for e in only} == {"marmousi"}
+
+
+def test_default_variant_resolution():
+    # Multi-variant names resolve to the canonical default (not alphabetical).
+    assert datasets.info("marmousi").variant == "2d-demo"      # not 2d-acoustic
+    assert datasets.info("overthrust").variant == "2d-demo"    # not 3d-acoustic
+    # Bare load(name) of a multi-variant model gives the embedded demo (offline).
+    assert datasets.load("marmousi")["variant"] == "2d-demo"
+    # Sole-variant names resolve unambiguously without a default flag.
+    assert datasets.info("bp-2004").variant == "2d-acoustic"
+    assert datasets.info("marmousi2").variant == "2d-elastic"
+
+
+def test_ambiguous_name_without_default_raises():
+    # A name with several variants and no default must not silently guess.
+    import numpy as np
+
+    def _stub():
+        return {"vp": np.zeros((2, 2), dtype="float32"), "dh": (1.0, 1.0)}
+
+    for v in ("va", "vb"):
+        datasets.register(
+            datasets.Entry(name="_pytest_ambig", variant=v, loader=_stub),
+            replace=True,
+        )
+    with pytest.raises(KeyError, match="multiple variants"):
+        datasets.info("_pytest_ambig")
+
+
+def test_downsample_uniform_and_per_axis():
+    a = np.arange(12 * 20, dtype="float32").reshape(12, 20)
+    # uniform int
+    out, fac = _formats.decimate(a, 2)
+    assert out.shape == (6, 10) and fac == (2, 2)
+    # per-axis tuple / list
+    out, fac = _formats.decimate(a, (2, 4))
+    assert out.shape == (6, 5) and fac == (2, 4)
+    out, fac = _formats.decimate(a, [1, 5])
+    assert out.shape == (12, 4) and fac == (1, 5)
+    # 3D per-axis
+    b = np.zeros((8, 6, 4), dtype="float32")
+    out, fac = _formats.decimate(b, (2, 1, 4))
+    assert out.shape == (4, 6, 1) and fac == (2, 1, 4)
+
+
+def test_downsample_validation():
+    a = np.zeros((10, 10), dtype="float32")
+    with pytest.raises(ValueError, match="axes but the model is 2-D"):
+        _formats.decimate(a, (2, 2, 2))         # wrong ndim
+    with pytest.raises(ValueError, match=">= 1"):
+        _formats.decimate(a, 0)                  # zero factor
+    with pytest.raises(ValueError, match=">= 1"):
+        _formats.decimate(a, (2, 0))             # per-axis zero
+
+
+def test_cli_offline_subcommands(capsys):
+    from sweep.datasets.cli import main
+
+    assert main(["list"]) == 0
+    assert "overthrust:3d-acoustic" in capsys.readouterr().out
+    assert main(["list", "marmousi"]) == 0
+    out = capsys.readouterr().out
+    assert "marmousi:2d-demo" in out and "bp-2004" not in out
+    assert main(["info", "bp-2004"]) == 0
+    assert "Billette" in capsys.readouterr().out
+    assert main(["where"]) == 0
+    assert capsys.readouterr().out.strip()
+
+
+def test_download_entry_metadata_flags():
+    # CC-BY models are re-hostable; AS-IS ones are not.
+    assert datasets.info("overthrust", "3d-acoustic").redistributable is True
+    assert datasets.info("seg-eage-salt", "3d-acoustic").redistributable is True
+    assert datasets.info("bp-2004", "2d-acoustic").redistributable is False
+    assert datasets.info("hess-vti", "2d-vti").redistributable is False


### PR DESCRIPTION
Merges the standalone `sweep-zoo` download registry into `sweep.datasets`, so
embedded demo models and full-size downloadable benchmarks share one registry
and `load()` / `available()` / `info()` / `catalog()` API. Back-compat helpers
(`load_marmousi`, `MARMOUSI_DH`, ...) are preserved — existing notebooks are
unchanged.

## Models (all byte-verified: shape, value range, slice image)

Fetched from their **official open-data source**, cached on first use:

- `overthrust` 3d (SEG/EAGE CD `.vites`), `seg-eage-salt` 3d — **CC-BY-4.0**
- `marmousi` / `marmousi2` (elastic vp/vs/rho), `bp-2004`, `bp-2007-tti`
  (vp/ε/δ/θ), `hess-vti` (vp/ε/δ) — free download + attribution

Sigsbee / SEAM / OpenFWI intentionally excluded on license grounds.

## Notes

- Parsing is **numpy-only** (inlined SEG-Y rev-1 reader) — no `sweep-io` / `h5py`
  dependency. The `[datasets]` extra only adds `requests` / `tqdm` for downloads.
- Per-axis `downsample` (int or per-axis tuple; `dh` scaled to match).
- `sweep datasets` CLI (`list` / `info` / `download` / `where`).
- User Guide docs page + small code/table font fix to match notebook cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)