### PR TITLE
fix(binding): a pre-built _C needs no CUDA toolkit at run time

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -132,8 +132,9 @@ From Python, the simplest one-liner is:
 ```python
 import sweep
 
-# True when PyTorch + a CUDA GPU + nvcc are present, so sweep._C can be
-# JIT-compiled on first use (this check itself does NOT trigger the compile).
+# True when sweep._C is already compiled on disk, OR PyTorch + a CUDA GPU +
+# nvcc are present so it can be JIT-compiled on first use (this check itself
+# does NOT trigger the compile).
 print(sweep.is_torch_binding_available())
 ```
 
@@ -144,9 +145,9 @@ import sweep
 
 print(sweep.backend.torch.is_available())            # PyTorch importable
 print(sweep.backend.torch.cuda.is_available())       # PyTorch sees a CUDA device
-print(sweep.backend.torch.binding.is_available())    # backend usable (torch + GPU + nvcc>=12.4)
-print(sweep.backend.torch.binding.is_compiled())     # backend already built (compiled/cached)
-print(sweep.backend.torch.binding.diagnostics())     # {'usable', 'reason', 'cuda_home', 'already_compiled'}
+print(sweep.backend.torch.binding.is_available())    # backend usable (pre-built, or torch + GPU + nvcc>=12.4)
+print(sweep.backend.torch.binding.is_compiled())     # backend already built (pre-built/compiled/cached)
+print(sweep.backend.torch.binding.diagnostics())     # {'usable', 'reason', 'cuda_home', 'already_compiled', 'prebuilt'}
 print(sweep.backend.jax.is_available())              # JAX importable
 ```
 

--- a/src/sweep/__init__.py
+++ b/src/sweep/__init__.py
@@ -28,6 +28,7 @@ except (ImportError, PackageNotFoundError):  # a source tree with nothing instal
 import sys
 from importlib import import_module
 from importlib.abc import MetaPathFinder
+from importlib.machinery import EXTENSION_SUFFIXES
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -87,12 +88,42 @@ def _extend_package_path_with_build_outputs() -> None:
 _extend_package_path_with_build_outputs()
 
 
+def _is_extension_origin(origin: str | None) -> bool:
+    """True when a module spec's origin is a compiled extension rather than a
+    ``.py`` file — i.e. ``sweep._C`` is a real binary, not the JIT shim."""
+    return bool(origin) and origin.endswith(tuple(EXTENSION_SUFFIXES))
+
+
+def _prebuilt_binding_present() -> bool:
+    """True when a compiled ``sweep._C`` extension already exists on disk.
+
+    Two ways to get one: a wheel built with ``SWEEP_BUILD_CUDA=1``, or
+    ``setup.py build_ext --inplace`` (whose output `_extend_package_path_with_
+    build_outputs` above already puts on ``sweep.__path__``). Either way the
+    kernels are compiled, so no CUDA toolkit is needed at run time.
+
+    Resolves the spec without importing, so this never compiles anything.
+    """
+    try:
+        spec = find_spec("sweep._C")
+    except Exception:
+        return False
+    return spec is not None and _is_extension_origin(spec.origin)
+
+
 def is_torch_binding_available() -> bool:
-    """Return True when PyTorch + a CUDA GPU + nvcc are present, so ``sweep._C``
+    """Return True when ``sweep._C`` can be used for ``impl='c'`` — either it is
+    already compiled on disk, or PyTorch + a CUDA GPU + nvcc are present so it
     can be JIT-compiled against your torch on first use. Does NOT trigger the
     compile itself (see ``sweep._jit``)."""
     if find_spec("torch") is None:
         return False
+    # A pre-built extension answers this on its own: the kernels exist, and
+    # asking `can_build()` would demand an nvcc the run does not need. Checking
+    # this first is what keeps a `SWEEP_BUILD_CUDA=1` install from silently
+    # falling back to eager on a node with no CUDA toolkit loaded.
+    if _prebuilt_binding_present():
+        return True
     try:
         from sweep import _jit
         return _jit.can_build()[0]

--- a/src/sweep/backend/torch/binding.py
+++ b/src/sweep/backend/torch/binding.py
@@ -1,29 +1,37 @@
 """Compiled PyTorch CUDA binding capability helpers.
 
-``sweep._C`` is JIT-compiled from source on first use (see ``sweep/_jit.py``), so a
-plain ``import sweep._C`` always succeeds regardless of whether the compile can or
-did happen. These helpers therefore report the real state without triggering a
-compile.
+``sweep._C`` reaches a process one of two ways. Normally it is JIT-compiled from
+source on first use (see ``sweep/_jit.py``), so a plain ``import sweep._C``
+always succeeds and says nothing about whether the compile can happen. But a
+wheel built with ``SWEEP_BUILD_CUDA=1`` — or ``setup.py build_ext --inplace`` —
+ships a real compiled extension instead, and then no CUDA toolkit is needed at
+run time at all. These helpers report the real state across both, without
+triggering a compile.
 """
 
 import os
 
 
 def is_available() -> bool:
-    """True when the compiled ``sweep._C`` backend is **usable** — i.e. PyTorch,
-    a CUDA GPU and a suitable ``nvcc`` (>=12.4) are present, so it can be (or
-    already is) JIT-compiled. Does NOT trigger the compile."""
+    """True when the compiled ``sweep._C`` backend is **usable** — either it is
+    already compiled on disk (needing no toolkit), or PyTorch, a CUDA GPU and a
+    suitable ``nvcc`` (>=12.4) are present so it can be JIT-compiled on first
+    use. Does NOT trigger the compile."""
     try:
-        from sweep import _jit
-        return _jit.can_build()[0]
+        from sweep import is_torch_binding_available
+        return is_torch_binding_available()
     except Exception:
         return False
 
 
 def is_compiled() -> bool:
-    """True when the backend is already built — compiled in this process, or a
-    cached ``.so`` from a previous run — so the first ``impl='c'`` use is instant."""
+    """True when the backend is already built — an ahead-of-time extension, one
+    compiled in this process, or a cached ``.so`` from a previous JIT run — so
+    the first ``impl='c'`` use is instant."""
     try:
+        from sweep import _prebuilt_binding_present
+        if _prebuilt_binding_present():
+            return True
         from sweep import _jit
         if _jit._module is not None:
             return True
@@ -35,19 +43,26 @@ def is_compiled() -> bool:
 
 
 def diagnostics() -> dict:
-    """Diagnostics for the compiled backend — usable / why-not / nvcc / built."""
+    """Diagnostics for the compiled backend — usable / why-not / nvcc / built.
+
+    ``prebuilt`` is the one that explains an otherwise confusing pair: with an
+    ahead-of-time extension the backend is usable even though ``cuda_home`` is
+    None, because nothing has to be compiled.
+    """
     try:
-        from sweep import _jit
-        usable, reason = _jit.can_build()
+        from sweep import _jit, _prebuilt_binding_present
+        prebuilt = _prebuilt_binding_present()
+        can_jit, reason = _jit.can_build()
         return {
-            "usable": usable,             # can impl='c' be used (built now / on first use)?
-            "reason": reason,             # explanation when usable is False
+            "usable": prebuilt or can_jit,   # can impl='c' be used at all?
+            "reason": "ok (pre-built extension)" if prebuilt else reason,
             "cuda_home": _jit._find_cuda_home(),
             "already_compiled": is_compiled(),
+            "prebuilt": prebuilt,            # compiled ahead of time, no toolkit needed
         }
     except Exception as exc:  # pragma: no cover
         return {"usable": False, "reason": f"{type(exc).__name__}: {exc}",
-                "cuda_home": None, "already_compiled": False}
+                "cuda_home": None, "already_compiled": False, "prebuilt": False}
 
 
 __all__ = ["diagnostics", "is_available", "is_compiled"]

--- a/test/test_prebuilt_binding_available.py
+++ b/test/test_prebuilt_binding_available.py
@@ -1,0 +1,154 @@
+"""``is_torch_binding_available()`` must not require a CUDA toolkit when the
+compiled ``sweep._C`` is already built.
+
+The regression it guards: the probe used to ask ``_jit.can_build()`` — "could I
+JIT-compile this?" — which needs nvcc. On a machine that installed with
+``SWEEP_BUILD_CUDA=1`` (or ran ``setup.py build_ext --inplace``) and then ran
+without a CUDA toolkit on PATH, the answer was False even though ``sweep._C``
+imported fine, so ``impl='c'`` silently fell back to eager with only a warning
+— a ~10-30x slowdown whose cause is invisible from the symptom.
+"""
+
+import pytest
+
+import sweep
+
+
+class TestExtensionOriginClassification:
+    """The suffix test that decides "real binary" vs "JIT shim"."""
+
+    @pytest.mark.parametrize("origin", [
+        "/x/sweep/_C.cpython-312-x86_64-linux-gnu.so",
+        "/x/sweep/_C.abi3.so",
+        "/x/sweep/_C.cp312-win_amd64.pyd",
+    ])
+    def test_compiled_extensions_are_recognised(self, origin):
+        # Only assert on suffixes this interpreter actually knows about;
+        # EXTENSION_SUFFIXES is platform-specific.
+        from importlib.machinery import EXTENSION_SUFFIXES
+        if not origin.endswith(tuple(EXTENSION_SUFFIXES)):
+            pytest.skip(f"{origin} is not an extension suffix on this platform")
+        assert sweep._is_extension_origin(origin) is True
+
+    @pytest.mark.parametrize("origin", [
+        "/x/sweep/_C.py",            # the lazy JIT shim
+        "/x/sweep/_C/__init__.py",
+        "",
+        None,
+    ])
+    def test_source_and_missing_origins_are_not_extensions(self, origin):
+        assert sweep._is_extension_origin(origin) is False
+
+
+@pytest.fixture
+def torch_present(monkeypatch):
+    """The probe returns False outright when torch is missing. These tests are
+    about the decision AFTER that gate, so pin it — otherwise they quietly pass
+    for the wrong reason on a torch-less interpreter."""
+    real_find_spec = sweep.find_spec
+    monkeypatch.setattr(
+        sweep, "find_spec",
+        lambda name: object() if name == "torch" else real_find_spec(name))
+
+
+class TestAvailabilityProbe:
+    def test_prebuilt_binding_beats_a_missing_toolkit(self, monkeypatch, torch_present):
+        """This is the bug: built kernels + no nvcc must still report available."""
+        from sweep import _jit
+        monkeypatch.setattr(sweep, "_prebuilt_binding_present", lambda: True)
+        monkeypatch.setattr(
+            _jit, "can_build",
+            lambda: (False, "no suitable CUDA toolkit found (need nvcc >=12.4 ...)"))
+
+        assert sweep.is_torch_binding_available() is True
+
+    def test_without_a_prebuilt_binding_the_toolkit_decides(self, monkeypatch, torch_present):
+        """The JIT path is unchanged: no binary on disk means nvcc is required."""
+        from sweep import _jit
+        monkeypatch.setattr(sweep, "_prebuilt_binding_present", lambda: False)
+
+        monkeypatch.setattr(_jit, "can_build", lambda: (False, "no nvcc"))
+        assert sweep.is_torch_binding_available() is False
+
+        monkeypatch.setattr(_jit, "can_build", lambda: (True, "ok"))
+        assert sweep.is_torch_binding_available() is True
+
+    def test_probe_never_triggers_the_jit_compile(self, monkeypatch, torch_present):
+        """The whole point of the probe is to answer without a surprise ~3 min
+        build, so it must not reach ``_jit.load()`` on either path."""
+        from sweep import _jit
+
+        def explode():
+            raise AssertionError("is_torch_binding_available() triggered a compile")
+
+        monkeypatch.setattr(_jit, "load", explode)
+        monkeypatch.setattr(sweep, "_prebuilt_binding_present", lambda: False)
+        sweep.is_torch_binding_available()
+        monkeypatch.setattr(sweep, "_prebuilt_binding_present", lambda: True)
+        sweep.is_torch_binding_available()
+
+    def test_spec_lookup_is_resilient(self, monkeypatch):
+        """A broken importer must degrade to 'ask the toolkit', not raise out of
+        a predicate every propagator construction calls."""
+        def boom(_name):
+            raise ImportError("meta path finder is unhappy")
+
+        monkeypatch.setattr(sweep, "find_spec", boom)
+        assert sweep._prebuilt_binding_present() is False
+
+
+def test_missing_torch_short_circuits(monkeypatch):
+    """No torch, no compiled path — regardless of what is on disk."""
+    monkeypatch.setattr(sweep, "find_spec", lambda name: None)
+    assert sweep.is_torch_binding_available() is False
+
+
+class TestBindingDiagnostics:
+    """``sweep.backend.torch.binding`` asked the same wrong question in three
+    more places, and its answers are what a confused user reads first."""
+
+    def test_is_available_follows_the_one_probe(self, monkeypatch):
+        from sweep.backend.torch import binding
+
+        monkeypatch.setattr(sweep, "is_torch_binding_available", lambda: True)
+        assert binding.is_available() is True
+        monkeypatch.setattr(sweep, "is_torch_binding_available", lambda: False)
+        assert binding.is_available() is False
+
+    def test_prebuilt_counts_as_compiled(self, monkeypatch):
+        """An ahead-of-time extension IS the built backend; reporting 'not
+        compiled' because the JIT cache is empty sends people to rebuild
+        something they already have."""
+        from sweep.backend.torch import binding
+
+        monkeypatch.setattr(sweep, "_prebuilt_binding_present", lambda: True)
+        assert binding.is_compiled() is True
+
+    def test_diagnostics_explains_usable_without_a_toolkit(self, monkeypatch):
+        from sweep import _jit
+        from sweep.backend.torch import binding
+
+        monkeypatch.setattr(sweep, "_prebuilt_binding_present", lambda: True)
+        monkeypatch.setattr(_jit, "can_build", lambda: (False, "no nvcc"))
+        monkeypatch.setattr(_jit, "_find_cuda_home", lambda: None)
+
+        d = binding.diagnostics()
+        assert d["usable"] is True
+        assert d["prebuilt"] is True
+        assert d["already_compiled"] is True
+        # usable with no cuda_home is exactly the pair that needs explaining
+        assert d["cuda_home"] is None
+        assert "pre-built" in d["reason"]
+
+    def test_diagnostics_unchanged_on_the_jit_path(self, monkeypatch):
+        from sweep import _jit
+        from sweep.backend.torch import binding
+
+        monkeypatch.setattr(sweep, "_prebuilt_binding_present", lambda: False)
+        monkeypatch.setattr(_jit, "can_build", lambda: (False, "no nvcc"))
+        monkeypatch.setattr(_jit, "_find_cuda_home", lambda: None)
+
+        d = binding.diagnostics()
+        assert d["usable"] is False
+        assert d["prebuilt"] is False
+        assert d["reason"] == "no nvcc"


### PR DESCRIPTION
`is_torch_binding_available()` asked `_jit.can_build()` — *could I compile this?* — which
needs `nvcc`. An ahead-of-time install (`SWEEP_BUILD_CUDA=1`, or `setup.py build_ext
--inplace`) already has the kernels on disk, so on a machine with no CUDA toolkit the
answer came back False and `impl='c'` **silently fell back to eager**: 10-30x slower, one
warning, nothing pointing at the cause.

`sweep.backend.torch.binding` asked the same wrong question in three more places, and
`diagnostics()` is what a confused user reads first — it would report a backend that is
sitting right there as "not compiled, install a CUDA toolkit".

## The fix

Check for an already-compiled extension first, and only then fall back to asking whether
one could be built. Resolution goes through `find_spec`, so nothing is imported and
nothing is compiled — the probe's "no surprise 3-min build" contract is intact.

This aligns the code with behaviour the docs already promised:
`docs/getting-started/installation.md` says *"A prebuilt `_C` extension takes precedence
over the JIT loader automatically."* Only the probes did not know.

`diagnostics()` gains a `prebuilt` key, which explains the otherwise baffling pair
`usable: true` with `cuda_home: null`.

## Evidence

On a V100 node with an AOT build present and **no** toolkit on `PATH` — the reported
failure case:

```
prebuilt _C on disk : True
can JIT-compile     : (False, "no suitable CUDA toolkit found (need nvcc >=12.4 ...)")
reported available  : True          <- was False
is_available : True    is_compiled : True
diagnostics  : {"usable": true, "reason": "ok (pre-built extension)",
                "cuda_home": null, "already_compiled": true, "prebuilt": true}
DD_NCCL_BACKWARD_CHECK: PASS   EXIT=0
```

Before the fix the same setup died with `AttributeError: '_PropTorchEager' object has no
attribute 'forward_func'` — the eager fallback reaching a c-backend-only path.

- New `test/test_prebuilt_binding_available.py`: 15 passed, 1 skipped. Covers the
  extension/source origin split, both probe branches, the `binding.*` trio, and asserts
  the probe never reaches `_jit.load()`.
- Full suite, one process per file, 69 files: **646 passed / 21 failed / 15 skipped**,
  failure set identical to `origin/dev` file by file. Zero regressions.
- Where a toolkit *is* present the answer is unchanged (`prebuilt False -> can_build True`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
