### PR TITLE
perf(acoustic_vrz): fuse backward adjoint+gradient (2D/3D) + bs boundary fix

### DIFF
--- a/src/sweep/csrc/cuda/common/acoustic_vrz_fused.cuh
+++ b/src/sweep/csrc/cuda/common/acoustic_vrz_fused.cuh
@@ -1,0 +1,81 @@
+#pragma once
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include "../operators/gradient.cuh"
+#include "../operators/laplace.cuh"
+
+// Functor building blocks for the fused AcousticVRZ backward kernels.
+//
+// The split backward path materialises the adjoint transpose buffers
+//   aq0 = vp^2 * lambda,  aqx = (dx b*kappa)*lambda,  aqz = (dz b*kappa)*lambda
+// (and the gradient buffers c_x/c_z/e_x/e_z), then re-reads them with a laplace
+// / gradient stencil.  The fused kernels instead recompute each stencil tap on
+// the fly from a time-invariant coefficient field times the current wavefield,
+// exactly as elastic_adjoint_fused.cuh does for the elastic solvers.
+//
+// Bit-exactness: gradient<>() already routes through centered_gradient_stencil
+// (operators/gradient.cuh), so a matching product accessor reproduces the split
+// numerics tap-for-tap.  centered_laplace1d_stencil below mirrors LaplaceGPU's
+// coefficient expressions (operators/laplace.cuh) line-for-line, including the
+// `/(h*h)` division order, so the fused laplace is bit-identical too.
+
+// value_at(off) = a[idx + off*stride] * b[idx + off*stride]
+struct VrzProductAccessor {
+    const float* __restrict__ a;
+    const float* __restrict__ b;
+    int idx;
+    int stride;
+
+    __device__ __forceinline__ float operator()(int off) const
+    {
+        int j = idx + off * stride;
+        return a[j] * b[j];
+    }
+};
+
+// Second derivative along one axis, applied to a functor value_at(off).
+// Coefficient expressions and division order match LaplaceGPU<Order> exactly.
+template<int Order, typename Accessor>
+__device__ __forceinline__ float centered_laplace1d_stencil(
+    const Accessor& v,
+    float h,
+    int M,
+    const float* __restrict__ coeff
+) {
+    if constexpr (Order == 2) {
+        return (v(-1) + v(1) - 2.f * v(0)) / (h * h);
+    } else if constexpr (Order == 4) {
+        constexpr float c0 = 5.f / 2.f;
+        constexpr float c1 = 4.f / 3.f;
+        constexpr float c2 = -1.f / 12.f;
+        return (c1 * (v(-1) + v(1))
+              + c2 * (v(-2) + v(2))
+              - c0 * v(0)) / (h * h);
+    } else if constexpr (Order == 6) {
+        constexpr float c0 = 49.f / 18.f;
+        constexpr float c1 = 3.f / 2.f;
+        constexpr float c2 = -3.f / 20.f;
+        constexpr float c3 = 1.f / 90.f;
+        return (c1 * (v(-1) + v(1))
+              + c2 * (v(-2) + v(2))
+              + c3 * (v(-3) + v(3))
+              - c0 * v(0)) / (h * h);
+    } else if constexpr (Order == 8) {
+        constexpr float c0 = 205.f / 72.f;
+        constexpr float c1 = 8.f / 5.f;
+        constexpr float c2 = -1.f / 5.f;
+        constexpr float c3 = 8.f / 315.f;
+        constexpr float c4 = -1.f / 560.f;
+        return (c1 * (v(-1) + v(1))
+              + c2 * (v(-2) + v(2))
+              + c3 * (v(-3) + v(3))
+              + c4 * (v(-4) + v(4))
+              - c0 * v(0)) / (h * h);
+    } else {
+        float acc = 0.f;
+        #pragma unroll 1
+        for (int k = 1; k <= M; ++k)
+            acc += coeff[k] * (v(k) + v(-k));
+        return (acc - coeff[0] * v(0)) / (h * h);
+    }
+}

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/backward.cu
@@ -290,6 +290,18 @@ BackwardOutput backward_bs(const BackwardInput& in)
         ctx
     );
 
+    // Zero the boundary/PML band of the initial reconstruction state so stale
+    // PML values carried in u_last_two don't leak inward during reverse
+    // propagation.  acoustic2d backward_bs does this; its absence was the main
+    // cause of the VRZ bs accuracy gap (acoustic bs is bit-exact, VRZ was not).
+    {
+        auto for_init = forward.view();
+        set_boundary_zeros<<<launch_config.grid, launch_config.block>>>(
+            for_init.u_prev, ctx.abcn + ctx.M, nx, nz, p.free_surface);
+        set_boundary_zeros<<<launch_config.grid, launch_config.block>>>(
+            for_init.u_now, ctx.abcn + ctx.M, nx, nz, p.free_surface);
+    }
+
     for (int it = p.nt - 1; it >= 1; --it) {
         auto adj_view = adjoint.view();
         auto for_view = forward.view();

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/backward.cu
@@ -78,13 +78,13 @@ BackwardOutput backward(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto c_x = torch::zeros_like(vp);
+    auto C0 = torch::zeros_like(vp);    // vp²       (time-invariant adjoint coeffs)
+    auto Cx = torch::zeros_like(vp);    // (∂ₓb·κ)
+    auto Cz = torch::zeros_like(vp);    // (∂_z b·κ)
+    auto c_x = torch::zeros_like(vp);   // split gradient scratch (order>=6 path)
     auto c_z = torch::zeros_like(vp);
     auto e_x = torch::zeros_like(vp);
     auto e_z = torch::zeros_like(vp);
-    auto aq0 = torch::zeros_like(vp);   // b·κ·λ   (adjoint transpose buffer)
-    auto aqx = torch::zeros_like(vp);   // (∂ₓb·κ)·λ
-    auto aqz = torch::zeros_like(vp);   // (∂_z b·κ)·λ
 
     AcousticCPMLTensor cpml_tensor;
     cpml_tensor.allocate(in.pml_vals, 2);
@@ -98,24 +98,26 @@ BackwardOutput backward(const BackwardInput& in)
     GradParam grad_ctx_x{1, 0, 0, M, in.grad_coes.data_ptr<float>(), dx, 0.f, 0.f};
     GradParam grad_ctx_z{1, 0, 0, M, in.grad_coes.data_ptr<float>(), dz, 0.f, 0.f};
 
+    // Time-invariant adjoint transpose coefficients (vp², ∂ₓb·κ, ∂_z b·κ),
+    // computed once so the fused adjoint kernel only multiplies by λ per step.
+    BUILD_VRZ_ADJOINT_COEFFS(
+        order,
+        launch_config.grid,
+        launch_config.block,
+        vp.data_ptr<float>(),
+        z.data_ptr<float>(),
+        inv_z.data_ptr<float>(),
+        C0.data_ptr<float>(),
+        Cx.data_ptr<float>(),
+        Cz.data_ptr<float>(),
+        grad_ctx,
+        ctx
+    );
+
     for (int it = in.nt - 1; it >= 0; --it) {
         auto adj_view = adjoint.view();
-        BUILD_VRZ_ADJOINT_FIELDS(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view.u_now,
-            vp.data_ptr<float>(),
-            z.data_ptr<float>(),
-            inv_z.data_ptr<float>(),
-            aq0.data_ptr<float>(),
-            aqx.data_ptr<float>(),
-            aqz.data_ptr<float>(),
-            grad_ctx,
-            ctx
-        );
 
-        ACOUSTIC_VRZ2D_ADJOINT(
+        ACOUSTIC_VRZ2D_ADJOINT_FUSED(
             order,
             launch_config.grid,
             launch_config.block,
@@ -123,9 +125,9 @@ BackwardOutput backward(const BackwardInput& in)
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
-            aq0.data_ptr<float>(),
-            aqx.data_ptr<float>(),
-            aqz.data_ptr<float>(),
+            C0.data_ptr<float>(),
+            Cx.data_ptr<float>(),
+            Cz.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
             grad_ctx_x,
@@ -145,35 +147,19 @@ BackwardOutput backward(const BackwardInput& in)
 
         adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
-        BUILD_VRZ_GRAD_FIELDS(
+        CALCULATE_GRAD_VRZ2D_AUTO(
             order,
             launch_config.grid,
             launch_config.block,
             in.u_forward.select(0, it).select(0, 0).data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            z.data_ptr<float>(),
-            c_x.data_ptr<float>(),
-            c_z.data_ptr<float>(),
-            e_x.data_ptr<float>(),
-            e_z.data_ptr<float>(),
-            grad_ctx,
-            ctx
-        );
-
-        CALCULATE_GRAD_VRZ2D(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            in.u_forward.select(0, it).select(0, 0).data_ptr<float>(),
-            adjoint.u_now_t.data_ptr<float>(),
-            c_x.data_ptr<float>(),
-            c_z.data_ptr<float>(),
-            e_x.data_ptr<float>(),
-            e_z.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_z.data_ptr<float>(),
             grad_vp.data_ptr<float>(),
             grad_z.data_ptr<float>(),
             grad_ctx,
@@ -237,13 +223,13 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto c_x = torch::zeros_like(vp);
+    auto C0 = torch::zeros_like(vp);    // vp²       (time-invariant adjoint coeffs)
+    auto Cx = torch::zeros_like(vp);    // (∂ₓb·κ)
+    auto Cz = torch::zeros_like(vp);    // (∂_z b·κ)
+    auto c_x = torch::zeros_like(vp);   // split gradient scratch (order>=6 path)
     auto c_z = torch::zeros_like(vp);
     auto e_x = torch::zeros_like(vp);
     auto e_z = torch::zeros_like(vp);
-    auto aq0 = torch::zeros_like(vp);   // b·κ·λ   (adjoint transpose buffer)
-    auto aqx = torch::zeros_like(vp);   // (∂ₓb·κ)·λ
-    auto aqz = torch::zeros_like(vp);   // (∂_z b·κ)·λ
     auto neg_adjoint_source = -p.adjoint_source;
 
     AcousticCPMLTensor cpml_tensor;
@@ -290,26 +276,25 @@ BackwardOutput backward_bs(const BackwardInput& in)
     );
     boundary_runtime.prefetch_initial_backward_chunk(p.nt);
 
+    BUILD_VRZ_ADJOINT_COEFFS(
+        order,
+        launch_config.grid,
+        launch_config.block,
+        vp.data_ptr<float>(),
+        z.data_ptr<float>(),
+        inv_z.data_ptr<float>(),
+        C0.data_ptr<float>(),
+        Cx.data_ptr<float>(),
+        Cz.data_ptr<float>(),
+        grad_ctx,
+        ctx
+    );
+
     for (int it = p.nt - 1; it >= 1; --it) {
         auto adj_view = adjoint.view();
         auto for_view = forward.view();
 
-        BUILD_VRZ_ADJOINT_FIELDS(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view.u_now,
-            vp.data_ptr<float>(),
-            z.data_ptr<float>(),
-            inv_z.data_ptr<float>(),
-            aq0.data_ptr<float>(),
-            aqx.data_ptr<float>(),
-            aqz.data_ptr<float>(),
-            grad_ctx,
-            ctx
-        );
-
-        ACOUSTIC_VRZ2D_ADJOINT(
+        ACOUSTIC_VRZ2D_ADJOINT_FUSED(
             order,
             launch_config.grid,
             launch_config.block,
@@ -317,9 +302,9 @@ BackwardOutput backward_bs(const BackwardInput& in)
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
-            aq0.data_ptr<float>(),
-            aqx.data_ptr<float>(),
-            aqz.data_ptr<float>(),
+            C0.data_ptr<float>(),
+            Cx.data_ptr<float>(),
+            Cz.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
             grad_ctx_x,
@@ -374,35 +359,19 @@ BackwardOutput backward_bs(const BackwardInput& in)
 
         forward.swap();
 
-        BUILD_VRZ_GRAD_FIELDS(
+        CALCULATE_GRAD_VRZ2D_AUTO(
             order,
             launch_config.grid,
             launch_config.block,
             forward.u_now_t.data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            z.data_ptr<float>(),
-            c_x.data_ptr<float>(),
-            c_z.data_ptr<float>(),
-            e_x.data_ptr<float>(),
-            e_z.data_ptr<float>(),
-            grad_ctx,
-            ctx
-        );
-
-        CALCULATE_GRAD_VRZ2D(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            forward.u_now_t.data_ptr<float>(),
-            adjoint.u_now_t.data_ptr<float>(),
-            c_x.data_ptr<float>(),
-            c_z.data_ptr<float>(),
-            e_x.data_ptr<float>(),
-            e_z.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_z.data_ptr<float>(),
             grad_vp.data_ptr<float>(),
             grad_z.data_ptr<float>(),
             grad_ctx,
@@ -465,13 +434,13 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto c_x = torch::zeros_like(vp);
+    auto C0 = torch::zeros_like(vp);    // vp²       (time-invariant adjoint coeffs)
+    auto Cx = torch::zeros_like(vp);    // (∂ₓb·κ)
+    auto Cz = torch::zeros_like(vp);    // (∂_z b·κ)
+    auto c_x = torch::zeros_like(vp);   // split gradient scratch (order>=6 path)
     auto c_z = torch::zeros_like(vp);
     auto e_x = torch::zeros_like(vp);
     auto e_z = torch::zeros_like(vp);
-    auto aq0 = torch::zeros_like(vp);   // b·κ·λ   (adjoint transpose buffer)
-    auto aqx = torch::zeros_like(vp);   // (∂ₓb·κ)·λ
-    auto aqz = torch::zeros_like(vp);   // (∂_z b·κ)·λ
     auto checkpoint_steps_cpu = p.checkpoint_steps.defined()
         ? p.checkpoint_steps.to(torch::kCPU).to(torch::kInt32).contiguous()
         : torch::empty({0}, torch::TensorOptions().dtype(torch::kInt32));
@@ -500,6 +469,21 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
     GradParam grad_ctx{1, 0, nx, M, p.grad_coes.data_ptr<float>(), dx, 0.f, dz};
     GradParam grad_ctx_x{1, 0, 0, M, p.grad_coes.data_ptr<float>(), dx, 0.f, 0.f};
     GradParam grad_ctx_z{1, 0, 0, M, p.grad_coes.data_ptr<float>(), dz, 0.f, 0.f};
+
+    // Time-invariant adjoint transpose coefficients, computed once for all segments.
+    BUILD_VRZ_ADJOINT_COEFFS(
+        order,
+        launch_config.grid,
+        launch_config.block,
+        vp.data_ptr<float>(),
+        z.data_ptr<float>(),
+        inv_z.data_ptr<float>(),
+        C0.data_ptr<float>(),
+        Cx.data_ptr<float>(),
+        Cz.data_ptr<float>(),
+        grad_ctx,
+        ctx
+    );
 
     int chunk_size = p.checkpoint_interval;
     int nt = static_cast<int>(p.nt);
@@ -587,22 +571,7 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
         for (int it = end - 1; it >= start; --it) {
             auto adj_view = adjoint.view();
 
-            BUILD_VRZ_ADJOINT_FIELDS(
-                order,
-                launch_config.grid,
-                launch_config.block,
-                adj_view.u_now,
-                vp.data_ptr<float>(),
-                z.data_ptr<float>(),
-                inv_z.data_ptr<float>(),
-                aq0.data_ptr<float>(),
-                aqx.data_ptr<float>(),
-                aqz.data_ptr<float>(),
-                grad_ctx,
-                ctx
-            );
-
-            ACOUSTIC_VRZ2D_ADJOINT(
+            ACOUSTIC_VRZ2D_ADJOINT_FUSED(
                 order,
                 launch_config.grid,
                 launch_config.block,
@@ -610,9 +579,9 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
                 vp.data_ptr<float>(),
                 z.data_ptr<float>(),
                 inv_z.data_ptr<float>(),
-                aq0.data_ptr<float>(),
-                aqx.data_ptr<float>(),
-                aqz.data_ptr<float>(),
+                C0.data_ptr<float>(),
+                Cx.data_ptr<float>(),
+                Cz.data_ptr<float>(),
                 lap_ctx,
                 grad_ctx,
                 grad_ctx_x,
@@ -632,35 +601,19 @@ BackwardOutput backward_ckpt(const BackwardInput& in)
 
             adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
-            BUILD_VRZ_GRAD_FIELDS(
+            CALCULATE_GRAD_VRZ2D_AUTO(
                 order,
                 launch_config.grid,
                 launch_config.block,
                 chunk_forward[it - start].data_ptr<float>(),
                 adjoint.u_now_t.data_ptr<float>(),
-                vp.data_ptr<float>(),
-                z.data_ptr<float>(),
-                c_x.data_ptr<float>(),
-                c_z.data_ptr<float>(),
-                e_x.data_ptr<float>(),
-                e_z.data_ptr<float>(),
-                grad_ctx,
-                ctx
-            );
-
-            CALCULATE_GRAD_VRZ2D(
-                order,
-                launch_config.grid,
-                launch_config.block,
-                chunk_forward[it - start].data_ptr<float>(),
-                adjoint.u_now_t.data_ptr<float>(),
-                c_x.data_ptr<float>(),
-                c_z.data_ptr<float>(),
-                e_x.data_ptr<float>(),
-                e_z.data_ptr<float>(),
                 vp.data_ptr<float>(),
                 z.data_ptr<float>(),
                 inv_z.data_ptr<float>(),
+                c_x.data_ptr<float>(),
+                c_z.data_ptr<float>(),
+                e_x.data_ptr<float>(),
+                e_z.data_ptr<float>(),
                 grad_vp.data_ptr<float>(),
                 grad_z.data_ptr<float>(),
                 grad_ctx,

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/kernels.cuh
@@ -4,6 +4,7 @@
 
 #include "../../common/acoustic.h"
 #include "../../common/context.h"
+#include "../../common/acoustic_vrz_fused.cuh"
 #include "../../operators/gradient.cuh"
 #include "../../operators/laplace.cuh"
 
@@ -757,3 +758,335 @@ __global__ void calculate_grad_vrz2d(
     grad_vp_b[idx] += -dt2 * g_vp;
     grad_z_b[idx]  += -dt2 * g_z;
 }
+
+// ===========================================================================
+// Fused backward kernels (functor recompute-at-tap, bit-exact with the split
+// prepare+apply path above).  Backward per step: build_vrz_adjoint_fields +
+// acoustic_vrz2nd_adjoint -> acoustic_vrz2nd_adjoint_fused;  build_vrz_grad_fields
+// + calculate_grad_vrz2d -> calculate_grad_vrz2d_fused.  The time-invariant
+// adjoint coefficients (vp^2, dx b*kappa, dz b*kappa) are precomputed once by
+// build_vrz_adjoint_coeffs before the timestep loop.
+// ===========================================================================
+
+// Time-invariant adjoint transpose coefficients (computed once per backward):
+//   C0 = vp^2 ,  Cx = (dx b)*kappa ,  Cz = (dz b)*kappa
+// so that per step aq0 = C0*lambda, aqx = Cx*lambda, aqz = Cz*lambda exactly.
+template<int Order>
+__global__ void build_vrz_adjoint_coeffs(
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    float* __restrict__ C0,
+    float* __restrict__ Cx,
+    float* __restrict__ Cz,
+    GradParam grad_ctx,
+    SolverContext solver
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iz = blockIdx.y * blockDim.y + threadIdx.y;
+    int b  = blockIdx.z;
+    if (ix >= solver.nx || iz >= solver.nz) return;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int m_static = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : m_static;
+    if (ix < halo || ix >= solver.nx - halo || iz < halo || iz >= solver.nz - halo)
+        return;
+
+    int spatial_size = solver.nx * solver.nz;
+    int idx = iz * solver.nx + ix;
+    int gidx = b * spatial_size + idx;
+
+    const float* vp_b = vp + b * spatial_size;
+    const float* z_b = z + b * spatial_size;
+    const float* inv_z_b = inv_z + b * spatial_size;
+
+    float dvpdx = gradient<2, Order, X>(vp_b, ix, 0, iz, grad_ctx);
+    float dvpdz = gradient<2, Order, Z>(vp_b, ix, 0, iz, grad_ctx);
+    float z1x = gradient<2, Order, X>(inv_z_b, ix, 0, iz, grad_ctx);
+    float z1z = gradient<2, Order, Z>(inv_z_b, ix, 0, iz, grad_ctx);
+    float v = vp_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float kappa = v * z_b[idx];
+    float dbdx = dvpdx * inv_z0 + v * z1x;
+    float dbdz = dvpdz * inv_z0 + v * z1z;
+
+    C0[gidx] = v * v;            // b*kappa = vp^2
+    Cx[gidx] = dbdx * kappa;     // (dx b)*kappa
+    Cz[gidx] = dbdz * kappa;     // (dz b)*kappa
+}
+
+template<int Order>
+__global__ void acoustic_vrz2nd_adjoint_fused(
+    AcousticWavefieldPointer wf,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    const float* __restrict__ C0,
+    const float* __restrict__ Cx,
+    const float* __restrict__ Cz,
+    LaplaceParam lap_ctx,
+    GradParam grad_ctx,
+    GradParam grad_ctx_x,
+    GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml,
+    SolverContext solver
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iz = blockIdx.y * blockDim.y + threadIdx.y;
+    int b  = blockIdx.z;
+
+    if (ix >= solver.nx || iz >= solver.nz) return;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int m_static = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : m_static;
+
+    if (ix < halo || ix >= solver.nx - halo || iz < halo || iz >= solver.nz - halo)
+        return;
+
+    int spatial_size = solver.nx * solver.nz;
+    int idx = iz * solver.nx + ix;
+
+    auto f = wf.offset(b, spatial_size);
+
+    bool in_pml = (ix < solver.abcn + halo) || (ix >= solver.nx - solver.abcn - halo) ||
+                  (iz < (solver.free_surface ? halo : solver.abcn + halo)) ||
+                  (iz >= solver.nz - solver.abcn - halo);
+
+    if (!in_pml) {
+        // Aᵀλ = ∇²(vp²·λ) − ∂ₓ((∂ₓb·κ)·λ) − ∂_z((∂_z b·κ)·λ), each tap recomputed
+        // as coeff*λ from the precomputed time-invariant coefficient fields.
+        const float* C0_b = C0 + b * spatial_size;
+        const float* Cx_b = Cx + b * spatial_size;
+        const float* Cz_b = Cz + b * spatial_size;
+        const float* lam = f.u_now;
+
+        VrzProductAccessor a0x{C0_b, lam, idx, 1};
+        VrzProductAccessor a0z{C0_b, lam, idx, solver.nx};
+        float lap_x = centered_laplace1d_stencil<Order>(a0x, lap_ctx.dx, solver.M, lap_ctx.coeff);
+        float lap_z = centered_laplace1d_stencil<Order>(a0z, lap_ctx.dz, solver.M, lap_ctx.coeff);
+
+        VrzProductAccessor axx{Cx_b, lam, idx, 1};
+        VrzProductAccessor azz{Cz_b, lam, idx, solver.nx};
+        float gx = centered_gradient_stencil<Order>(axx, solver.M, grad_ctx.coeff, grad_ctx.dx);
+        float gz = centered_gradient_stencil<Order>(azz, solver.M, grad_ctx.coeff, grad_ctx.dz);
+
+        float rhs = (lap_x + lap_z) - gx - gz;
+        f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + solver.dt * solver.dt * rhs;
+        return;
+    }
+
+    // PML branch: identical to acoustic_vrz2nd_adjoint (recompute from u_now).
+    const float* vp_b = vp + b * spatial_size;
+    const float* z_b = z + b * spatial_size;
+    const float* inv_z_b = inv_z + b * spatial_size;
+
+    float lap_x = laplace<2, Order, X>(f.u_now, ix, 0, iz, lap_ctx);
+    float lap_z = laplace<2, Order, Z>(f.u_now, ix, 0, iz, lap_ctx);
+
+    float dqdx = gradient<2, Order, X>(f.u_now, ix, 0, iz, grad_ctx);
+    float dqdz = gradient<2, Order, Z>(f.u_now, ix, 0, iz, grad_ctx);
+
+    float dvpdx = gradient<2, Order, X>(vp_b, ix, 0, iz, grad_ctx);
+    float dvpdz = gradient<2, Order, Z>(vp_b, ix, 0, iz, grad_ctx);
+    float z1x = gradient<2, Order, X>(inv_z_b, ix, 0, iz, grad_ctx);
+    float z1z = gradient<2, Order, Z>(inv_z_b, ix, 0, iz, grad_ctx);
+
+    float v = vp_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float beta = v * inv_z0;
+    float dbdx = dvpdx * inv_z0 + v * z1x;
+    float dbdz = dvpdz * inv_z0 + v * z1z;
+    float kappa = v * z_b[idx];
+
+    float ax_ = cpml.ax[ix];
+    float az_ = cpml.az[iz];
+    float bx_ = cpml.bx[ix];
+    float bz_ = cpml.bz[iz];
+    float dbxdx_ = cpml.dbxdx[ix];
+    float dbzdz_ = cpml.dbzdz[iz];
+
+    float dpsixdx = gradient<2, Order, X>(f.psix, ix, 0, iz, grad_ctx);
+    float dpsizdz = gradient<2, Order, Z>(f.psiz, ix, 0, iz, grad_ctx);
+
+    float daxdx = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
+    float dazdz = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
+
+    float tmpx = ((1.0f + bx_) * lap_x + dbxdx_ * dqdx) + (daxdx * f.psix[idx] + ax_ * dpsixdx);
+    float psixn = bx_ * dqdx + ax_ * f.psix[idx];
+    float zetaxn = bx_ * tmpx + ax_ * f.zetax[idx];
+
+    float tmpz = ((1.0f + bz_) * lap_z + dbzdz_ * dqdz) + (dazdz * f.psiz[idx] + az_ * dpsizdz);
+    float psizn = bz_ * dqdz + az_ * f.psiz[idx];
+    float zetazn = bz_ * tmpz + az_ * f.zetaz[idx];
+
+    float qx = dqdx + psixn;
+    float qz = dqdz + psizn;
+    float w_sum = (1.0f + bx_) * tmpx + ax_ * f.zetax[idx]
+                + (1.0f + bz_) * tmpz + az_ * f.zetaz[idx];
+
+    float rhs = kappa * (beta * w_sum + dbdx * qx + dbdz * qz);
+
+    (f.psixn ? f.psixn : f.psix)[idx] = psixn;
+    (f.psizn ? f.psizn : f.psiz)[idx] = psizn;
+    f.zetax[idx] = zetaxn;
+    f.zetaz[idx] = zetazn;
+
+    f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + solver.dt * solver.dt * rhs;
+}
+
+// Accessor recomputing c_d = λ·vp·∂_d p  (UseE=false) or e_d = λ·vp²·z·∂_d p
+// (UseE=true) at stencil tap `off` along Dir, matching build_vrz_grad_fields.
+template<int Order, int Dir, bool UseE>
+struct VrzGradAccessor2D {
+    const float* __restrict__ p;
+    const float* __restrict__ lam;
+    const float* __restrict__ vp;
+    const float* __restrict__ z;
+    int ix, iz, nx, nz, halo;
+    GradParam grad_ctx;
+
+    __device__ __forceinline__ float operator()(int off) const
+    {
+        int jx = ix;
+        int jz = iz;
+        if constexpr (Dir & X) jx = ix + off; else jz = iz + off;
+        if (jx < halo || jx >= nx - halo || jz < halo || jz >= nz - halo)
+            return 0.f;
+        int j = jz * nx + jx;
+        float dpd = gradient<2, Order, Dir>(p, jx, 0, jz, grad_ctx);
+        float lam_j = lam[j];
+        float v_j = vp[j];
+        if constexpr (UseE) {
+            float lam_v2z = ((lam_j * v_j) * v_j) * z[j];   // λ·vp²·z
+            return lam_v2z * dpd;
+        } else {
+            float lam_v = lam_j * v_j;                       // λ·vp
+            return lam_v * dpd;
+        }
+    }
+};
+
+template<int Order>
+__global__ void calculate_grad_vrz2d_fused(
+    const float* __restrict__ f_u_now,
+    const float* __restrict__ lambda_now,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    float* __restrict__ grad_vp,
+    float* __restrict__ grad_z,
+    GradParam grad_ctx,
+    LaplaceParam lap_ctx,
+    SolverContext solver
+) {
+    int ix = blockIdx.x * blockDim.x + threadIdx.x;
+    int iz = blockIdx.y * blockDim.y + threadIdx.y;
+    int b  = blockIdx.z;
+
+    if (ix >= solver.nx || iz >= solver.nz) return;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int m_static = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : m_static;
+
+    if (ix < halo || ix >= solver.nx - halo || iz < halo || iz >= solver.nz - halo)
+        return;
+
+    int spatial_size = solver.nx * solver.nz;
+    int idx = iz * solver.nx + ix;
+    int shift = b * spatial_size;
+
+    const float* p_b = f_u_now + shift;
+    const float* lambda_b = lambda_now + shift;
+    const float* vp_b = vp + shift;
+    const float* z_b = z + shift;
+    const float* inv_z_b = inv_z + shift;
+    float* grad_vp_b = grad_vp + shift;
+    float* grad_z_b = grad_z + shift;
+
+    float lap_x = laplace<2, Order, X>(p_b, ix, 0, iz, lap_ctx);
+    float lap_z = laplace<2, Order, Z>(p_b, ix, 0, iz, lap_ctx);
+
+    float dpdx = gradient<2, Order, X>(p_b, ix, 0, iz, grad_ctx);
+    float dpdz = gradient<2, Order, Z>(p_b, ix, 0, iz, grad_ctx);
+
+    float dvpdx = gradient<2, Order, X>(vp_b, ix, 0, iz, grad_ctx);
+    float dvpdz = gradient<2, Order, Z>(vp_b, ix, 0, iz, grad_ctx);
+    float z1x = gradient<2, Order, X>(inv_z_b, ix, 0, iz, grad_ctx);
+    float z1z = gradient<2, Order, Z>(inv_z_b, ix, 0, iz, grad_ctx);
+
+    // ∇·(c) and ∇·(e) recomputed tap-by-tap (transpose of forward gradient).
+    VrzGradAccessor2D<Order, X, false> cx{p_b, lambda_b, vp_b, z_b, ix, iz, solver.nx, solver.nz, halo, grad_ctx};
+    VrzGradAccessor2D<Order, Z, false> cz{p_b, lambda_b, vp_b, z_b, ix, iz, solver.nx, solver.nz, halo, grad_ctx};
+    VrzGradAccessor2D<Order, X, true>  ex{p_b, lambda_b, vp_b, z_b, ix, iz, solver.nx, solver.nz, halo, grad_ctx};
+    VrzGradAccessor2D<Order, Z, true>  ez{p_b, lambda_b, vp_b, z_b, ix, iz, solver.nx, solver.nz, halo, grad_ctx};
+    float div_c = centered_gradient_stencil<Order>(cx, solver.M, grad_ctx.coeff, grad_ctx.dx)
+                + centered_gradient_stencil<Order>(cz, solver.M, grad_ctx.coeff, grad_ctx.dz);
+    float div_e = centered_gradient_stencil<Order>(ex, solver.M, grad_ctx.coeff, grad_ctx.dx)
+                + centered_gradient_stencil<Order>(ez, solver.M, grad_ctx.coeff, grad_ctx.dz);
+
+    float v = vp_b[idx];
+    float zz = z_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float lam = lambda_b[idx];
+
+    float dp_dvp   = dpdx * dvpdx + dpdz * dvpdz;
+    float dp_dinvz = dpdx * z1x  + dpdz * z1z;
+
+    float g_vp = 2.0f * v * lam * (lap_x + lap_z)
+               + lam * dp_dvp
+               - div_c
+               + 2.0f * v * zz * lam * dp_dinvz;
+    float g_z  = lam * v * v * dp_dinvz
+               + div_e * inv_z0 * inv_z0;
+
+    float dt2 = solver.dt * solver.dt;
+    grad_vp_b[idx] += -dt2 * g_vp;
+    grad_z_b[idx]  += -dt2 * g_z;
+}
+
+#define BUILD_VRZ_ADJOINT_COEFFS(order, grid, block, ...)                                     \
+    do {                                                                                      \
+        if      ((order) == 2) build_vrz_adjoint_coeffs<2><<<grid, block>>>(__VA_ARGS__);     \
+        else if ((order) == 4) build_vrz_adjoint_coeffs<4><<<grid, block>>>(__VA_ARGS__);     \
+        else if ((order) == 6) build_vrz_adjoint_coeffs<6><<<grid, block>>>(__VA_ARGS__);     \
+        else if ((order) == 8) build_vrz_adjoint_coeffs<8><<<grid, block>>>(__VA_ARGS__);     \
+        else                   build_vrz_adjoint_coeffs<-1><<<grid, block>>>(__VA_ARGS__);    \
+    } while (0)
+
+#define ACOUSTIC_VRZ2D_ADJOINT_FUSED(order, grid, block, ...)                                 \
+    do {                                                                                      \
+        if      ((order) == 2) acoustic_vrz2nd_adjoint_fused<2><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 4) acoustic_vrz2nd_adjoint_fused<4><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 6) acoustic_vrz2nd_adjoint_fused<6><<<grid, block>>>(__VA_ARGS__); \
+        else if ((order) == 8) acoustic_vrz2nd_adjoint_fused<8><<<grid, block>>>(__VA_ARGS__); \
+        else                   acoustic_vrz2nd_adjoint_fused<-1><<<grid, block>>>(__VA_ARGS__);\
+    } while (0)
+
+#define CALCULATE_GRAD_VRZ2D_FUSED(order, grid, block, ...)                                   \
+    do {                                                                                      \
+        if      ((order) == 2) calculate_grad_vrz2d_fused<2><<<grid, block>>>(__VA_ARGS__);   \
+        else if ((order) == 4) calculate_grad_vrz2d_fused<4><<<grid, block>>>(__VA_ARGS__);   \
+        else if ((order) == 6) calculate_grad_vrz2d_fused<6><<<grid, block>>>(__VA_ARGS__);   \
+        else if ((order) == 8) calculate_grad_vrz2d_fused<8><<<grid, block>>>(__VA_ARGS__);   \
+        else                   calculate_grad_vrz2d_fused<-1><<<grid, block>>>(__VA_ARGS__);  \
+    } while (0)
+
+// Gradient dispatch: the fused functor kernel recomputes ∂p at every stencil tap
+// (O(M²) per point), which beats the buffered split path only at low order.
+// Measured on RTX 6000 Ada: order 4 ~1.3–2.0x faster, order 8 ~0.8x (slower).
+// So fuse for order<=4 and fall back to the split (build+calculate) for order>=6.
+#define CALCULATE_GRAD_VRZ2D_AUTO(order, grid, block, P, LAM, VP, Z, INVZ, CX, CZ, EX, EZ, GVP, GZ, GCTX, LCTX, SCTX) \
+    do {                                                                                      \
+        if ((order) == 2 || (order) == 4) {                                                   \
+            CALCULATE_GRAD_VRZ2D_FUSED((order), grid, block,                                  \
+                P, LAM, VP, Z, INVZ, GVP, GZ, GCTX, LCTX, SCTX);                              \
+        } else {                                                                              \
+            BUILD_VRZ_GRAD_FIELDS((order), grid, block,                                       \
+                P, LAM, VP, Z, CX, CZ, EX, EZ, GCTX, SCTX);                                   \
+            CALCULATE_GRAD_VRZ2D((order), grid, block,                                        \
+                P, LAM, CX, CZ, EX, EZ, VP, Z, INVZ, GVP, GZ, GCTX, LCTX, SCTX);              \
+        }                                                                                     \
+    } while (0)

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/backward.cu
@@ -77,11 +77,11 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto aq0 = torch::zeros_like(vp);   // adjoint transpose buffers (b·κ·λ, (∂b·κ)λ)
-    auto aqx = torch::zeros_like(vp);
-    auto aqy = torch::zeros_like(vp);
-    auto aqz = torch::zeros_like(vp);
-    auto c_x = torch::zeros_like(vp);   // gradient assembly buffers (λ·vp·∂p, λ·vp²z·∂p)
+    auto C0 = torch::zeros_like(vp);    // vp²       (time-invariant adjoint coeffs)
+    auto Cx = torch::zeros_like(vp);    // ∂ₓb·κ
+    auto Cy = torch::zeros_like(vp);    // ∂_yb·κ
+    auto Cz = torch::zeros_like(vp);    // ∂_z b·κ
+    auto c_x = torch::zeros_like(vp);   // split gradient scratch (order>=6 path)
     auto c_y = torch::zeros_like(vp);
     auto c_z = torch::zeros_like(vp);
     auto e_x = torch::zeros_like(vp);
@@ -100,25 +100,26 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
     GradParam grad_ctx_y{1, 0, 0, in.M, in.grad_coes.data_ptr<float>(), dy, 0.f, 0.f};
     GradParam grad_ctx_z{1, 0, 0, in.M, in.grad_coes.data_ptr<float>(), dz, 0.f, 0.f};
 
+    // Time-invariant adjoint transpose coefficients, computed once.
+    BUILD_VRZ_ADJOINT_COEFFS_3D(
+        order,
+        launch_config.grid,
+        launch_config.block,
+        vp.data_ptr<float>(),
+        z.data_ptr<float>(),
+        inv_z.data_ptr<float>(),
+        C0.data_ptr<float>(),
+        Cx.data_ptr<float>(),
+        Cy.data_ptr<float>(),
+        Cz.data_ptr<float>(),
+        grad_ctx,
+        ctx
+    );
+
     for (int it = in.nt - 1; it >= 0; --it) {
         auto adj_view = adjoint.view();
-        BUILD_VRZ_ADJOINT_FIELDS_3D(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view.u_now,
-            vp.data_ptr<float>(),
-            z.data_ptr<float>(),
-            inv_z.data_ptr<float>(),
-            aq0.data_ptr<float>(),
-            aqx.data_ptr<float>(),
-            aqy.data_ptr<float>(),
-            aqz.data_ptr<float>(),
-            grad_ctx,
-            ctx
-        );
 
-        ACOUSTIC_VRZ3D_ADJOINT(
+        ACOUSTIC_VRZ3D_ADJOINT_FUSED(
             order,
             launch_config.grid,
             launch_config.block,
@@ -126,10 +127,10 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
-            aq0.data_ptr<float>(),
-            aqx.data_ptr<float>(),
-            aqy.data_ptr<float>(),
-            aqz.data_ptr<float>(),
+            C0.data_ptr<float>(),
+            Cx.data_ptr<float>(),
+            Cy.data_ptr<float>(),
+            Cz.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
             grad_ctx_x,
@@ -150,39 +151,21 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
 
         adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
-        BUILD_VRZ_GRAD_FIELDS_3D(
+        CALCULATE_GRAD_VRZ3D_AUTO(
             order,
             launch_config.grid,
             launch_config.block,
             in.u_forward.select(0, it).select(0, 0).data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            z.data_ptr<float>(),
-            c_x.data_ptr<float>(),
-            c_y.data_ptr<float>(),
-            c_z.data_ptr<float>(),
-            e_x.data_ptr<float>(),
-            e_y.data_ptr<float>(),
-            e_z.data_ptr<float>(),
-            grad_ctx,
-            ctx
-        );
-
-        CALCULATE_GRAD_VRZ3D(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            in.u_forward.select(0, it).select(0, 0).data_ptr<float>(),
-            adjoint.u_now_t.data_ptr<float>(),
-            c_x.data_ptr<float>(),
-            c_y.data_ptr<float>(),
-            c_z.data_ptr<float>(),
-            e_x.data_ptr<float>(),
-            e_y.data_ptr<float>(),
-            e_z.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_y.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_y.data_ptr<float>(),
+            e_z.data_ptr<float>(),
             grad_vp.data_ptr<float>(),
             grad_z.data_ptr<float>(),
             grad_ctx,
@@ -266,11 +249,11 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto aq0 = torch::zeros_like(vp);   // adjoint transpose buffers (b·κ·λ, (∂b·κ)λ)
-    auto aqx = torch::zeros_like(vp);
-    auto aqy = torch::zeros_like(vp);
-    auto aqz = torch::zeros_like(vp);
-    auto c_x = torch::zeros_like(vp);   // gradient assembly buffers (λ·vp·∂p, λ·vp²z·∂p)
+    auto C0 = torch::zeros_like(vp);    // vp²       (time-invariant adjoint coeffs)
+    auto Cx = torch::zeros_like(vp);    // ∂ₓb·κ
+    auto Cy = torch::zeros_like(vp);    // ∂_yb·κ
+    auto Cz = torch::zeros_like(vp);    // ∂_z b·κ
+    auto c_x = torch::zeros_like(vp);   // split gradient scratch (order>=6 path)
     auto c_y = torch::zeros_like(vp);
     auto c_z = torch::zeros_like(vp);
     auto e_x = torch::zeros_like(vp);
@@ -327,26 +310,26 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
     );
     boundary_runtime.prefetch_initial_backward_chunk(p.nt);
 
+    // Time-invariant adjoint transpose coefficients, computed once.
+    BUILD_VRZ_ADJOINT_COEFFS_3D(
+        order,
+        launch_config.grid,
+        launch_config.block,
+        vp.data_ptr<float>(),
+        z.data_ptr<float>(),
+        inv_z.data_ptr<float>(),
+        C0.data_ptr<float>(),
+        Cx.data_ptr<float>(),
+        Cy.data_ptr<float>(),
+        Cz.data_ptr<float>(),
+        grad_ctx,
+        ctx
+    );
+
     for (int it = p.nt - 1; it >= 1; --it) {
         auto adj_view = adjoint.view();
 
-        BUILD_VRZ_ADJOINT_FIELDS_3D(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            adj_view.u_now,
-            vp.data_ptr<float>(),
-            z.data_ptr<float>(),
-            inv_z.data_ptr<float>(),
-            aq0.data_ptr<float>(),
-            aqx.data_ptr<float>(),
-            aqy.data_ptr<float>(),
-            aqz.data_ptr<float>(),
-            grad_ctx,
-            ctx
-        );
-
-        ACOUSTIC_VRZ3D_ADJOINT(
+        ACOUSTIC_VRZ3D_ADJOINT_FUSED(
             order,
             launch_config.grid,
             launch_config.block,
@@ -354,10 +337,10 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
-            aq0.data_ptr<float>(),
-            aqx.data_ptr<float>(),
-            aqy.data_ptr<float>(),
-            aqz.data_ptr<float>(),
+            C0.data_ptr<float>(),
+            Cx.data_ptr<float>(),
+            Cy.data_ptr<float>(),
+            Cz.data_ptr<float>(),
             lap_ctx,
             grad_ctx,
             grad_ctx_x,
@@ -415,39 +398,21 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
 
         forward.swap();
 
-        BUILD_VRZ_GRAD_FIELDS_3D(
+        CALCULATE_GRAD_VRZ3D_AUTO(
             order,
             launch_config.grid,
             launch_config.block,
             forward.u_now_t.data_ptr<float>(),
             adjoint.u_now_t.data_ptr<float>(),
-            vp.data_ptr<float>(),
-            z.data_ptr<float>(),
-            c_x.data_ptr<float>(),
-            c_y.data_ptr<float>(),
-            c_z.data_ptr<float>(),
-            e_x.data_ptr<float>(),
-            e_y.data_ptr<float>(),
-            e_z.data_ptr<float>(),
-            grad_ctx,
-            ctx
-        );
-
-        CALCULATE_GRAD_VRZ3D(
-            order,
-            launch_config.grid,
-            launch_config.block,
-            forward.u_now_t.data_ptr<float>(),
-            adjoint.u_now_t.data_ptr<float>(),
-            c_x.data_ptr<float>(),
-            c_y.data_ptr<float>(),
-            c_z.data_ptr<float>(),
-            e_x.data_ptr<float>(),
-            e_y.data_ptr<float>(),
-            e_z.data_ptr<float>(),
             vp.data_ptr<float>(),
             z.data_ptr<float>(),
             inv_z.data_ptr<float>(),
+            c_x.data_ptr<float>(),
+            c_y.data_ptr<float>(),
+            c_z.data_ptr<float>(),
+            e_x.data_ptr<float>(),
+            e_y.data_ptr<float>(),
+            e_z.data_ptr<float>(),
             grad_vp.data_ptr<float>(),
             grad_z.data_ptr<float>(),
             grad_ctx,
@@ -526,11 +491,11 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
 
     auto grad_vp = torch::zeros_like(vp);
     auto grad_z = torch::zeros_like(z);
-    auto aq0 = torch::zeros_like(vp);   // adjoint transpose buffers (b·κ·λ, (∂b·κ)λ)
-    auto aqx = torch::zeros_like(vp);
-    auto aqy = torch::zeros_like(vp);
-    auto aqz = torch::zeros_like(vp);
-    auto c_x = torch::zeros_like(vp);   // gradient assembly buffers (λ·vp·∂p, λ·vp²z·∂p)
+    auto C0 = torch::zeros_like(vp);    // vp²       (time-invariant adjoint coeffs)
+    auto Cx = torch::zeros_like(vp);    // ∂ₓb·κ
+    auto Cy = torch::zeros_like(vp);    // ∂_yb·κ
+    auto Cz = torch::zeros_like(vp);    // ∂_z b·κ
+    auto c_x = torch::zeros_like(vp);   // split gradient scratch (order>=6 path)
     auto c_y = torch::zeros_like(vp);
     auto c_z = torch::zeros_like(vp);
     auto e_x = torch::zeros_like(vp);
@@ -597,6 +562,22 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
 
     auto chunk_forward = torch::zeros({max_segment_length, N, C, nz, ny, nx}, vp.options());
 
+    // Time-invariant adjoint transpose coefficients, computed once for all segments.
+    BUILD_VRZ_ADJOINT_COEFFS_3D(
+        order,
+        launch_config.grid,
+        launch_config.block,
+        vp.data_ptr<float>(),
+        z.data_ptr<float>(),
+        inv_z.data_ptr<float>(),
+        C0.data_ptr<float>(),
+        Cx.data_ptr<float>(),
+        Cy.data_ptr<float>(),
+        Cz.data_ptr<float>(),
+        grad_ctx,
+        ctx
+    );
+
     for (int segment_id = num_segments - 1; segment_id >= 0; --segment_id) {
         int start;
         int end;
@@ -651,23 +632,7 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
         for (int it = end - 1; it >= start; --it) {
             auto adj_view = adjoint.view();
 
-            BUILD_VRZ_ADJOINT_FIELDS_3D(
-                order,
-                launch_config.grid,
-                launch_config.block,
-                adj_view.u_now,
-                vp.data_ptr<float>(),
-                z.data_ptr<float>(),
-                inv_z.data_ptr<float>(),
-                aq0.data_ptr<float>(),
-                aqx.data_ptr<float>(),
-                aqy.data_ptr<float>(),
-                aqz.data_ptr<float>(),
-                grad_ctx,
-                ctx
-            );
-
-            ACOUSTIC_VRZ3D_ADJOINT(
+            ACOUSTIC_VRZ3D_ADJOINT_FUSED(
                 order,
                 launch_config.grid,
                 launch_config.block,
@@ -675,10 +640,10 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
                 vp.data_ptr<float>(),
                 z.data_ptr<float>(),
                 inv_z.data_ptr<float>(),
-                aq0.data_ptr<float>(),
-                aqx.data_ptr<float>(),
-                aqy.data_ptr<float>(),
-                aqz.data_ptr<float>(),
+                C0.data_ptr<float>(),
+                Cx.data_ptr<float>(),
+                Cy.data_ptr<float>(),
+                Cz.data_ptr<float>(),
                 lap_ctx,
                 grad_ctx,
                 grad_ctx_x,
@@ -699,39 +664,21 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
 
             adjoint.swap_pml();   // rotate u AND psi<->psin: race-free adjoint psi
 
-            BUILD_VRZ_GRAD_FIELDS_3D(
+            CALCULATE_GRAD_VRZ3D_AUTO(
                 order,
                 launch_config.grid,
                 launch_config.block,
                 chunk_forward[it - start].data_ptr<float>(),
                 adjoint.u_now_t.data_ptr<float>(),
-                vp.data_ptr<float>(),
-                z.data_ptr<float>(),
-                c_x.data_ptr<float>(),
-                c_y.data_ptr<float>(),
-                c_z.data_ptr<float>(),
-                e_x.data_ptr<float>(),
-                e_y.data_ptr<float>(),
-                e_z.data_ptr<float>(),
-                grad_ctx,
-                ctx
-            );
-
-            CALCULATE_GRAD_VRZ3D(
-                order,
-                launch_config.grid,
-                launch_config.block,
-                chunk_forward[it - start].data_ptr<float>(),
-                adjoint.u_now_t.data_ptr<float>(),
-                c_x.data_ptr<float>(),
-                c_y.data_ptr<float>(),
-                c_z.data_ptr<float>(),
-                e_x.data_ptr<float>(),
-                e_y.data_ptr<float>(),
-                e_z.data_ptr<float>(),
                 vp.data_ptr<float>(),
                 z.data_ptr<float>(),
                 inv_z.data_ptr<float>(),
+                c_x.data_ptr<float>(),
+                c_y.data_ptr<float>(),
+                c_z.data_ptr<float>(),
+                e_x.data_ptr<float>(),
+                e_y.data_ptr<float>(),
+                e_z.data_ptr<float>(),
                 grad_vp.data_ptr<float>(),
                 grad_z.data_ptr<float>(),
                 grad_ctx,

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/kernels.cuh
@@ -4,6 +4,7 @@
 
 #include "../../common/acoustic.h"
 #include "../../common/context.h"
+#include "../../common/acoustic_vrz_fused.cuh"
 #include "../../operators/gradient.cuh"
 #include "../../operators/laplace.cuh"
 
@@ -805,3 +806,342 @@ __global__ void calculate_grad_vrz3d(
     grad_vp_b[idx] += -dt2 * g_vp;
     grad_z_b[idx]  += -dt2 * g_z;
 }
+
+// ===========================================================================
+// Fused backward kernels (3-D). Same functor recompute-at-tap approach as the
+// 2-D fused kernels, bit-exact (mod fast-math FMA) with the split prepare+apply
+// path.  Time-invariant coefficients (vp², ∂_d b·κ) precomputed once.
+// ===========================================================================
+
+template<int Order>
+__global__ void build_vrz_adjoint_coeffs_3d(
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    float* __restrict__ C0, float* __restrict__ Cx,
+    float* __restrict__ Cy, float* __restrict__ Cz,
+    GradParam grad_ctx,
+    SolverContext solver
+) {
+    int ix, iy, iz, b;
+    vrz3d_index<Order>(solver, ix, iy, iz, b);
+    if (!vrz3d_interior<Order>(solver, ix, iy, iz, b)) return;
+
+    int spatial_size = solver.nx * solver.ny * solver.nz;
+    int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
+    int gidx = b * spatial_size + idx;
+
+    const float* vp_b = vp + b * spatial_size;
+    const float* z_b = z + b * spatial_size;
+    const float* inv_z_b = inv_z + b * spatial_size;
+
+    float dvpdx = gradient<3, Order, X>(vp_b, ix, iy, iz, grad_ctx);
+    float dvpdy = gradient<3, Order, Y>(vp_b, ix, iy, iz, grad_ctx);
+    float dvpdz = gradient<3, Order, Z>(vp_b, ix, iy, iz, grad_ctx);
+    float z1x = gradient<3, Order, X>(inv_z_b, ix, iy, iz, grad_ctx);
+    float z1y = gradient<3, Order, Y>(inv_z_b, ix, iy, iz, grad_ctx);
+    float z1z = gradient<3, Order, Z>(inv_z_b, ix, iy, iz, grad_ctx);
+    float v = vp_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float kappa = v * z_b[idx];
+    float dbdx = dvpdx * inv_z0 + v * z1x;
+    float dbdy = dvpdy * inv_z0 + v * z1y;
+    float dbdz = dvpdz * inv_z0 + v * z1z;
+
+    C0[gidx] = v * v;
+    Cx[gidx] = dbdx * kappa;
+    Cy[gidx] = dbdy * kappa;
+    Cz[gidx] = dbdz * kappa;
+}
+
+template<int Order>
+__global__ void acoustic_vrz3nd_adjoint_fused(
+    AcousticWavefieldPointer wf,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    const float* __restrict__ C0,
+    const float* __restrict__ Cx,
+    const float* __restrict__ Cy,
+    const float* __restrict__ Cz,
+    LaplaceParam lap_ctx,
+    GradParam grad_ctx,
+    GradParam grad_ctx_x,
+    GradParam grad_ctx_y,
+    GradParam grad_ctx_z,
+    AcousticCPMLPointer cpml,
+    SolverContext solver
+) {
+    int ix, iy, iz, b;
+    vrz3d_index<Order>(solver, ix, iy, iz, b);
+    if (!vrz3d_interior<Order>(solver, ix, iy, iz, b)) return;
+
+    int spatial_size = solver.nx * solver.ny * solver.nz;
+    int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
+
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int m_static = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : m_static;
+
+    auto f = wf.offset(b, spatial_size);
+
+    bool in_pml = (ix < solver.abcn + halo) || (ix >= solver.nx - solver.abcn - halo) ||
+                  (iy < solver.abcn + halo) || (iy >= solver.ny - solver.abcn - halo) ||
+                  (iz < (solver.free_surface ? halo : solver.abcn + halo)) ||
+                  (iz >= solver.nz - solver.abcn - halo);
+
+    if (!in_pml) {
+        const float* C0_b = C0 + b * spatial_size;
+        const float* Cx_b = Cx + b * spatial_size;
+        const float* Cy_b = Cy + b * spatial_size;
+        const float* Cz_b = Cz + b * spatial_size;
+        const float* lam = f.u_now;
+        int sy = solver.nx;
+        int sz = solver.nx * solver.ny;
+
+        VrzProductAccessor a0x{C0_b, lam, idx, 1};
+        VrzProductAccessor a0y{C0_b, lam, idx, sy};
+        VrzProductAccessor a0z{C0_b, lam, idx, sz};
+        float lap_x = centered_laplace1d_stencil<Order>(a0x, lap_ctx.dx, solver.M, lap_ctx.coeff);
+        float lap_y = centered_laplace1d_stencil<Order>(a0y, lap_ctx.dy, solver.M, lap_ctx.coeff);
+        float lap_z = centered_laplace1d_stencil<Order>(a0z, lap_ctx.dz, solver.M, lap_ctx.coeff);
+
+        VrzProductAccessor axx{Cx_b, lam, idx, 1};
+        VrzProductAccessor ayy{Cy_b, lam, idx, sy};
+        VrzProductAccessor azz{Cz_b, lam, idx, sz};
+        float gx = centered_gradient_stencil<Order>(axx, solver.M, grad_ctx.coeff, grad_ctx.dx);
+        float gy = centered_gradient_stencil<Order>(ayy, solver.M, grad_ctx.coeff, grad_ctx.dy);
+        float gz = centered_gradient_stencil<Order>(azz, solver.M, grad_ctx.coeff, grad_ctx.dz);
+
+        float rhs = (lap_x + lap_y + lap_z) - gx - gy - gz;
+        f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + solver.dt * solver.dt * rhs;
+        return;
+    }
+
+    // PML branch: identical to acoustic_vrz3nd_adjoint (recompute from u_now).
+    const float* vp_b = vp + b * spatial_size;
+    const float* z_b = z + b * spatial_size;
+    const float* inv_z_b = inv_z + b * spatial_size;
+
+    float lap_x = laplace<3, Order, X>(f.u_now, ix, iy, iz, lap_ctx);
+    float lap_y = laplace<3, Order, Y>(f.u_now, ix, iy, iz, lap_ctx);
+    float lap_z = laplace<3, Order, Z>(f.u_now, ix, iy, iz, lap_ctx);
+
+    float dudx = gradient<3, Order, X>(f.u_now, ix, iy, iz, grad_ctx);
+    float dudy = gradient<3, Order, Y>(f.u_now, ix, iy, iz, grad_ctx);
+    float dudz = gradient<3, Order, Z>(f.u_now, ix, iy, iz, grad_ctx);
+
+    float dvpdx = gradient<3, Order, X>(vp_b, ix, iy, iz, grad_ctx);
+    float dvpdy = gradient<3, Order, Y>(vp_b, ix, iy, iz, grad_ctx);
+    float dvpdz = gradient<3, Order, Z>(vp_b, ix, iy, iz, grad_ctx);
+    float z1x = gradient<3, Order, X>(inv_z_b, ix, iy, iz, grad_ctx);
+    float z1y = gradient<3, Order, Y>(inv_z_b, ix, iy, iz, grad_ctx);
+    float z1z = gradient<3, Order, Z>(inv_z_b, ix, iy, iz, grad_ctx);
+
+    float v = vp_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float beta = v * inv_z0;
+    float kappa = v * z_b[idx];
+    float dbdx = dvpdx * inv_z0 + v * z1x;
+    float dbdy = dvpdy * inv_z0 + v * z1y;
+    float dbdz = dvpdz * inv_z0 + v * z1z;
+
+    float dpsixdx = gradient<3, Order, X>(f.psix, ix, iy, iz, grad_ctx);
+    float dpsiydy = gradient<3, Order, Y>(f.psiy, ix, iy, iz, grad_ctx);
+    float dpsizdz = gradient<3, Order, Z>(f.psiz, ix, iy, iz, grad_ctx);
+
+    float daxdx = gradient<2, Order, X>(cpml.ax, ix, 0, 0, grad_ctx_x);
+    float daydy = gradient<2, Order, X>(cpml.ay, iy, 0, 0, grad_ctx_y);
+    float dazdz = gradient<2, Order, X>(cpml.az, iz, 0, 0, grad_ctx_z);
+
+    float ax_ = cpml.ax[ix];
+    float ay_ = cpml.ay[iy];
+    float az_ = cpml.az[iz];
+    float bx_ = cpml.bx[ix];
+    float by_ = cpml.by[iy];
+    float bz_ = cpml.bz[iz];
+
+    float tmpx = ((1.0f + bx_) * lap_x + cpml.dbxdx[ix] * dudx)
+               + daxdx * f.psix[idx] + ax_ * dpsixdx;
+    float tmpy = ((1.0f + by_) * lap_y + cpml.dbydy[iy] * dudy)
+               + daydy * f.psiy[idx] + ay_ * dpsiydy;
+    float tmpz = ((1.0f + bz_) * lap_z + cpml.dbzdz[iz] * dudz)
+               + dazdz * f.psiz[idx] + az_ * dpsizdz;
+
+    float psixn = bx_ * dudx + ax_ * f.psix[idx];
+    float psiyn = by_ * dudy + ay_ * f.psiy[idx];
+    float psizn = bz_ * dudz + az_ * f.psiz[idx];
+    float zetaxn = bx_ * tmpx + ax_ * f.zetax[idx];
+    float zetayn = by_ * tmpy + ay_ * f.zetay[idx];
+    float zetazn = bz_ * tmpz + az_ * f.zetaz[idx];
+
+    float px = dudx + psixn;
+    float py = dudy + psiyn;
+    float pz = dudz + psizn;
+    float w_sum = (1.0f + bx_) * tmpx + ax_ * f.zetax[idx]
+                + (1.0f + by_) * tmpy + ay_ * f.zetay[idx]
+                + (1.0f + bz_) * tmpz + az_ * f.zetaz[idx];
+
+    float rhs = kappa * (beta * w_sum + dbdx * px + dbdy * py + dbdz * pz);
+
+    (f.psixn ? f.psixn : f.psix)[idx] = psixn;
+    (f.psiyn ? f.psiyn : f.psiy)[idx] = psiyn;
+    (f.psizn ? f.psizn : f.psiz)[idx] = psizn;
+    f.zetax[idx] = zetaxn;
+    f.zetay[idx] = zetayn;
+    f.zetaz[idx] = zetazn;
+    f.u_next[idx] = 2.0f * f.u_now[idx] - f.u_prev[idx] + solver.dt * solver.dt * rhs;
+}
+
+// Accessor recomputing c_d = λ·vp·∂_d p (UseE=false) or e_d = λ·vp²·z·∂_d p
+// (UseE=true) at stencil tap `off` along Dir, matching build_vrz_grad_fields_3d.
+template<int Order, int Dir, bool UseE>
+struct VrzGradAccessor3D {
+    const float* __restrict__ p;
+    const float* __restrict__ lam;
+    const float* __restrict__ vp;
+    const float* __restrict__ z;
+    int ix, iy, iz, b;
+    SolverContext solver;
+    GradParam grad_ctx;
+
+    __device__ __forceinline__ float operator()(int off) const
+    {
+        int jx = ix, jy = iy, jz = iz;
+        if constexpr (Dir & X) jx = ix + off;
+        else if constexpr (Dir & Y) jy = iy + off;
+        else jz = iz + off;
+        if (!vrz3d_interior<Order>(solver, jx, jy, jz, b))
+            return 0.f;
+        int j = jz * solver.nx * solver.ny + jy * solver.nx + jx;
+        float dpd = gradient<3, Order, Dir>(p, jx, jy, jz, grad_ctx);
+        float lam_j = lam[j];
+        float v_j = vp[j];
+        if constexpr (UseE) {
+            float lam_v2z = ((lam_j * v_j) * v_j) * z[j];
+            return lam_v2z * dpd;
+        } else {
+            float lam_v = lam_j * v_j;
+            return lam_v * dpd;
+        }
+    }
+};
+
+template<int Order>
+__global__ void calculate_grad_vrz3d_fused(
+    const float* __restrict__ f_u_now,
+    const float* __restrict__ lambda_now,
+    const float* __restrict__ vp,
+    const float* __restrict__ z,
+    const float* __restrict__ inv_z,
+    float* __restrict__ grad_vp,
+    float* __restrict__ grad_z,
+    GradParam grad_ctx,
+    LaplaceParam lap_ctx,
+    SolverContext solver
+) {
+    int ix, iy, iz, b;
+    vrz3d_index<Order>(solver, ix, iy, iz, b);
+    if (!vrz3d_interior<Order>(solver, ix, iy, iz, b)) return;
+
+    int spatial_size = solver.nx * solver.ny * solver.nz;
+    int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
+    int shift = b * spatial_size;
+
+    const float* p_b = f_u_now + shift;
+    const float* lambda_b = lambda_now + shift;
+    const float* vp_b = vp + shift;
+    const float* z_b = z + shift;
+    const float* inv_z_b = inv_z + shift;
+    float* grad_vp_b = grad_vp + shift;
+    float* grad_z_b = grad_z + shift;
+
+    float lap_x = laplace<3, Order, X>(p_b, ix, iy, iz, lap_ctx);
+    float lap_y = laplace<3, Order, Y>(p_b, ix, iy, iz, lap_ctx);
+    float lap_z = laplace<3, Order, Z>(p_b, ix, iy, iz, lap_ctx);
+
+    float dpdx = gradient<3, Order, X>(p_b, ix, iy, iz, grad_ctx);
+    float dpdy = gradient<3, Order, Y>(p_b, ix, iy, iz, grad_ctx);
+    float dpdz = gradient<3, Order, Z>(p_b, ix, iy, iz, grad_ctx);
+
+    float dvpdx = gradient<3, Order, X>(vp_b, ix, iy, iz, grad_ctx);
+    float dvpdy = gradient<3, Order, Y>(vp_b, ix, iy, iz, grad_ctx);
+    float dvpdz = gradient<3, Order, Z>(vp_b, ix, iy, iz, grad_ctx);
+    float z1x = gradient<3, Order, X>(inv_z_b, ix, iy, iz, grad_ctx);
+    float z1y = gradient<3, Order, Y>(inv_z_b, ix, iy, iz, grad_ctx);
+    float z1z = gradient<3, Order, Z>(inv_z_b, ix, iy, iz, grad_ctx);
+
+    VrzGradAccessor3D<Order, X, false> cx{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
+    VrzGradAccessor3D<Order, Y, false> cy{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
+    VrzGradAccessor3D<Order, Z, false> cz{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
+    float div_c = centered_gradient_stencil<Order>(cx, solver.M, grad_ctx.coeff, grad_ctx.dx)
+                + centered_gradient_stencil<Order>(cy, solver.M, grad_ctx.coeff, grad_ctx.dy)
+                + centered_gradient_stencil<Order>(cz, solver.M, grad_ctx.coeff, grad_ctx.dz);
+    VrzGradAccessor3D<Order, X, true> ex{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
+    VrzGradAccessor3D<Order, Y, true> ey{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
+    VrzGradAccessor3D<Order, Z, true> ez{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
+    float div_e = centered_gradient_stencil<Order>(ex, solver.M, grad_ctx.coeff, grad_ctx.dx)
+                + centered_gradient_stencil<Order>(ey, solver.M, grad_ctx.coeff, grad_ctx.dy)
+                + centered_gradient_stencil<Order>(ez, solver.M, grad_ctx.coeff, grad_ctx.dz);
+
+    float v = vp_b[idx];
+    float zz = z_b[idx];
+    float inv_z0 = inv_z_b[idx];
+    float lam = lambda_b[idx];
+
+    float dp_dvp   = dpdx * dvpdx + dpdy * dvpdy + dpdz * dvpdz;
+    float dp_dinvz = dpdx * z1x  + dpdy * z1y  + dpdz * z1z;
+
+    float g_vp = 2.0f * v * lam * (lap_x + lap_y + lap_z)
+               + lam * dp_dvp
+               - div_c
+               + 2.0f * v * zz * lam * dp_dinvz;
+    float g_z  = lam * v * v * dp_dinvz
+               + div_e * inv_z0 * inv_z0;
+
+    float dt2 = solver.dt * solver.dt;
+    grad_vp_b[idx] += -dt2 * g_vp;
+    grad_z_b[idx]  += -dt2 * g_z;
+}
+
+#define BUILD_VRZ_ADJOINT_COEFFS_3D(order, grid, block, ...)                                    \
+    do {                                                                                        \
+        if      ((order) == 2) build_vrz_adjoint_coeffs_3d<2><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 4) build_vrz_adjoint_coeffs_3d<4><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 6) build_vrz_adjoint_coeffs_3d<6><<<grid, block>>>(__VA_ARGS__);    \
+        else if ((order) == 8) build_vrz_adjoint_coeffs_3d<8><<<grid, block>>>(__VA_ARGS__);    \
+        else                   build_vrz_adjoint_coeffs_3d<-1><<<grid, block>>>(__VA_ARGS__);   \
+    } while (0)
+
+#define ACOUSTIC_VRZ3D_ADJOINT_FUSED(order, grid, block, ...)                                   \
+    do {                                                                                        \
+        if      ((order) == 2) acoustic_vrz3nd_adjoint_fused<2><<<grid, block>>>(__VA_ARGS__);  \
+        else if ((order) == 4) acoustic_vrz3nd_adjoint_fused<4><<<grid, block>>>(__VA_ARGS__);  \
+        else if ((order) == 6) acoustic_vrz3nd_adjoint_fused<6><<<grid, block>>>(__VA_ARGS__);  \
+        else if ((order) == 8) acoustic_vrz3nd_adjoint_fused<8><<<grid, block>>>(__VA_ARGS__);  \
+        else                   acoustic_vrz3nd_adjoint_fused<-1><<<grid, block>>>(__VA_ARGS__); \
+    } while (0)
+
+#define CALCULATE_GRAD_VRZ3D_FUSED(order, grid, block, ...)                                     \
+    do {                                                                                        \
+        if      ((order) == 2) calculate_grad_vrz3d_fused<2><<<grid, block>>>(__VA_ARGS__);     \
+        else if ((order) == 4) calculate_grad_vrz3d_fused<4><<<grid, block>>>(__VA_ARGS__);     \
+        else if ((order) == 6) calculate_grad_vrz3d_fused<6><<<grid, block>>>(__VA_ARGS__);     \
+        else if ((order) == 8) calculate_grad_vrz3d_fused<8><<<grid, block>>>(__VA_ARGS__);     \
+        else                   calculate_grad_vrz3d_fused<-1><<<grid, block>>>(__VA_ARGS__);    \
+    } while (0)
+
+// Gradient dispatch (see 2-D note): fuse for order<=4, split for order>=6 where
+// the O(M²) nested stencils regress (order 8 measured ~0.67x on RTX 6000 Ada).
+#define CALCULATE_GRAD_VRZ3D_AUTO(order, grid, block, P, LAM, VP, Z, INVZ, CX, CY, CZ, EX, EY, EZ, GVP, GZ, GCTX, LCTX, SCTX) \
+    do {                                                                                        \
+        if ((order) == 2 || (order) == 4) {                                                     \
+            CALCULATE_GRAD_VRZ3D_FUSED((order), grid, block,                                    \
+                P, LAM, VP, Z, INVZ, GVP, GZ, GCTX, LCTX, SCTX);                                \
+        } else {                                                                                \
+            BUILD_VRZ_GRAD_FIELDS_3D((order), grid, block,                                      \
+                P, LAM, VP, Z, CX, CY, CZ, EX, EY, EZ, GCTX, SCTX);                             \
+            CALCULATE_GRAD_VRZ3D((order), grid, block,                                          \
+                P, LAM, CX, CY, CZ, EX, EY, EZ, VP, Z, INVZ, GVP, GZ, GCTX, LCTX, SCTX);        \
+        }                                                                                       \
+    } while (0)


### PR DESCRIPTION
## Summary
Fuses the AcousticVRZ backward kernels (2D & 3D) and fixes a boundary-saving reconstruction accuracy gap.

### perf: fuse backward adjoint + gradient kernels (2D/3D) — `41ec69a`
- Backward per step: 5 kernels → 3, via functor recompute-at-tap (mirrors the elastic fused adjoint), not shared-mem tiling.
- **Adjoint kernel** fused: time-invariant transpose coefficients (`vp²`, `∂ₓb·κ`, `∂_z b·κ`) precomputed once outside the loop; each step a functor multiplies by λ to form `∇²(vp²λ) − ∂ₓ(∂ₓb·κ·λ) − …`. O(M), always fused. PML branch unchanged.
- **Gradient kernel** fused: nested O(M²) recompute — wins at low order, regresses at order 8. Dispatched by `CALCULATE_GRAD_VRZ*_AUTO`: order 2/4 fused, order≥6/runtime falls back to the split path.
- All three backward paths (full / bs / ckpt) × 2D/3D.
- **Bit-exact** vs the pre-fuse split path (cos = 1.0, rel ≤ 6.5e-7; residual is `--use_fast_math` FMA contraction only).
- **Speedup** (RTX 6000 Ada, impl='c', full store-all): backward order4 2D 1.2–2.0× / 3D 1.1–1.5×; order8 no regression; forward unchanged.

### fix: zero boundary band in bs reconstruction — `345da32`
- `acoustic_vrz2d` `backward_bs` copied `u_last_two` (full-domain live PML values) into the reverse-reconstruction initial state without zeroing the boundary/PML band, so stale PML values leaked inward and reduced bs gradient accuracy. `acoustic2d` `backward_bs` already does this; add the same `set_boundary_zeros` on the initial `forward.u_prev/u_now`.
- bs-vs-eager gradient cos improves (fd_edge grad_z 0.916 → 0.969); typical FWI geometry (source below the free surface) is 0.99+ and unaffected. One-time cost (2 launches before the loop), no effect on the fused per-step path.

## Test
- `solver_gradient_mode_suite --solvers vrz2d,vrz3d`: all pass (8 modes × 3 scenarios).
- Fused vs pre-fuse split: cos = 1.0.
- Forward record C == eager: rel ~ 1e-6; baseline VRZ gradient vs eager on clean geometry cos 0.997–0.9998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
