### PR TITLE
fix(test): map DD elastic CPML slabs by band, not by physical-grid index

### DIFF
--- a/test/test_dd_elastic_tiles_3d.py
+++ b/test/test_dd_elastic_tiles_3d.py
@@ -294,15 +294,60 @@ def test_tiles_3d_elastic_bitexact(py, px, free_surface):
 
     # final state over each tile's physical region — every wavefield slot
     # (9 physical + 27 CPML memories) must be bitwise identical.
+    #
+    # How a slot is INDEXED depends on what it is. The 9 physical slots are
+    # full-grid, so a physical-grid (y, x) range picks the tile's own cells.
+    # Since `5ea32fa` a CPML memory instead lives in a slab holding only the PML
+    # band(s) of ONE axis — the axis named by the last letter of its elastic.h
+    # symbol, so m_vxx/m_vxy/m_vxz/... cycle x, y, z in slot order. Per axis:
+    #
+    #   the slab's OWN axis: laid out [low band | high band]. The single domain
+    #       carries both; a tile at the low end of that axis keeps only the low
+    #       band, one at the high end only the high band, because a CUT face
+    #       carries no PML. The tile's whole extent maps onto that end.
+    #   any OTHER axis: the slab spans it in full, so slice it physically.
+    #
+    # A y-slab on a py>1 mesh needs BOTH rules at once, and getting it wrong is
+    # not loud: slicing its y band by a physical y range truncates to a shape
+    # that can match the reference's, so the mismatch surfaces as unequal VALUES
+    # rather than as a shape error.
+    CPML_AXIS = ("x", "y", "z")       # slot NPHYS+k has axis CPML_AXIS[k % 3]
+
+    def _band(tile_arr, full_arr, dim, idx, n):
+        # (tile slice, full slice) along a slab's OWN axis.
+        if n == 1:                                   # uncut: the tile has both bands
+            return slice(None), slice(None)
+        w = tile_arr.shape[dim]
+        if idx == 0:
+            return slice(None), slice(0, w)
+        assert idx == n - 1, (
+            f"tile index {idx} of {n} is interior — it owns no PML band on this "
+            f"axis, so the slab layout assumed here no longer holds"
+        )
+        return slice(None), slice(full_arr.shape[dim] - w, None)
+
     for rank, (runner, _, lo_y, lo_x) in tiles.items():
         topo_yi, topo_xi = rank // px, rank % px
         for f in range(NWF):
-            ref = runner_full.L[f][
-                ...,
-                PAD + topo_yi * nyp: PAD + topo_yi * nyp + nyp,
-                PAD + topo_xi * nxp: PAD + topo_xi * nxp + nxp,
-            ]
-            got = runner.L[f][..., lo_y:lo_y + nyp, lo_x:lo_x + nxp]
+            axis = CPML_AXIS[(f - NPHYS) % 3] if f >= NPHYS else None
+            t, full = runner.L[f], runner_full.L[f]
+
+            if axis == "y":
+                gy, ry = _band(t, full, -2, topo_yi, py)
+            else:
+                gy = slice(lo_y, lo_y + nyp)
+                ry = slice(PAD + topo_yi * nyp, PAD + topo_yi * nyp + nyp)
+            if axis == "x":
+                gx, rx = _band(t, full, -1, topo_xi, px)
+            else:
+                gx = slice(lo_x, lo_x + nxp)
+                rx = slice(PAD + topo_xi * nxp, PAD + topo_xi * nxp + nxp)
+
+            got, ref = t[..., gy, gx], full[..., ry, rx]
+            assert got.shape == ref.shape, (
+                f"tile {rank} slot {f}: mapped shapes disagree, "
+                f"{tuple(got.shape)} vs {tuple(ref.shape)} — the aux layout changed"
+            )
             assert torch.equal(got, ref), (
                 f"tile {rank} wavefield slot {f} differs over physical region"
             )

--- a/test/test_dd_elastic_two_tile.py
+++ b/test/test_dd_elastic_two_tile.py
@@ -275,11 +275,36 @@ def test_two_tile_elastic_bitexact(src_gx, free_surface):
 
     # final state over each tile's physical region — every wavefield slot
     # (5 physical + 10 CPML memories) must be bitwise identical.
+    #
+    # How a slot is INDEXED depends on what it is. The 5 physical slots are
+    # full-grid, so a physical-grid x range picks the tile's own columns. Since
+    # `5ea32fa` a CPML memory instead lives in a slab holding only the PML
+    # band(s) of ONE axis — the axis named by the last letter of its elastic.h
+    # symbol, so m_vxx/m_vxz/m_vzx/m_vzz/... run x, z, x, z ... in slot order:
+    #
+    #   z-slab: still spans x in full -> slice it exactly like a physical field.
+    #   x-slab: laid out [low band | high band]. The single domain carries both;
+    #           tile 0 keeps only the low band and tile 1 only the high one,
+    #           because a CUT face carries no PML. So the tile's WHOLE slab maps
+    #           onto that end of the single domain's — comparing it against a
+    #           physical-grid x range compares unrelated cells.
+    CPML_AXIS = ("x", "z")            # slot NPHYS+k has axis CPML_AXIS[k % 2]
     for xi, r in enumerate(runners):
         lo_x = los[xi]
         for f in range(NWF):
-            ref = runner_full.L[f][..., PAD + xi * nxp: PAD + xi * nxp + nxp]
-            got = r.L[f][..., lo_x:lo_x + nxp]
+            if f >= NPHYS and CPML_AXIS[(f - NPHYS) % len(CPML_AXIS)] == "x":
+                w = r.L[f].shape[-1]                       # this tile's single band
+                full_w = runner_full.L[f].shape[-1]
+                got = r.L[f]
+                ref = (runner_full.L[f][..., :w] if xi == 0
+                       else runner_full.L[f][..., full_w - w:])
+            else:
+                got = r.L[f][..., lo_x:lo_x + nxp]
+                ref = runner_full.L[f][..., PAD + xi * nxp: PAD + xi * nxp + nxp]
+            assert got.shape == ref.shape, (
+                f"tile {xi} slot {f}: mapped shapes disagree, "
+                f"{tuple(got.shape)} vs {tuple(ref.shape)} — the aux layout changed"
+            )
             assert torch.equal(got, ref), (
                 f"tile {xi} wavefield slot {f} differs over physical region"
             )


### PR DESCRIPTION
`test_dd_elastic_two_tile.py` and `test_dd_elastic_tiles_3d.py` have been red on `dev`
since `5ea32fa` — 8 failures, bisected to that single commit (`99f0e61` before it: 4
passed; `5ea32fa`: 4 failed).

They compare every wavefield slot of each DD tile against the single-domain run. Since
`5ea32fa` the CPML memories no longer live on the full grid but in **per-axis slabs**, so
slicing them by a physical-grid range compares unrelated cells. The tests were written 59
commits earlier in the same branch and never followed.

Nothing is wrong with the solver: the record, all physical slots and the uncut-axis slabs
were bit-identical throughout. Failure mode on both sm_70 and sm_89.

## The fix

Map each slab **on its own axis** instead. A slab is `[low band | high band]`; the single
domain carries both, and a tile owns whichever end it actually borders — a cut face
carries no PML. Other axes still slice physically.

Every slot stays compared: **15/15 in 2-D, 36/36 in 3-D**, all bit-identical.

Worth stating, since the obvious shortcut is worse: skipping the cut-axis slabs also turns
the suite green, and that was the first thing I wrote. It is wrong. Those slabs *do* have
a correct counterpart in the single domain and they *do* match it, so skipping them
deletes a real check that passes.

## Two traps this leaves guarded

- `torch.equal` returns **False** on a shape mismatch instead of raising, so the original
  breakage surfaced as `slot 5 differs` — reading like a numerical error for months. The
  new code asserts the mapped shapes agree first, with a message naming the aux layout.
- Shape is not a usable discriminator. A 3-D y-slab sliced by a physical y range truncates
  to a shape that **collides** with the reference's, so a shape-based guard waves it
  through and then compares unrelated cells. The axis is taken from the slot's `elastic.h`
  symbol instead.

## Evidence

Per-slot mutation sweep — each slot perturbed by 1e-3 in turn, then restored:

```
2-D  15/15 slots:  clean=True  mutation_caught=True   (incl. all 5 cut-axis x-slabs)
3-D  36/36 slots:  all clean+caught = True            (py=2 px=2, both axes cut)
```

`clean` says the solver is right; `caught` says the test is not vacuous. Both are needed
for this change to stand.

DD suite green on RTX 6000 Ada and V100: the two files 4+4 passed, plus
`test_dd_two_tile`, `test_dd_tiles_3d`, `test_dd_backward_two_tile{,_3d}`,
`test_dd_tail_two_tile`, `test_dd_elastic_backward_two_tile`, `test_model_parallel_{halo,pml,padding}`.

Test-only change — no solver behaviour is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
