### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-24
+
 ### Added
 - **Domain decomposition (`sweep.parallel`).**  `ModelParallel` splits one
   model into tiles — one GPU per tile — and exchanges a halo every time step,
@@ -127,4 +129,5 @@ see the
 [GitHub commit history](https://github.com/DeepWave-KAUST/sweep/commits/dev)
 for changes prior to this entry.
 
-[Unreleased]: https://github.com/DeepWave-KAUST/sweep/compare/main...dev
+[Unreleased]: https://github.com/DeepWave-KAUST/sweep/compare/v0.2.0...dev
+[0.2.0]: https://github.com/DeepWave-KAUST/sweep/compare/v0.1.0...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sweep-solver"
-version = "0.1.0"
+version = "0.2.0"
 description = "Seismic Wave Equation Exploration Platform — equations, propagators, operators."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/sweep/__init__.py
+++ b/src/sweep/__init__.py
@@ -18,6 +18,13 @@ convenience namespace.
 
 from __future__ import annotations
 
+try:  # distribution name differs from the import name (`sweep`)
+    from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+    __version__ = _pkg_version("sweep-solver")
+except (ImportError, PackageNotFoundError):  # a source tree with nothing installed
+    __version__ = "unknown"
+
 import sys
 from importlib import import_module
 from importlib.abc import MetaPathFinder


### PR DESCRIPTION
Version bump for the domain-decomposition release; the content itself landed in #63.

- `sweep-solver` 0.1.0 -> 0.2.0, `sweepx` 0.1.1 -> 0.2.0 (its own non-git tree)
- CHANGELOG `[Unreleased]` -> `[0.2.0]`
- `sweep.__version__` now resolves from the installed distribution's metadata; it was `None` before, which the 0.1.0 release noted and deferred

Both packages are already on PyPI:
- https://pypi.org/project/sweep-solver/0.2.0/
- https://pypi.org/project/sweepx/0.2.0/