### PR TITLE
docs(examples): run domain decomposition across nodes

### DIFF
--- a/docs/user-guide/parallel.md
+++ b/docs/user-guide/parallel.md
@@ -49,6 +49,23 @@ Launch with one process per GPU:
 torchrun --standalone --nproc-per-node=4 your_script.py
 ```
 
+`--standalone` means *this machine only*. To spread the same tiles over several
+machines, drop it and give the ranks a meeting point instead — every node then
+runs an identical command and negotiates its own numbering:
+
+```bash
+torchrun --nnodes=3 --nproc-per-node=4 \
+  --rdzv-backend=c10d --rdzv-endpoint=<first-node>:29500 --rdzv-id=dd1 \
+  your_script.py                      # py * px must now be 3 * 4 = 12
+```
+
+Nothing in your script changes: `ModelParallel` never picks a device and NCCL
+does not care whether a tile's neighbour is on this machine or the next one.
+The cross-node gradient is bit-identical to the single-domain one, same as
+within a node. A ready SLURM batch script and the pitfalls (one task per *node*,
+not per GPU; ask for partial nodes) are in
+[`examples/multi-gpu/torch/README.md`](https://github.com/DeepWave-KAUST/sweep/blob/dev/examples/multi-gpu/torch/README.md#across-nodes).
+
 ## Forward and gradients — plain autograd
 
 The forward returns this rank's differentiable tile record; `backward()`

--- a/examples/multi-gpu/torch/README.md
+++ b/examples/multi-gpu/torch/README.md
@@ -229,3 +229,67 @@ It also shows the forward-only path: generating observed data under
 `torch.no_grad()` keeps the DD capture free of adjoint wavefields and of the
 boundary ring, and the capture is promoted automatically at the first
 `.backward()`.
+
+### Across nodes
+
+Every script above runs unchanged on several machines. They read `LOCAL_RANK`
+and the process group, and `torchrun` sets both the same way whether the ranks
+share a machine or not — so going multi-node is a launcher change, not a code
+change. What grows is `py × px`, which must equal *nodes × GPUs-per-node*.
+
+`torchrun` needs four numbers, and only one of them is awkward:
+
+| | where it comes from |
+|---|---|
+| `--nnodes` | you know it |
+| `--nproc-per-node` | GPUs per node, you know it |
+| `--rdzv-endpoint` | pick one node as the meeting point |
+| *which node am I* | **the only thing a scheduler is needed for** |
+
+With `--rdzv-backend=c10d` the ranks negotiate their own numbering, so that
+last row disappears and every node runs an identical command. Two nodes, four
+GPUs each, by hand:
+
+```bash
+# on BOTH nodes, character for character
+torchrun --nnodes=2 --nproc-per-node=4 \
+  --rdzv-backend=c10d --rdzv-endpoint=node0:29500 --rdzv-id=dd1 \
+  examples/multi-gpu/torch/dd_fwi_overthrust_update.py --py 4 --px 2
+```
+
+That is the whole mechanism; a scheduler only automates it. On SLURM:
+
+```bash
+sbatch examples/multi-gpu/torch/dd_fwi_multinode.slurm
+```
+
+`dd_fwi_multinode.slurm` is that same command with `--nnodes` and the endpoint
+filled in from the allocation. On PBS, LSF or SGE, substitute the host list
+(`$PBS_NODEFILE`, `$LSB_DJOB_HOSTFILE`, `$PE_HOSTFILE`) for `scontrol show
+hostnames` and launch it once per node however that scheduler does it — only
+the SLURM path is exercised here, so treat the others as the recipe rather than
+a tested script.
+
+The older static form (`--node-rank=$SLURM_NODEID` with `--master-addr` /
+`--master-port`) also works and is what you want if your torch predates
+`--rdzv-backend`. It needs the scheduler to tell each node its index, which is
+exactly the coupling c10d removes.
+
+**Verified** on `origin/dev`, V100: `test/dd_nccl_backward_check.py` with tiles
+spanning a node boundary returns `grad_vp`, `grad_wavelet` and both
+illuminations **bit-identical** to the single-domain reference — on 2 nodes and
+on 3, under c10d and static rendezvous alike. `dd_fwi_multinode.slurm` itself
+was run unmodified over 2 nodes on `dd_fwi_overthrust_update.py`: a full 3-D
+update, misfit 7.44e+02 -> 6.76e+02, 4.70 GiB per tile. Production runs at this
+repo's scale have gone to 12 V100 over 3 nodes and 16 over 4.
+
+Three things that cost real time when they are wrong:
+
+- **One task per node, not one per GPU.** `--ntasks-per-node=1`: `srun` starts
+  one `torchrun` and `torchrun` forks the GPU workers. One task per GPU starts
+  four launchers per node and the job hangs in rendezvous.
+- **Never pipe `torchrun` through `grep`/`tail`.** The pipe eats the worker
+  traceback and a crash reports only the launcher's exit code.
+- **Ask for partial nodes.** On a cluster whose GPU nodes hold 8, requesting
+  4 GPUs on each of 3 nodes schedules far sooner than 8 on each of 2, and the
+  halo does not care.

--- a/examples/multi-gpu/torch/dd_fwi_multinode.slurm
+++ b/examples/multi-gpu/torch/dd_fwi_multinode.slurm
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Domain decomposition across NODES, not just across GPUs.
+#
+# Nothing in the Python changes -- dd_fwi_*.py read LOCAL_RANK and the process
+# group, both of which torchrun sets identically whether the ranks sit on one
+# machine or twelve.  All this file does is start one torchrun per node.
+#
+#   sbatch examples/multi-gpu/torch/dd_fwi_multinode.slurm
+#   SCRIPT=... ARGS=... sbatch examples/multi-gpu/torch/dd_fwi_multinode.slurm
+#
+# Not on SLURM?  See "Across nodes" in README.md -- torchrun needs four numbers
+# and this script only exists to fill them in from the scheduler.
+
+#SBATCH --job-name=dd-multinode
+#SBATCH --nodes=3
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:v100:4
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=200G
+#SBATCH --time=02:00:00
+#SBATCH --output=dd-multinode-%j.log
+
+# --ntasks-per-node=1 above is deliberate and easy to get wrong: srun starts ONE
+# torchrun per node and torchrun forks the per-GPU workers itself.  Asking for
+# one task per GPU starts four torchruns per node, each believing it owns the
+# node, and the run deadlocks in rendezvous.  Keep it in step with --gres.
+GPUS_PER_NODE=${GPUS_PER_NODE:-4}
+
+SCRIPT=${SCRIPT:-examples/multi-gpu/torch/dd_fwi_overthrust_update.py}
+# py * px must equal SLURM_NNODES * GPUS_PER_NODE
+ARGS=${ARGS:---py 4 --px 3}
+
+# SCRIPT is relative to the repo root, so submit from there.
+cd "${SLURM_SUBMIT_DIR:-.}" || exit 1
+
+nodes=($(scontrol show hostnames "$SLURM_JOB_NODELIST"))
+export MASTER_ADDR=${nodes[0]}
+export MASTER_PORT=${MASTER_PORT:-29500}
+
+echo "nodes=${nodes[*]}  world=$((SLURM_NNODES * GPUS_PER_NODE))  script=$SCRIPT $ARGS"
+
+# c10d rendezvous: every node runs the SAME command and the ranks negotiate
+# their own numbering, so no --node-rank and no scheduler variable reaches
+# torchrun.  Swap in --node-rank=$SLURM_NODEID --master-addr/--master-port if
+# you need the static form instead; both are verified equivalent here.
+#
+# Do not pipe this through grep/tail: a pipe swallows the worker traceback and
+# a failed run then reports nothing but the launcher's own exit code.
+srun --export=ALL --ntasks="$SLURM_NNODES" --ntasks-per-node=1 \
+  torchrun \
+    --nnodes="$SLURM_NNODES" \
+    --nproc-per-node="$GPUS_PER_NODE" \
+    --rdzv-backend=c10d \
+    --rdzv-endpoint="$MASTER_ADDR:$MASTER_PORT" \
+    --rdzv-id="$SLURM_JOB_ID" \
+    $SCRIPT $ARGS


### PR DESCRIPTION
`ModelParallel` already ran across machines — the DD scripts read `LOCAL_RANK` and the
process group, and `torchrun` sets both the same way whether the ranks share a node or
not. What was missing was the launcher and any statement that it works. Every launch
command in the docs used `torchrun --standalone`, which by definition is single-node.

## What lands

- `examples/multi-gpu/torch/dd_fwi_multinode.slurm` — the file that was actually run, unedited.
- An **Across nodes** section in the examples README.
- A short multi-node paragraph in `docs/user-guide/parallel.md`, where `--standalone` is
  the thing readers misread.

No Python changes: `py × px` grows to *nodes × GPUs-per-node* and that is the whole diff
on the user's side.

## Not SLURM-specific

`torchrun` needs four numbers and only one of them — *which node am I* — needs a
scheduler. With `--rdzv-backend=c10d` the ranks negotiate their own numbering, so that one
disappears and every node runs a byte-identical command:

```bash
# on BOTH nodes, character for character
torchrun --nnodes=2 --nproc-per-node=4 \
  --rdzv-backend=c10d --rdzv-endpoint=node0:29500 --rdzv-id=dd1 \
  examples/multi-gpu/torch/dd_fwi_overthrust_update.py --py 4 --px 2
```

That is the primary recipe; the `.slurm` file is convenience on top. PBS / LSF / SGE get
their host-list variable named in the README as a recipe, **not** shipped as code — only
the SLURM path is exercised here and untested branches claiming to work are worse than
none.

## Evidence

- `test/dd_nccl_backward_check.py` with tiles spanning a node boundary: `grad_vp`,
  `grad_wavelet` and both illuminations **bit-identical** to the single-domain reference,
  on 2 nodes and on 3, under c10d and static rendezvous alike (V100, `origin/dev`).
- `dd_fwi_multinode.slurm` run unmodified over 2 nodes on `dd_fwi_overthrust_update.py`:
  a full 3-D update, misfit 7.435e+02 -> 6.764e+02 (-9.0%, step accepted), 4.70 GiB per tile.
- Production runs at this repo's scale have gone to 12 V100 over 3 nodes and 16 over 4.

## Three pitfalls documented, each hit for real

- **One task per node, not per GPU.** `srun` starts one `torchrun`; `torchrun` forks the
  GPU workers. One task per GPU starts N launchers per node and the job hangs in rendezvous.
- **Never pipe `torchrun` through `grep`/`tail`.** The pipe eats the worker traceback. An
  earlier multi-node attempt lost its root cause this way and left a "multi-node does not
  work" belief on the record that turned out to be unfounded.
- **Ask for partial nodes.** On 8-GPU nodes, 4 GPUs on each of 3 schedules far sooner than
  8 on each of 2, and the halo does not care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
