### PR TITLE
fix(propagator): move CPML profiles to compute device for impl='c'

### DIFF
--- a/src/sweep/equations/base.py
+++ b/src/sweep/equations/base.py
@@ -305,7 +305,12 @@ class FirstOrderEquation(WaveEquation, ):
         if axis < 0 or axis >= self.ndim:
             raise ValueError(f"Axis {axis} is out of bounds for ndim={self.ndim}.")
 
-        if np.isscalar(h):
+        # isinstance (not np.isscalar) keeps this traceable under torch.compile:
+        # np.isscalar returns a Python bool that triggers a Dynamo graph break
+        # (a hard error under fullgraph=True). numpy scalars (np.float32, 0-d
+        # arrays) fall through to the ndim==0 branch below, so behaviour is
+        # unchanged; np.float64 is a Python float subclass and matches here.
+        if isinstance(h, (int, float)):
             return h
 
         if hasattr(h, "ndim") and getattr(h, "ndim", 0) == 0:
@@ -394,7 +399,12 @@ class SecondOrderEquation(OperatorBase, WaveEquation):
         if axis < 0 or axis >= self.ndim:
             raise ValueError(f"Axis {axis} is out of bounds for ndim={self.ndim}.")
 
-        if np.isscalar(h):
+        # isinstance (not np.isscalar) keeps this traceable under torch.compile:
+        # np.isscalar returns a Python bool that triggers a Dynamo graph break
+        # (a hard error under fullgraph=True). numpy scalars (np.float32, 0-d
+        # arrays) fall through to the ndim==0 branch below, so behaviour is
+        # unchanged; np.float64 is a Python float subclass and matches here.
+        if isinstance(h, (int, float)):
             return h
 
         if hasattr(h, "ndim") and getattr(h, "ndim", 0) == 0:

--- a/src/sweep/propagator/_c.py
+++ b/src/sweep/propagator/_c.py
@@ -1146,9 +1146,15 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
             topo_cat_arg = cat_t
             use_apm_arg = True
 
+        # CPML profiles are built on ``equation.device`` (default 'cpu'); pin
+        # them to the propagator's compute device so an equation created
+        # without ``device=`` (e.g. ``Acoustic()`` + ``PropTorch(dev='cuda')``)
+        # doesn't feed host pointers to the CUDA kernel -> illegal address.
+        # ``.to`` is a no-op when the tensors already live on ``self.dev``.
+        pml_vals = [b.to(self.dev) for b in self.equation.b]
         syn = Warpper.apply(
                 self.forward_func,
-                self.backward_func, 
+                self.backward_func,
                 self.backward_bs_func,
                 self.backward_ckpt_func,
                 self.backward_recursive_ckpt_func,
@@ -1162,7 +1168,7 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
                 self.abcn,
                 spacing,
                 self._dt,
-                self.equation.b,
+                pml_vals,
                 use_checkpoint,
                 self.ckpt_chunks,
                 use_recursive_checkpoint,
@@ -1416,7 +1422,7 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         fwd.receivers_loc = receivers_t.contiguous()
         fwd.source_field_indices = self._field_indices_tensor(self.source_type, is_source=True)
         fwd.receiver_field_indices = self._field_indices_tensor(self.receiver_type, is_source=False)
-        fwd.pml_vals = [p.contiguous() for p in self.equation.b]
+        fwd.pml_vals = [p.to(self.dev).contiguous() for p in self.equation.b]
         fwd.save_all_wavefields = save_all_wavefields
         fwd.use_boundary_saving = use_boundary_saving
         fwd.use_checkpoint = use_ckpt
@@ -1476,7 +1482,7 @@ class _CompiledPropagator(PropBase, torch.nn.Module):
         bwd.forward_sources_loc = sources_t.contiguous()
         bwd.source_field_indices = self._field_indices_tensor(self.source_type, is_source=True)
         bwd.receiver_field_indices = self._field_indices_tensor(self.receiver_type, is_source=False)
-        bwd.pml_vals = [p.contiguous() for p in self.equation.b]
+        bwd.pml_vals = [p.to(self.dev).contiguous() for p in self.equation.b]
         bwd.nt = self.nt
         bwd.dt = self._dt
         bwd.spacing = spacing


### PR DESCRIPTION
## Problem

`PropTorch(eq, dev='cuda')` with an equation on its **default device** — `'cpu'`, e.g. `Acoustic(spatial_order=8)` created **without** `device=` — passed the CPML profile tensors (`equation.b`) to the `impl='c'` CUDA kernel while they were still on the host. The kernel dereferenced those host pointers → a wild out-of-bounds read that surfaced as `cudaErrorIllegalAddress` in `acoustic2nd` (compute-sanitizer: read ~22 TB **below** the nearest GPU allocation — the CPU-pointer signature).

Minimal repro:
```python
prop = PropTorch(Acoustic(spatial_order=8), backend='torch', impl='c',
                 shape=(40, 60), abcn=10, nt=40, B=1, dev=torch.device('cuda'))
prop(wav, src, rec, models=[vp])   # -> illegal memory access
```

### It is NOT
- **2D-specific** — 3D (`Acoustic3D()` without `device=`) crashes identically.
- **domain-decomposition / ADCIG / boundary-saving related** — reproduces on a clean build of any branch (`dev`, `feat/adcig-space-lag`, `feat/dd-adcig`).
- **a stale build** — reproduces on freshly, cleanly built `.so`.

The only knob is whether the equation was given `device=`. Root cause: the equation defaults `device='cpu'` and the propagator never reconciles `equation.device` with its own resolved `self.dev`.

## Fix

`lap_coes`/`grad_coes` are already built on `self.dev`; the only device-mismatched tensor reaching the kernel is `equation.b`. Pin it to `self.dev` at the three C-path entry points (forward `Warpper.apply` + RTM fwd/bwd). `.to` is a no-op when the tensors already live on the device, so the common `device=`-set path is byte-for-byte unchanged.

## Verification

- **KW60443 (RTX 6000 Ada, torch 2.9.1+cu128):** minimal repro forward — before: 1312 compute-sanitizer memcheck errors → after: **0 errors**. 2D/3D × forward/backward/RTM with device absent all pass; device-present path unchanged; `test_c_default_boundary_saving.py` 3 passed. Branch-independent (also confirmed on a clean `feat/adcig-space-lag` build).
- **ibex Tesla V100-SXM2 (sm_70):** unfixed build device-absent → `cudaErrorIllegalAddress`; fixed → 2D + 3D pass, memcheck **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)