### PR TITLE
perf(boundary): band-only compact 2D kernel + cached phys_* bounds

### DIFF
--- a/src/sweep/csrc/cuda/common/boundary/kernels.cuh
+++ b/src/sweep/csrc/cuda/common/boundary/kernels.cuh
@@ -21,6 +21,29 @@ __global__ void boundary_kernel2d(
     int tangent_pad = 0
 );
 
+// Band-only counterpart of boundary_kernel2d: one thread per boundary-band
+// cell instead of one per grid cell.  The full-grid scan launches nx*nz*B
+// threads of which only ~4% (at production sizes) land inside a band; every
+// other thread still pays the prologue -- four SolverContext::phys_*()
+// evaluations -- which is essentially this kernel's whole cost.  Mirrors
+// boundary_kernel3d_compact.  FP32 save/restore only; the bf16 / fp16 / int8
+// paths keep the scan kernel.
+__global__ void boundary_kernel2d_compact(
+    float* __restrict__ u,
+
+    float* __restrict__ top,
+    float* __restrict__ bottom,
+    float* __restrict__ left,
+    float* __restrict__ right,
+
+    int it,
+    int width,
+    int offset,
+    SolverContext ctx,
+    int mode,
+    int tangent_pad = 0
+);
+
 __global__ void boundary_kernel3d(
     float* __restrict__ u,
 

--- a/src/sweep/csrc/cuda/common/boundary/runtime.cuh
+++ b/src/sweep/csrc/cuda/common/boundary/runtime.cuh
@@ -99,6 +99,11 @@ public:
           copy_stream_(copy_stream)
     {
         profile_enabled_ = std::getenv("SWEEP_BOUNDARY_PROFILE") != nullptr;
+        // Escape hatch back to the full-grid scan kernels.  The compact and
+        // scan paths are bit-identical by construction, so this exists to prove
+        // that in a test (and to isolate the compact kernels if they are ever
+        // suspected), not to change results.
+        no_compact_kernel_ = std::getenv("SWEEP_BOUNDARY_NO_COMPACT") != nullptr;
         if (!enabled_ || !staged_)
             return;
 
@@ -597,6 +602,13 @@ public:
                 /*it=*/0, width, offset, ctx, BOUNDARY_SAVE);
             int64_t bt = boundary_time_index(chunk);
             quantize_step_2d(b, bt);
+        } else if (use_compact_boundary_kernel()) {
+            int compact_total = compact_boundary_count_2d(ctx, width, 0);
+            int compact_threads = 512;
+            int compact_blocks = (compact_total + compact_threads - 1) / compact_threads;
+            boundary_kernel2d_compact<<<compact_blocks, compact_threads>>>(
+                u, b.top, b.bottom, b.left, b.right,
+                boundary_time_index(chunk), width, offset, ctx, BOUNDARY_SAVE);
         } else {
             boundary_kernel2d<<<grid, block>>>(
                 u, b.top, b.bottom, b.left, b.right,
@@ -622,7 +634,7 @@ public:
         wait_before_forward_save(chunk);
         auto b = forward_save_ptrs(chunk, direct);
 
-        if (use_compact_3d_boundary_kernel()) {
+        if (use_compact_boundary_kernel()) {
             int compact_total = compact_boundary_count_3d(ctx, width, 0);
             int compact_threads = 512;
             int compact_blocks = (compact_total + compact_threads - 1) / compact_threads;
@@ -687,6 +699,13 @@ public:
                 u, b.top, b.bottom, b.left, b.right,
                 /*it=*/0, width, offset, ctx, BOUNDARY_SAVE);
             quantize_step_2d(b, boundary_time_index_field(chunk));
+        } else if (use_compact_boundary_kernel()) {
+            int compact_total = compact_boundary_count_2d(ctx, width, 0);
+            int compact_threads = 512;
+            int compact_blocks = (compact_total + compact_threads - 1) / compact_threads;
+            boundary_kernel2d_compact<<<compact_blocks, compact_threads>>>(
+                u, b.top, b.bottom, b.left, b.right,
+                boundary_time_index_field(chunk), width, offset, ctx, BOUNDARY_SAVE);
         } else {
             boundary_kernel2d<<<grid, block>>>(
                 u, b.top, b.bottom, b.left, b.right,
@@ -715,7 +734,7 @@ public:
         wait_before_forward_save(chunk);
         auto b = forward_save_ptrs_field(chunk, direct, field_idx);
 
-        if (use_compact_3d_boundary_kernel()) {
+        if (use_compact_boundary_kernel()) {
             int compact_total = compact_boundary_count_3d(ctx, width, 0);
             int compact_threads = 512;
             int compact_blocks = (compact_total + compact_threads - 1) / compact_threads;
@@ -1084,6 +1103,13 @@ public:
             boundary_kernel2d<<<grid, block>>>(
                 u, b.top, b.bottom, b.left, b.right,
                 /*it=*/0, width, offset, ctx, BOUNDARY_RESTORE);
+        } else if (use_compact_boundary_kernel()) {
+            int compact_total = compact_boundary_count_2d(ctx, width, 0);
+            int compact_threads = 512;
+            int compact_blocks = (compact_total + compact_threads - 1) / compact_threads;
+            boundary_kernel2d_compact<<<compact_blocks, compact_threads>>>(
+                u, b.top, b.bottom, b.left, b.right,
+                backward_time_index(it), width, offset, ctx, BOUNDARY_RESTORE);
         } else {
             boundary_kernel2d<<<grid, block>>>(
                 u, b.top, b.bottom, b.left, b.right,
@@ -1105,7 +1131,7 @@ public:
     {
         wait_before_backward_restore(it);
         auto b = backward_restore_ptrs(it, direct);
-        if (use_compact_3d_boundary_kernel()) {
+        if (use_compact_boundary_kernel()) {
             int compact_total = compact_boundary_count_3d(ctx, width, 0);
             int compact_threads = 512;
             int compact_blocks = (compact_total + compact_threads - 1) / compact_threads;
@@ -1168,6 +1194,13 @@ public:
             boundary_kernel2d<<<grid, block>>>(
                 u, b.top, b.bottom, b.left, b.right,
                 /*it=*/0, width, offset, ctx, BOUNDARY_RESTORE);
+        } else if (use_compact_boundary_kernel()) {
+            int compact_total = compact_boundary_count_2d(ctx, width, 0);
+            int compact_threads = 512;
+            int compact_blocks = (compact_total + compact_threads - 1) / compact_threads;
+            boundary_kernel2d_compact<<<compact_blocks, compact_threads>>>(
+                u, b.top, b.bottom, b.left, b.right,
+                backward_time_index_field(it), width, offset, ctx, BOUNDARY_RESTORE);
         } else {
             boundary_kernel2d<<<grid, block>>>(
                 u, b.top, b.bottom, b.left, b.right,
@@ -1194,7 +1227,7 @@ public:
         if (wait_chunk)
             wait_before_backward_restore(it);
         auto b = backward_restore_ptrs_field(it, direct, field_idx);
-        if (use_compact_3d_boundary_kernel()) {
+        if (use_compact_boundary_kernel()) {
             int compact_total = compact_boundary_count_3d(ctx, width, 0);
             int compact_threads = 512;
             int compact_blocks = (compact_total + compact_threads - 1) / compact_threads;
@@ -1281,6 +1314,7 @@ private:
     cudaStream_t compute_stream_ = nullptr;
     cudaStream_t copy_stream_ = nullptr;
     bool profile_enabled_ = false;
+    bool no_compact_kernel_ = false;
     bool backward_active_ = false;
     bool profile_printed_ = false;
     bool profile_have_compute_start_ = true;
@@ -1328,8 +1362,20 @@ private:
         return ctx.B * (2 * top_count + 2 * front_count + 2 * left_count);
     }
 
-    inline bool use_compact_3d_boundary_kernel() const
+    inline int compact_boundary_count_2d(const SolverContext& ctx, int width, int tangent_pad) const
     {
+        int nx_boundary = ctx.nx_phys() + 2 * tangent_pad;
+        int nz_boundary = ctx.nz_phys() + 2 * tangent_pad;
+        return ctx.B * (2 * width * nx_boundary + 2 * nz_boundary * width);
+    }
+
+    // Gate for both the 2-D and 3-D compact kernels: the synchronous disk path
+    // reuses the full-grid launch geometry, everything else takes band-only
+    // threads.
+    inline bool use_compact_boundary_kernel() const
+    {
+        if (no_compact_kernel_)
+            return false;
         return !boundary_on_disk_ || boundary_disk_async_read_;
     }
 

--- a/src/sweep/csrc/cuda/common/boundarysaver.cu
+++ b/src/sweep/csrc/cuda/common/boundarysaver.cu
@@ -607,6 +607,119 @@ __global__ void boundary_kernel3d_bf16(
                                           it, width, offset, ctx, mode, tangent_pad);
 }
 
+// One thread per boundary-band cell, covering exactly what the full-grid
+// boundary_kernel2d covers -- including the corner cells that belong to both a
+// horizontal and a vertical band.  In the scan kernel one thread writes such a
+// cell into two buffers; here they are two threads carrying the same value, so
+// SAVE is identical.  On RESTORE the two threads write the same wavefield cell,
+// but both read the value the same SAVE wrote, so the (unordered) duplicate
+// write is bit-identical either way -- which is why this path is FP32 only:
+// under a lossy storage dtype the two copies could differ.
+__global__ void boundary_kernel2d_compact(
+    float* __restrict__ u,
+
+    float* __restrict__ top,
+    float* __restrict__ bottom,
+    float* __restrict__ left,
+    float* __restrict__ right,
+
+    int it,
+    int width,
+    int offset,
+    SolverContext ctx,
+    int mode,
+    int tangent_pad
+)
+{
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    int x0 = ctx.phys_x0();
+    int x1 = ctx.phys_x1();
+    int z0 = ctx.phys_z0();
+    int z1 = ctx.phys_z1();
+
+    int nx_boundary = ctx.nx_phys() + 2 * tangent_pad;
+    int nz_boundary = ctx.nz_phys() + 2 * tangent_pad;
+
+    int tb_count = width * nx_boundary;
+    int lr_count = nz_boundary * width;
+    int per_batch = 2 * tb_count + 2 * lr_count;
+    int total = ctx.B * per_batch;
+    if (tid >= total)
+        return;
+
+    int b = tid / per_batch;
+    int local = tid - b * per_batch;
+
+    int x_t0 = x0 - tangent_pad;
+    int z_t0 = z0 - tangent_pad;
+    int top_start = z0 + offset;
+    int bot_end = z1 - offset;
+    int bot_start = bot_end - width;
+    int left_start = x0 + offset;
+    int right_end = x1 - offset;
+    int right_start = right_end - width;
+
+    int ix = 0;
+    int iz = 0;
+    int64_t idx = 0;
+    float* boundary = nullptr;
+
+    // DD cut faces carry neighbour data supplied by HaloExchange, not saved
+    // boundary values; the scan kernel drops them via !ctx.cut_*(), so the
+    // matching band is skipped here.  Their buffer slots are never written,
+    // so restoring from them would read uninitialised memory.
+    if (local < tb_count) {
+        if (ctx.cut_z_lo()) return;
+        int zloc = local / nx_boundary;
+        int xloc = local - zloc * nx_boundary;
+        iz = top_start + zloc;
+        ix = x_t0 + xloc;
+        idx = ((static_cast<int64_t>(it) * ctx.B + b) * width + zloc) * nx_boundary + xloc;
+        boundary = top;
+    } else if (local < 2 * tb_count) {
+        if (ctx.cut_z_hi()) return;
+        int rem = local - tb_count;
+        int zloc = rem / nx_boundary;
+        int xloc = rem - zloc * nx_boundary;
+        iz = bot_start + zloc;
+        ix = x_t0 + xloc;
+        idx = ((static_cast<int64_t>(it) * ctx.B + b) * width + zloc) * nx_boundary + xloc;
+        boundary = bottom;
+    } else if (local < 2 * tb_count + lr_count) {
+        if (ctx.cut_x_lo()) return;
+        int rem = local - 2 * tb_count;
+        int zloc = rem / width;
+        int xloc = rem - zloc * width;
+        ix = left_start + xloc;
+        iz = z_t0 + zloc;
+        idx = ((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc) * width + xloc;
+        boundary = left;
+    } else {
+        if (ctx.cut_x_hi()) return;
+        int rem = local - 2 * tb_count - lr_count;
+        int zloc = rem / width;
+        int xloc = rem - zloc * width;
+        ix = right_start + xloc;
+        iz = z_t0 + zloc;
+        idx = ((static_cast<int64_t>(it) * ctx.B + b) * nz_boundary + zloc) * width + xloc;
+        boundary = right;
+    }
+
+    // The scan kernel's threads are grid-derived, so a band cell outside the
+    // allocated grid simply never had a thread; with a nonzero tangent_pad the
+    // band can reach past an edge, and those slots stay unwritten there.  Drop
+    // the same cells here instead of running off the wavefield.
+    if (ix < 0 || ix >= ctx.nx || iz < 0 || iz >= ctx.nz)
+        return;
+
+    float* u_b = u + b * (ctx.nx * ctx.nz);
+    if (mode == BOUNDARY_SAVE)
+        boundary[idx] = u_b[iz * ctx.nx + ix];
+    else
+        u_b[iz * ctx.nx + ix] = boundary[idx];
+}
+
 __global__ void boundary_kernel3d_compact(
     float* __restrict__ u,
 

--- a/src/sweep/csrc/cuda/common/boundarysaver.cu
+++ b/src/sweep/csrc/cuda/common/boundarysaver.cu
@@ -81,7 +81,7 @@ __global__ void boundary_kernel2d(
     int right_end   = x1 - offset;
     int right_start = right_end - width;
 
-    // DD cut faces (ctx.cut_mask: bit0=x_lo/left, bit1=x_hi/right,
+    // DD cut faces (ctx.cut_mask(): bit0=x_lo/left, bit1=x_hi/right,
     // bit2=z_lo/top, bit3=z_hi/bottom) are skipped: the strip there is
     // reverse-leapfrog-computed + halo-exchanged instead of restored.
     bool is_top =
@@ -332,7 +332,7 @@ __global__ void boundary_kernel3d(
     int right_end   = x1 - offset;
     int right_start = right_end - width;
 
-    // DD cut faces (ctx.cut_mask) are skipped — see boundary_kernel2d.
+    // DD cut faces (ctx.cut_mask()) are skipped — see boundary_kernel2d.
     bool is_top =
         iz >= top_start && iz < top_end &&
         iy >= y_t0 && iy < y_t1 &&

--- a/src/sweep/csrc/cuda/common/context.h
+++ b/src/sweep/csrc/cuda/common/context.h
@@ -1,29 +1,67 @@
 #pragma once
 #include <vector>
+#include <type_traits>
+
+// ============================================================================
+// SolverContext -- launch-invariant solver geometry, passed BY VALUE to every
+// kernel of every equation.
+//
+// WHY THE PHYSICAL BOUNDS ARE CACHED
+// ----------------------------------
+// phys_x0() ... nz_phys() are launch-invariant, yet every thread of every
+// kernel evaluates them.  Stacking the DD cut-select on top of the per-edge pad
+// sentinels made each face a 3-deep nested conditional (x 6 faces); ptxas gives
+// up on if-conversion and emits a serial chain of warp-uniform branches in the
+// kernel prologue.  For a thin kernel -- a boundary saver, a no-PML update --
+// that prologue IS the kernel, which is how a purely geometric refactor came to
+// cost 93% on boundary_kernel2d and 47% on acoustic2nd_nopml.
+//
+// So they are resolved ONCE, on the host, in refresh(), and stored as plain
+// ints; the device accessors are then bare loads from the kernel parameter
+// bank.  One place to fix, every equation benefits.
+//
+// WHY THE CACHE CANNOT GO STALE
+// -----------------------------
+// Enforced by the compiler, not by discipline:
+//   * every input to refresh() is either ``const`` (a post-construction write
+//     is a compile error) or ``private`` (reachable only through a setter that
+//     re-runs refresh());
+//   * there is deliberately NO default constructor, so a SolverContext cannot
+//     exist without having gone through refresh();
+//   * copy-assignment is implicitly deleted by the const members, so a
+//     refreshed context can never be overwritten wholesale (copy-CONSTRUCTION
+//     stays trivial, which is what the by-value kernel launches need).
+// The remaining public members (topo_rows, has_topo, topo_category, use_apm,
+// x_base, x_limit, aux_*) are free to assign because none of them feeds
+// refresh().
+// IF YOU ADD A MEMBER THAT phys_*() DEPENDS ON, IT MUST GO IN THE PRIVATE
+// SECTION WITH A REFRESHING SETTER, OR BE const.
+// ============================================================================
 struct SolverContext {
 
-    int ndim;
+    // ---- Geometry & physics: immutable after construction ----------------
+    const int ndim;
 
-    int nx;
-    int ny;
-    int nz;
+    const int nx;
+    const int ny;
+    const int nz;
 
-    int B;
+    const int B;
 
-    float dt;
-    unsigned int nt;
+    const float dt;
+    const unsigned int nt;
 
-    int M;
-    int abcn;
+    const int M;
+    const int abcn;
 
-    bool free_surface;
+    const bool free_surface;
 
-    const float* lap_coeff;
-    const float* grad_coeff;
+    const float* const lap_coeff;
+    const float* const grad_coeff;
 
-    float dx;
-    float dy;
-    float dz;
+    const float dx;
+    const float dy;
+    const float dz;
 
     // ---- Trailing fields (default-initialised, so existing brace-init
     // sites that pass the first 13 positional args don't need to change).
@@ -50,29 +88,29 @@ struct SolverContext {
     // ``fs_faces = -1`` and ``pad_* < 0`` (the defaults) reproduce the legacy
     // single ``free_surface`` (z-min only) + uniform ``abcn`` layout, so every
     // untouched brace-init / call site is bit-exact.
-    int fs_faces = -1;
-    int pad_lo[3] = {-1, -1, -1};   // [z, y, x]
-    int pad_hi[3] = {-1, -1, -1};
+    // (private: see the bottom of the struct -- writes must go through
+    // set_per_edge()/set_cut_mask() so the cached bounds stay in sync.)
 
     __host__ __device__
     inline bool fsLo(int axis) const {
-        return fs_faces < 0 ? (axis == 0 && free_surface) : ((fs_faces >> (2 * axis)) & 1);
+        return fs_faces_ < 0 ? (axis == 0 && free_surface) : ((fs_faces_ >> (2 * axis)) & 1);
     }
     __host__ __device__
     inline bool fsHi(int axis) const {
-        return fs_faces < 0 ? false : ((fs_faces >> (2 * axis + 1)) & 1);
+        return fs_faces_ < 0 ? false : ((fs_faces_ >> (2 * axis + 1)) & 1);
     }
+    __host__ __device__ inline int fs_faces() const { return fs_faces_; }
     // Per-face PML pad.  An explicit ``pad_lo``/``pad_hi`` (>= 0, per-edge
     // thickness) wins; otherwise a free-surface face has 0 pad and every other
     // face the uniform ``abcn``.  With ``fs_faces = -1`` this is exactly the
     // legacy ``free_surface ? 0 : abcn`` on z-min and ``abcn`` elsewhere.
     __host__ __device__
     inline int padLo(int axis) const {
-        return pad_lo[axis] >= 0 ? pad_lo[axis] : (fsLo(axis) ? 0 : abcn);
+        return pad_lo_[axis] >= 0 ? pad_lo_[axis] : (fsLo(axis) ? 0 : abcn);
     }
     __host__ __device__
     inline int padHi(int axis) const {
-        return pad_hi[axis] >= 0 ? pad_hi[axis] : (fsHi(axis) ? 0 : abcn);
+        return pad_hi_[axis] >= 0 ? pad_hi_[axis] : (fsHi(axis) ? 0 : abcn);
     }
 
     // Host-only: copy per-edge fields from a bound input's ``fs_faces`` +
@@ -80,11 +118,12 @@ struct SolverContext {
     // leave the -1 sentinels => legacy layout.  Call right after the positional
     // brace-init of a SolverContext at every driver.
     inline void set_per_edge(int fs, const std::vector<int>& plo, const std::vector<int>& phi) {
-        fs_faces = fs;
+        fs_faces_ = fs;
         for (int a = 0; a < 3; ++a) {
-            pad_lo[a] = (a < (int)plo.size()) ? plo[a] : -1;
-            pad_hi[a] = (a < (int)phi.size()) ? phi[a] : -1;
+            pad_lo_[a] = (a < (int)plo.size()) ? plo[a] : -1;
+            pad_hi_[a] = (a < (int)phi.size()) ? phi[a] : -1;
         }
+        refresh();
     }
 
     // ---- Domain-decomposition cut faces ---------------------------------
@@ -104,14 +143,18 @@ struct SolverContext {
     //   bit4 = y_lo, bit5 = y_hi.
     // 0 (default) = single domain — every kernel below behaves exactly as
     // before.  Backward drivers copy BackwardInput::cut_face_mask here.
-    int cut_mask = 0;
+    // (private ``cut_mask_``; assign through set_cut_mask().)
 
-    __host__ __device__ inline bool cut_x_lo() const { return cut_mask & 1; }
-    __host__ __device__ inline bool cut_x_hi() const { return cut_mask & 2; }
-    __host__ __device__ inline bool cut_z_lo() const { return cut_mask & 4; }
-    __host__ __device__ inline bool cut_z_hi() const { return cut_mask & 8; }
-    __host__ __device__ inline bool cut_y_lo() const { return cut_mask & 16; }
-    __host__ __device__ inline bool cut_y_hi() const { return cut_mask & 32; }
+    __host__ __device__ inline int  cut_mask() const { return cut_mask_; }
+    __host__ __device__ inline bool cut_x_lo() const { return cut_mask_ & 1; }
+    __host__ __device__ inline bool cut_x_hi() const { return cut_mask_ & 2; }
+    __host__ __device__ inline bool cut_z_lo() const { return cut_mask_ & 4; }
+    __host__ __device__ inline bool cut_z_hi() const { return cut_mask_ & 8; }
+    __host__ __device__ inline bool cut_y_lo() const { return cut_mask_ & 16; }
+    __host__ __device__ inline bool cut_y_hi() const { return cut_mask_ & 32; }
+
+    // The ONLY way to change the DD cut faces: re-runs refresh().
+    __host__ __device__ inline void set_cut_mask(int mask) { cut_mask_ = mask; refresh(); }
 
     // Ranged x stencil launch (DD phase-split forward): the kernel adds
     // ``x_base`` to its block/thread-derived ix and early-returns at
@@ -142,32 +185,18 @@ struct SolverContext {
     //   cut face                       -> ``M`` (legacy DD behaviour)
     // The z-low legacy ``free_surface ? M : abcn + M`` is reproduced via
     // ``padLo(0)``, whose fs_faces == -1 branch is ``free_surface ? 0 : abcn``.
-    __host__ __device__
-    inline int phys_x0() const { return cut_x_lo() ? M : padLo(2) + M; }
+    // Bare loads: refresh() resolved the branch chain on the host.
+    // Axis order of the cache is [z, y, x] (0, 1, 2), as everywhere else here.
+    __host__ __device__ inline int phys_x0() const { return phys_lo_[2]; }
+    __host__ __device__ inline int phys_x1() const { return phys_hi_[2]; }
+    __host__ __device__ inline int phys_y0() const { return phys_lo_[1]; }
+    __host__ __device__ inline int phys_y1() const { return phys_hi_[1]; }
+    __host__ __device__ inline int phys_z0() const { return phys_lo_[0]; }
+    __host__ __device__ inline int phys_z1() const { return phys_hi_[0]; }
 
-    __host__ __device__
-    inline int phys_x1() const { return nx - (cut_x_hi() ? M : padHi(2) + M); }
-
-    __host__ __device__
-    inline int phys_y0() const { return cut_y_lo() ? M : padLo(1) + M; }
-
-    __host__ __device__
-    inline int phys_y1() const { return ny - (cut_y_hi() ? M : padHi(1) + M); }
-
-    __host__ __device__
-    inline int phys_z0() const { return cut_z_lo() ? M : padLo(0) + M; }
-
-    __host__ __device__
-    inline int phys_z1() const { return nz - (cut_z_hi() ? M : padHi(0) + M); }
-
-    __host__ __device__
-    inline int nx_phys() const { return phys_x1() - phys_x0(); }
-
-    __host__ __device__
-    inline int ny_phys() const { return phys_y1() - phys_y0(); }
-
-    __host__ __device__
-    inline int nz_phys() const { return phys_z1() - phys_z0(); }
+    __host__ __device__ inline int nx_phys() const { return phys_hi_[2] - phys_lo_[2]; }
+    __host__ __device__ inline int ny_phys() const { return phys_hi_[1] - phys_lo_[1]; }
+    __host__ __device__ inline int nz_phys() const { return phys_hi_[0] - phys_lo_[0]; }
 
     // Per-column surface row (2-D propagator).  Returns the row index of
     // the first SOLID cell in column ``ix`` (matches Python ``topo_rows``
@@ -308,4 +337,66 @@ struct SolverContext {
         return has_topo ? topo_rows[iy * nx + ix] : phys_z0();
     }
 
+    // ---- Sole constructor ------------------------------------------------
+    // Its parameter list is exactly the 15 leading members, in order, so every
+    // existing brace-init site
+    //     SolverContext ctx{2, nx, 0, nz, B, dt, nt, M, abcn, fs,
+    //                       lap, grad, dx, 0.f, dz};
+    // still compiles verbatim -- it is now a constructor call rather than
+    // aggregate initialisation, with identical narrowing rules.  There is no
+    // default constructor on purpose: it would let a context exist with an
+    // unrefreshed cache.
+    __host__ __device__
+    SolverContext(int ndim_, int nx_, int ny_, int nz_, int B_,
+                  float dt_, unsigned int nt_, int M_, int abcn_,
+                  bool free_surface_,
+                  const float* lap_coeff_, const float* grad_coeff_,
+                  float dx_, float dy_, float dz_)
+        : ndim(ndim_), nx(nx_), ny(ny_), nz(nz_), B(B_),
+          dt(dt_), nt(nt_), M(M_), abcn(abcn_), free_surface(free_surface_),
+          lap_coeff(lap_coeff_), grad_coeff(grad_coeff_),
+          dx(dx_), dy(dy_), dz(dz_)
+    {
+        refresh();
+    }
+
+private:
+    // ---- Refresh inputs: private, so the only writers are the setters -----
+    int fs_faces_ = -1;
+    int pad_lo_[3] = {-1, -1, -1};   // [z, y, x]
+    int pad_hi_[3] = {-1, -1, -1};
+    int cut_mask_ = 0;
+
+    // ---- The cache -------------------------------------------------------
+    int phys_lo_[3] = {0, 0, 0};      // [z, y, x]
+    int phys_hi_[3] = {0, 0, 0};
+
+    // Resolve the per-face bounds once.  A DD cut face is exactly M regardless
+    // of the per-edge pad (its halo holds neighbour data); otherwise the face
+    // carries padLo/padHi, which is 0 on a free surface.  This is the former
+    // phys_*() expression, evaluated on the host instead of per thread.
+    __host__ __device__ void refresh()
+    {
+        const int extent[3] = {nz, ny, nx};
+        for (int a = 0; a < 3; ++a) {
+            // cut_mask bit layout: 0=x_lo 1=x_hi 2=z_lo 3=z_hi 4=y_lo 5=y_hi
+            const int lo_bit = (a == 0) ? 4 : (a == 1) ? 16 : 1;
+            const int hi_bit = (a == 0) ? 8 : (a == 1) ? 32 : 2;
+            const bool cl = (cut_mask_ & lo_bit) != 0;
+            const bool ch = (cut_mask_ & hi_bit) != 0;
+            phys_lo_[a] = cl ? M : padLo(a) + M;
+            phys_hi_[a] = extent[a] - (ch ? M : padHi(a) + M);
+        }
+    }
 };
+
+// Kernels take SolverContext BY VALUE, so trivial copyability is not
+// negotiable.  The const members delete copy-ASSIGNMENT (which is what stops a
+// refreshed context being overwritten wholesale) but leave copy-CONSTRUCTION
+// trivial, which is what the launches actually use.
+static_assert(std::is_trivially_copyable<SolverContext>::value,
+              "SolverContext must stay trivially copyable: it is passed by value to kernels.");
+static_assert(!std::is_default_constructible<SolverContext>::value,
+              "SolverContext must not be default-constructible: the bounds cache would be unrefreshed.");
+static_assert(!std::is_copy_assignable<SolverContext>::value,
+              "SolverContext must not be copy-assignable: that would bypass refresh().");

--- a/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/backward.cu
@@ -280,7 +280,7 @@ void run_full_imaging(
     SolverContext ctx{2, nx, 0, nz, B, dt, p.nt, M, p.abcn, p.free_surface, p.lap_coes.data_ptr<float>(), p.grad_coes.data_ptr<float>(), dx, 0.f, dz};
     if (p.has_topo) { ctx.topo_rows = p.topo_rows.data_ptr<int>(); ctx.has_topo = true; }
     ctx.set_per_edge(p.fs_faces, p.pad_lo, p.pad_hi);
-    ctx.cut_mask = 0;  // full-storage / RTM path is DD-free (DD is backward_bs only)
+    ctx.set_cut_mask(0);  // full-storage / RTM path is DD-free (DD is backward_bs only)
     acoustic_init_aux_slabs(ctx, adjoint);
 
     LaplaceParam lap_ctx{nx, 1, M, p.lap_coes.data_ptr<float>(), dx, 0, dz};
@@ -466,7 +466,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
     ctx.set_per_edge(p.fs_faces, p.pad_lo, p.pad_hi);
     // DD: skip cut faces in the strip restore, the seed rim-zeroing, the
     // NOPML exclusion band and the fused-adjoint pure_interior test.
-    ctx.cut_mask = p.cut_face_mask;
+    ctx.set_cut_mask(p.cut_face_mask);
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
@@ -524,10 +524,10 @@ BackwardOutput backward_bs(const BackwardInput& in)
         auto for_view = forward.view();
         set_boundary_zeros<<<launch_config.grid, launch_config.block>>>(
             for_view.u_prev, ctx.abcn+ctx.M, nx, nz,
-            ctx.fsLo(0), ctx.fsHi(0), ctx.fsLo(2), ctx.fsHi(2), ctx.cut_mask);
+            ctx.fsLo(0), ctx.fsHi(0), ctx.fsLo(2), ctx.fsHi(2), ctx.cut_mask());
         set_boundary_zeros<<<launch_config.grid, launch_config.block>>>(
             for_view.u_now, ctx.abcn+ctx.M, nx, nz,
-            ctx.fsLo(0), ctx.fsHi(0), ctx.fsLo(2), ctx.fsHi(2), ctx.cut_mask);
+            ctx.fsLo(0), ctx.fsHi(0), ctx.fsLo(2), ctx.fsHi(2), ctx.cut_mask());
     }
 
 
@@ -562,7 +562,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
     // _run_adjoint) must simply not issue segments entirely below bs_stop —
     // it derives the SAME stop from (nt, tail) on every rank, keeping the
     // lockstep halo exchanges aligned.  Cut faces are orthogonal: the strip
-    // save/restore is already cut-aware via ctx.cut_mask and the per-step
+    // save/restore is already cut-aware via ctx.cut_mask() and the per-step
     // strip layout does not depend on the step index, so the saved-step
     // shift passes through untouched.
     const int bs_it0 = (p.boundary_tail_steps > 0)

--- a/src/sweep/csrc/cuda/equations/acoustic2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/forward.cu
@@ -44,29 +44,18 @@ ForwardOutput forward(const ForwardInput& in) {
     const int order =
         (p.M <= 4) ? static_cast<int>(2 * p.M) : -1;
 
-    SolverContext ctx;
-    ctx.ndim         = 2;
-    ctx.nx           = nx;
-    ctx.ny           = 0;
-    ctx.nz           = nz;
-    ctx.B            = B;
-    ctx.dt           = p.dt;
-    ctx.nt           = p.nt;
-    ctx.M            = p.M;
-    ctx.abcn         = p.abcn;
-    ctx.free_surface = p.free_surface;
-    ctx.lap_coeff    = p.lap_coes.data_ptr<float>();
-    ctx.grad_coeff   = p.grad_coes.data_ptr<float>();
-    ctx.dx           = dx;
-    ctx.dy           = 0.f;
-    ctx.dz           = dz;
+    // The geometry feeds the cached phys_* bounds, so it is const after
+    // construction and goes through the constructor instead of field writes.
+    SolverContext ctx{2, nx, 0, nz, B, p.dt, p.nt, p.M, p.abcn, p.free_surface,
+                      p.lap_coes.data_ptr<float>(), p.grad_coes.data_ptr<float>(),
+                      dx, 0.f, dz};
     ctx.topo_rows    = p.has_topo ? p.topo_rows.data_ptr<int>() : nullptr;
     ctx.has_topo     = p.has_topo;
     ctx.topo_category = nullptr;
     ctx.use_apm      = false;
     ctx.set_per_edge(p.fs_faces, p.pad_lo, p.pad_hi);
     // Cut-aware physical bounds (0 = single domain → legacy per-edge pad + M).
-    ctx.cut_mask     = p.cut_face_mask;
+    ctx.set_cut_mask(p.cut_face_mask);
 
     const int it0 = p.it_begin;
     const int it1 = (p.it_end < 0) ? static_cast<int>(p.nt) : p.it_end;

--- a/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
@@ -656,7 +656,7 @@ void run_full_imaging(
 
     SolverContext ctx{3, nx, ny, nz, B, p.dt, p.nt, p.M, p.abcn, p.free_surface, p.lap_coes.data_ptr<float>(), p.grad_coes.data_ptr<float>(), dx, dy, dz};
     if (p.has_topo) { ctx.topo_rows = p.topo_rows.data_ptr<int>(); ctx.has_topo = true; }
-    ctx.cut_mask = 0;  // full-storage / RTM path is DD-free (DD is backward_bs only)
+    ctx.set_cut_mask(0);  // full-storage / RTM path is DD-free (DD is backward_bs only)
     acoustic_init_aux_slabs(ctx, adjoint);
 
     LaplaceParam lap_ctx{nx, ny, p.M, p.lap_coes.data_ptr<float>(), dx, dy, dz};
@@ -813,7 +813,7 @@ void run_bs_imaging(
     // DD: skip cut faces in the strip restore, the NOPML exclusion band
     // and the fused-adjoint pure_interior test (3D has no seed
     // rim-zeroing — nothing to mask there).
-    ctx.cut_mask = p.cut_face_mask;
+    ctx.set_cut_mask(p.cut_face_mask);
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())

--- a/src/sweep/csrc/cuda/equations/acoustic3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/forward.cu
@@ -60,7 +60,7 @@ ForwardOutput forward(const ForwardInput& in)
     // Cut-aware physical bounds: a cut face carries only the M halo (no abcn
     // PML pad), so phys_x0()/phys_x1()/... must shrink there. 0 = single
     // domain (every bound collapses to the legacy abcn+M).
-    ctx.cut_mask = p.cut_face_mask;
+    ctx.set_cut_mask(p.cut_face_mask);
 
     const int it0 = p.it_begin;
     const int it1 = (p.it_end < 0) ? static_cast<int>(nt) : p.it_end;

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/backward.cu
@@ -86,7 +86,7 @@ BackwardOutput backward_full_impl(const BackwardInput& in)
     SolverContext ctx{3, nx, ny, nz, B, in.dt, in.nt, in.M, in.abcn, in.free_surface,
                       in.lap_coes.data_ptr<float>(), in.grad_coes.data_ptr<float>(),
                       dx, dy, dz};
-    ctx.cut_mask = in.cut_face_mask;   // DD cut-aware: skip cut faces in bs reconstruction
+    ctx.set_cut_mask(in.cut_face_mask);   // DD cut-aware: skip cut faces in bs reconstruction
 
     AcousticWavefieldTensor adjoint;
     if (!in.adjoint_wavefields.empty())
@@ -247,7 +247,7 @@ BackwardOutput backward_bs_impl(const BackwardInput& in)
     SolverContext ctx{3, nx, ny, nz, B, p.dt, p.nt, p.M, p.abcn, p.free_surface,
                       p.lap_coes.data_ptr<float>(), p.grad_coes.data_ptr<float>(),
                       dx, dy, dz};
-    ctx.cut_mask = p.cut_face_mask;   // DD cut-aware: skip cut faces in boundary reconstruction
+    ctx.set_cut_mask(p.cut_face_mask);   // DD cut-aware: skip cut faces in boundary reconstruction
 
     // Stepped backward: process [bw_it_end, bw_begin()) in descending order so a
     // DD driver can halo-exchange the adjoint + reconstruction fields between
@@ -669,7 +669,7 @@ BackwardOutput backward_ckpt_impl(const BackwardInput& in)
     SolverContext ctx{3, nx, ny, nz, B, p.dt, p.nt, p.M, p.abcn, p.free_surface,
                       p.lap_coes.data_ptr<float>(), p.grad_coes.data_ptr<float>(),
                       dx, dy, dz};
-    ctx.cut_mask = p.cut_face_mask;   // DD cut-aware: skip cut faces in boundary reconstruction
+    ctx.set_cut_mask(p.cut_face_mask);   // DD cut-aware: skip cut faces in boundary reconstruction
 
     AcousticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/forward.cu
@@ -55,7 +55,7 @@ ForwardOutput forward(const ForwardInput& in)
     // face on ctx.cut_* — but only if cut_mask is propagated here (acoustic3d does
     // the same).  Missing this makes VRZ write cut faces' null buffers => illegal
     // memory access under DD (PY*/PX* tiles with cut faces).
-    ctx.cut_mask = p.cut_face_mask;
+    ctx.set_cut_mask(p.cut_face_mask);
 
     // Stepped execution: run [it_begin, it_end) instead of [0, nt) so a DD
     // driver can halo-exchange between single steps.  All per-step indexing

--- a/src/sweep/csrc/cuda/equations/elastic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic2d/backward.cu
@@ -801,7 +801,7 @@ BackwardOutput backward(const BackwardInput& in)
     solver.set_per_edge(p.fs_faces, p.pad_lo, p.pad_hi);
     if (p.has_topo) { solver.topo_rows = p.topo_rows.data_ptr<int>(); solver.has_topo = true; }
     // DD: cut-aware PML predicates in the adjoint prepare kernels.
-    solver.cut_mask = p.cut_face_mask;
+    solver.set_cut_mask(p.cut_face_mask);
 
     ElasticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
@@ -1298,7 +1298,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
     // DD: skip cut faces in the strip restore, collapse the NOPML exclusion
     // bands to the stencil halo on cut sides, and route cut-side cells of
     // the adjoint prepare kernels through the interior branch.
-    solver.cut_mask = p.cut_face_mask;
+    solver.set_cut_mask(p.cut_face_mask);
     SGradParam grad_ctx{1, 0, nx, p.M, p.grad_coes.data_ptr<float>(), dx, 0.f, dz};
 
     ElasticWavefieldTensor adjoint;

--- a/src/sweep/csrc/cuda/equations/elastic2d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic2d/forward.cu
@@ -114,7 +114,7 @@ ForwardOutput forward(const ForwardInput& in)
     SolverContext solver{2, nx, 0, nz, B, p.dt, p.nt, p.M, p.abcn, p.free_surface, p.lap_coes.data_ptr<float>(), p.grad_coes.data_ptr<float>(), dx, 0.f, dz};
     solver.set_per_edge(p.fs_faces, p.pad_lo, p.pad_hi);
     if (p.has_topo) { solver.topo_rows = p.topo_rows.data_ptr<int>(); solver.has_topo = true; }
-    solver.cut_mask = p.cut_face_mask;   // cut-aware phys bounds (0 = single domain)
+    solver.set_cut_mask(p.cut_face_mask);   // cut-aware phys bounds (0 = single domain)
     elastic_init_aux_slabs(solver, wavefield);
 
     EffectiveBoundarySaver boundary_saver;
@@ -353,7 +353,7 @@ ForwardOutput apm_forward(const ForwardInput& in)
                          dx, 0.f, dz};
     solver.topo_category = p.topo_category.data_ptr<int>();
     solver.use_apm = true;
-    solver.cut_mask = p.cut_face_mask;   // cut-aware phys bounds (0 = single domain)
+    solver.set_cut_mask(p.cut_face_mask);   // cut-aware phys bounds (0 = single domain)
     elastic_init_aux_slabs(solver, wavefield);
 
     EffectiveBoundarySaver boundary_saver;

--- a/src/sweep/csrc/cuda/equations/elastic2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/elastic2d/kernels.cuh
@@ -634,7 +634,7 @@ __global__ void elastic_stress_adjoint_prepare(
     // q* outputs collapse to bar_dv*_d* and the four m_v* writes become
     // 0 -> 0. Skip them — saves 4 reads + 4 writes per interior cell.
     // Matches the forward elastic_stress_kernel fast-path (line 230).
-    // DD cut faces (solver.cut_mask) carry no PML; the matching cells of
+    // DD cut faces (solver.cut_mask()) carry no PML; the matching cells of
     // the un-split run take the interior branch, so the cut-side band must
     // take it too (the zero-coefficient PML branch is mathematically the
     // identity but not bitwise identical — q at cut-side halo cells feeds

--- a/src/sweep/csrc/cuda/equations/elastic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic3d/backward.cu
@@ -826,7 +826,7 @@ BackwardOutput backward_bs(const BackwardInput& in)
     // DD: skip cut faces in the strip restore, collapse the NOPML exclusion
     // bands to the stencil halo on cut sides, and route cut-side cells of
     // the adjoint prepare kernels through the interior branch.
-    solver.cut_mask = p.cut_face_mask;
+    solver.set_cut_mask(p.cut_face_mask);
 
     ElasticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())
@@ -1162,7 +1162,7 @@ BackwardOutput backward(const BackwardInput& in)
 
     SolverContext solver{3, nx, ny, nz, B, p.dt, p.nt, p.M, p.abcn, p.free_surface, p.lap_coes.data_ptr<float>(), p.grad_coes.data_ptr<float>(), dx, dy, dz};
     // DD: cut-aware PML predicates in the adjoint prepare kernels.
-    solver.cut_mask = p.cut_face_mask;
+    solver.set_cut_mask(p.cut_face_mask);
 
     ElasticWavefieldTensor adjoint;
     if (!p.adjoint_wavefields.empty())

--- a/src/sweep/csrc/cuda/equations/elastic3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic3d/forward.cu
@@ -125,7 +125,7 @@ ForwardOutput forward(const ForwardInput& in)
                 "elastic3d forward cut_face_mask supports x/y bits only "
                 "(bit0=x_lo, bit1=x_hi, bit4=y_lo, bit5=y_hi), got ",
                 p.cut_face_mask);
-    solver.cut_mask = p.cut_face_mask;
+    solver.set_cut_mask(p.cut_face_mask);
     elastic_init_aux_slabs(solver, wavefield);
 
     EffectiveBoundarySaver boundary_saver;

--- a/src/sweep/csrc/cuda/equations/elastic3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/elastic3d/kernels.cuh
@@ -181,7 +181,7 @@ __global__ void __launch_bounds__(256, ELASTIC3D_LB_MINBLOCKS) elastic_velocity_
 
     float inv_rho = 1.f / rho_b[idx];
 
-    // DD cut faces (solver.cut_mask) carry no PML (per-rank widths zero the
+    // DD cut faces (solver.cut_mask()) carry no PML (per-rank widths zero the
     // profile there), and the matching cells of the un-split run take the
     // interior branch.  The PML branch with all-zero coefficients is
     // mathematically identity but NOT bitwise identical (different FMA
@@ -507,7 +507,7 @@ __global__ void elastic_velocity_kernel_3d_nopml(
     }
 
     // Per-side exclusion bands.  On a non-cut side keep the legacy width
-    // (PML band + saved strip); on a DD cut side (solver.cut_mask) the band
+    // (PML band + saved strip); on a DD cut side (solver.cut_mask()) the band
     // collapses to the stencil halo M — there is no PML at a cut, the
     // restore skips the cut-face strip, and the cut-adjacent cells are
     // reconstructed by the plain reverse stencil reading the per-phase
@@ -587,7 +587,7 @@ __global__ void elastic_stress_kernel_3d_nopml(
     }
 
     // Per-side exclusion bands.  On a non-cut side keep the legacy width
-    // (PML band + saved strip); on a DD cut side (solver.cut_mask) the band
+    // (PML band + saved strip); on a DD cut side (solver.cut_mask()) the band
     // collapses to the stencil halo M — there is no PML at a cut, the
     // restore skips the cut-face strip, and the cut-adjacent cells are
     // reconstructed by the plain reverse stencil reading the per-phase
@@ -907,7 +907,7 @@ __global__ void elastic_velocity_adjoint_prepare_3d(
     // read.  (The legacy code loaded them unconditionally over the full
     // grid; the interior path never consumed them.)
 
-    // DD cut faces (solver.cut_mask) carry no PML and the matching cells
+    // DD cut faces (solver.cut_mask()) carry no PML and the matching cells
     // of the un-split run take the interior branch; the cut-side band must
     // take it too (different FMA contraction on the PML branch — see
     // elastic_velocity_kernel_3d).  p at cut-side halo cells feeds owned

--- a/test/test_boundary_compact_kernel.py
+++ b/test/test_boundary_compact_kernel.py
@@ -1,0 +1,203 @@
+"""The band-only (compact) boundary kernels must be bit-identical to the scan.
+
+``boundary_kernel2d`` walks the whole padded grid and lets ~96% of its threads
+return after the prologue -- four ``SolverContext::phys_*()`` evaluations that,
+since the per-edge / DD rework, are a branch chain rather than a constant.  That
+prologue is essentially the kernel's entire cost, so the scan was replaced by
+``boundary_kernel2d_compact``, which launches one thread per boundary-band cell
+(the 3-D path has worked this way for a while).
+
+The compact kernel changes only *which* threads do the work, never the
+arithmetic, so every gradient must come back bit-for-bit identical.  These tests
+pin that by running the same problem twice, once with ``SWEEP_BOUNDARY_NO_COMPACT``
+forcing the scan kernels, and comparing the raw bytes.
+"""
+
+import os
+
+import numpy as np
+import pytest
+import torch
+
+from sweep.equations import Acoustic, Acoustic3D, Elastic
+from sweep.propagator.torch import PropTorch
+from sweep.signal import ricker
+
+
+cuda_only = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="impl='c' requires CUDA."
+)
+
+_DT = 1.5e-3
+_NT = 300
+
+
+def _wavelet(nt=_NT, dt=_DT, f=9.0):
+    t = np.arange(nt, dtype=np.float32) * dt
+    return ricker(t - 0.12, f=f)
+
+
+def _acoustic_grad(force_scan, *, shape, free_surface, batch, storage_dtype="fp32"):
+    """d(loss)/d(vp) for a small 2-D acoustic problem with boundary saving."""
+    nz, nx = shape
+    dev = torch.device("cuda")
+    z = np.arange(nz, dtype=np.float32)[:, None]
+    vp_init = (1500.0 + 8.0 * z).repeat(nx, 1).astype(np.float32)
+    vp_true = vp_init.copy()
+    vp_true[nz // 2:, nx // 3: 2 * nx // 3] += 400.0
+
+    src_x = np.linspace(nx * 0.2, nx * 0.8, batch).astype(np.int64)
+    sources = np.stack([src_x, np.full(batch, 3, dtype=np.int64)], axis=1)
+    rec_x = np.linspace(2, nx - 3, min(nx - 4, 48)).astype(np.int64)
+    receivers = np.repeat(
+        np.stack([rec_x, np.full(rec_x.size, 4, dtype=np.int64)], axis=1)[None, ...],
+        batch, axis=0)
+
+    with _forced(force_scan):
+        solver = PropTorch(
+            Acoustic(spatial_order=4, device=dev, backend="torch"),
+            shape=shape, dh=15.0, dt=_DT, impl="c", free_surface=free_surface,
+            boundary_saving_config={"enabled": True, "storage": "gpu",
+                                    "storage_dtype": storage_dtype},
+        )
+        wavelet = _wavelet()
+        with torch.no_grad():
+            obs = solver(wavelet, sources, receivers,
+                         models=[torch.tensor(vp_true, device=dev)]).detach()
+        vp = torch.tensor(vp_init, device=dev, requires_grad=True)
+        loss = (solver(wavelet, sources, receivers, models=[vp]) - obs).pow(2).mean()
+        loss.backward()
+    return vp.grad.detach().cpu().numpy(), float(loss.detach())
+
+
+def _acoustic3d_grad(force_scan, *, shape=(48, 44, 52), nt=150):
+    nz, ny, nx = shape
+    dev = torch.device("cuda")
+    z = np.arange(nz, dtype=np.float32)[:, None, None]
+    vp_init = (1800.0 + 12.0 * z).repeat(ny, 1).repeat(nx, 2).astype(np.float32)
+    vp_true = vp_init.copy()
+    vp_true[nz // 2:, :, :] += 300.0
+
+    sources = np.array([[nx // 2, ny // 2, 3]], dtype=np.int64)
+    rx = np.linspace(2, nx - 3, 6).astype(np.int64)
+    ry = np.linspace(2, ny - 3, 6).astype(np.int64)
+    rxg, ryg = np.meshgrid(rx, ry, indexing="ij")
+    receivers = np.stack([rxg.ravel(), ryg.ravel(),
+                          np.full(rxg.size, 3, dtype=np.int64)], axis=1)[None, ...]
+
+    with _forced(force_scan):
+        solver = PropTorch(
+            Acoustic3D(spatial_order=4, device=dev, backend="torch"),
+            shape=shape, dh=20.0, dt=_DT, impl="c",
+            boundary_saving_config={"enabled": True, "storage": "gpu"},
+        )
+        wavelet = _wavelet(nt=nt)
+        with torch.no_grad():
+            obs = solver(wavelet, sources, receivers,
+                         models=[torch.tensor(vp_true, device=dev)]).detach()
+        vp = torch.tensor(vp_init, device=dev, requires_grad=True)
+        loss = (solver(wavelet, sources, receivers, models=[vp]) - obs).pow(2).mean()
+        loss.backward()
+    return vp.grad.detach().cpu().numpy(), float(loss.detach())
+
+
+def _elastic_grad(force_scan, *, shape=(70, 110), free_surface=False, nt=250):
+    """Multi-field boundary saving -> the per-field save/restore launch sites."""
+    nz, nx = shape
+    dev = torch.device("cuda")
+    z = np.arange(nz, dtype=np.float32)[:, None]
+    vp = (2000.0 + 6.0 * z).repeat(nx, 1).astype(np.float32)
+    vs = (vp / 1.8).astype(np.float32)
+    rho = (1800.0 + 0.3 * z).repeat(nx, 1).astype(np.float32)
+    vp_true = vp.copy()
+    vp_true[nz // 2:, :] += 300.0
+
+    sources = np.array([[nx // 2, 4]], dtype=np.int64)
+    rec_x = np.linspace(2, nx - 3, 32).astype(np.int64)
+    receivers = np.stack([rec_x, np.full(rec_x.size, 3, dtype=np.int64)], axis=1)[None, ...]
+
+    with _forced(force_scan):
+        solver = PropTorch(
+            Elastic(spatial_order=4, device=dev, backend="torch"),
+            shape=shape, dh=15.0, dt=1e-3, impl="c", free_surface=free_surface,
+            boundary_saving_config={"enabled": True, "storage": "gpu"},
+        )
+        wavelet = _wavelet(nt=nt, dt=1e-3, f=8.0)
+        t = lambda a: torch.tensor(a, device=dev)
+        with torch.no_grad():
+            obs = solver(wavelet, sources, receivers,
+                         models=[t(vp_true), t(vs), t(rho)]).detach()
+        vpp = torch.tensor(vp, device=dev, requires_grad=True)
+        loss = (solver(wavelet, sources, receivers,
+                       models=[vpp, t(vs), t(rho)]) - obs).pow(2).mean()
+        loss.backward()
+    return vpp.grad.detach().cpu().numpy(), float(loss.detach())
+
+
+class _forced:
+    """Force the scan kernels for the lifetime of the block (env is read when
+    the C++ BoundarySaver is constructed, i.e. inside PropTorch)."""
+
+    def __init__(self, on):
+        self.on = on
+
+    def __enter__(self):
+        self.prev = os.environ.get("SWEEP_BOUNDARY_NO_COMPACT")
+        if self.on:
+            os.environ["SWEEP_BOUNDARY_NO_COMPACT"] = "1"
+        else:
+            os.environ.pop("SWEEP_BOUNDARY_NO_COMPACT", None)
+        return self
+
+    def __exit__(self, *exc):
+        if self.prev is None:
+            os.environ.pop("SWEEP_BOUNDARY_NO_COMPACT", None)
+        else:
+            os.environ["SWEEP_BOUNDARY_NO_COMPACT"] = self.prev
+
+
+def _assert_bit_identical(a, b, what):
+    ga, la = a
+    gb, lb = b
+    assert ga.shape == gb.shape, f"{what}: shape {ga.shape} vs {gb.shape}"
+    assert la.hex() == lb.hex(), f"{what}: loss {la!r} vs {lb!r}"
+    assert ga.tobytes() == gb.tobytes(), (
+        f"{what}: gradient differs (max |d| = {np.abs(ga - gb).max():.3e}, "
+        f"rel = {np.abs(ga - gb).max() / max(np.abs(ga).max(), 1e-30):.3e})")
+
+
+@cuda_only
+@pytest.mark.parametrize("free_surface", [False, True])
+@pytest.mark.parametrize("shape,batch", [((40, 48), 2), ((110, 240), 3)])
+def test_compact_matches_scan_acoustic2d(shape, batch, free_surface):
+    """The headline path: 2-D acoustic, FP32 boundary saving on GPU."""
+    kw = dict(shape=shape, free_surface=free_surface, batch=batch)
+    _assert_bit_identical(_acoustic_grad(False, **kw), _acoustic_grad(True, **kw),
+                          f"acoustic2d {shape} fs={free_surface}")
+
+
+@cuda_only
+@pytest.mark.parametrize("storage_dtype", ["bf16", "int8"])
+def test_lossy_storage_keeps_scan_kernel(storage_dtype):
+    """Lossy storage dtypes are excluded from the compact path -- their two
+    copies of a corner cell need not round-trip identically -- so forcing the
+    scan must be a no-op for them."""
+    kw = dict(shape=(60, 96), free_surface=False, batch=2, storage_dtype=storage_dtype)
+    _assert_bit_identical(_acoustic_grad(False, **kw), _acoustic_grad(True, **kw),
+                          f"acoustic2d {storage_dtype}")
+
+
+@cuda_only
+@pytest.mark.parametrize("free_surface", [False, True])
+def test_compact_matches_scan_elastic2d(free_surface):
+    """Elastic saves several fields -> the per-field launch sites."""
+    _assert_bit_identical(_elastic_grad(False, free_surface=free_surface),
+                          _elastic_grad(True, free_surface=free_surface),
+                          f"elastic2d fs={free_surface}")
+
+
+@cuda_only
+def test_compact_matches_scan_acoustic3d():
+    """The 3-D compact path shares the gate; pin it against the scan too."""
+    _assert_bit_identical(_acoustic3d_grad(False), _acoustic3d_grad(True),
+                          "acoustic3d")

--- a/test/test_boundary_compact_kernel.py
+++ b/test/test_boundary_compact_kernel.py
@@ -29,7 +29,8 @@ cuda_only = pytest.mark.skipif(
 )
 
 _DT = 1.5e-3
-_NT = 300
+_NT = 900          # long enough for the reflection to reach the receivers
+_PERTURB_FRAC = 4  # perturbation at nz/4, not nz/2 -- see _assert_nonvacuous
 
 
 def _wavelet(nt=_NT, dt=_DT, f=9.0):
@@ -44,7 +45,7 @@ def _acoustic_grad(force_scan, *, shape, free_surface, batch, storage_dtype="fp3
     z = np.arange(nz, dtype=np.float32)[:, None]
     vp_init = (1500.0 + 8.0 * z).repeat(nx, 1).astype(np.float32)
     vp_true = vp_init.copy()
-    vp_true[nz // 2:, nx // 3: 2 * nx // 3] += 400.0
+    vp_true[nz // _PERTURB_FRAC:, nx // 3: 2 * nx // 3] += 400.0
 
     src_x = np.linspace(nx * 0.2, nx * 0.8, batch).astype(np.int64)
     sources = np.stack([src_x, np.full(batch, 3, dtype=np.int64)], axis=1)
@@ -70,13 +71,13 @@ def _acoustic_grad(force_scan, *, shape, free_surface, batch, storage_dtype="fp3
     return vp.grad.detach().cpu().numpy(), float(loss.detach())
 
 
-def _acoustic3d_grad(force_scan, *, shape=(48, 44, 52), nt=150):
+def _acoustic3d_grad(force_scan, *, shape=(48, 44, 52), nt=500):
     nz, ny, nx = shape
     dev = torch.device("cuda")
     z = np.arange(nz, dtype=np.float32)[:, None, None]
     vp_init = (1800.0 + 12.0 * z).repeat(ny, 1).repeat(nx, 2).astype(np.float32)
     vp_true = vp_init.copy()
-    vp_true[nz // 2:, :, :] += 300.0
+    vp_true[nz // _PERTURB_FRAC:, :, :] += 300.0
 
     sources = np.array([[nx // 2, ny // 2, 3]], dtype=np.int64)
     rx = np.linspace(2, nx - 3, 6).astype(np.int64)
@@ -101,7 +102,7 @@ def _acoustic3d_grad(force_scan, *, shape=(48, 44, 52), nt=150):
     return vp.grad.detach().cpu().numpy(), float(loss.detach())
 
 
-def _elastic_grad(force_scan, *, shape=(70, 110), free_surface=False, nt=250):
+def _elastic_grad(force_scan, *, shape=(70, 110), free_surface=False, nt=900):
     """Multi-field boundary saving -> the per-field save/restore launch sites."""
     nz, nx = shape
     dev = torch.device("cuda")
@@ -110,7 +111,7 @@ def _elastic_grad(force_scan, *, shape=(70, 110), free_surface=False, nt=250):
     vs = (vp / 1.8).astype(np.float32)
     rho = (1800.0 + 0.3 * z).repeat(nx, 1).astype(np.float32)
     vp_true = vp.copy()
-    vp_true[nz // 2:, :] += 300.0
+    vp_true[nz // _PERTURB_FRAC:, :] += 300.0
 
     sources = np.array([[nx // 2, 4]], dtype=np.int64)
     rec_x = np.linspace(2, nx - 3, 32).astype(np.int64)
@@ -156,9 +157,24 @@ class _forced:
             os.environ["SWEEP_BOUNDARY_NO_COMPACT"] = self.prev
 
 
+def _assert_nonvacuous(g, loss, what):
+    """A zero loss or an all-zero gradient makes the byte comparison pass no
+    matter what the kernels do.  That is the failure mode this whole file
+    exists to catch, so check the check."""
+    assert loss > 0.0, (
+        f"{what}: loss is exactly 0 -- nothing reached the receivers, so the "
+        "bit-comparison below would be vacuous. Lengthen nt or move the "
+        "perturbation shallower.")
+    assert np.abs(g).max() > 0.0, (
+        f"{what}: gradient is identically zero -- the bit-comparison would be "
+        "vacuous.")
+
+
 def _assert_bit_identical(a, b, what):
     ga, la = a
     gb, lb = b
+    _assert_nonvacuous(ga, la, what + " [compact]")
+    _assert_nonvacuous(gb, lb, what + " [scan]")
     assert ga.shape == gb.shape, f"{what}: shape {ga.shape} vs {gb.shape}"
     assert la.hex() == lb.hex(), f"{what}: loss {la!r} vs {lb!r}"
     assert ga.tobytes() == gb.tobytes(), (


### PR DESCRIPTION
Restores 2-D `impl='c'` FWI throughput, which v0.2.0 had cost ~15%, and ends up
slightly ahead of v0.1.0. Gradients are bit-identical throughout.

## What regressed, and why

`SolverContext::phys_x0()...nz_phys()` used to be a constant (`abcn + M`). The
per-edge free surface and the DD cut-select turned each face into a 3-deep
conditional; ptxas gives up on if-conversion and emits a branch chain in the
kernel prologue. For a *thin* kernel that prologue **is** the kernel — hence
`boundary_kernel2d` +93%, `acoustic2nd_nopml` +47%, while the main stencil
(prologue amortised by the Laplacian) was unaffected.

`boundary_kernel2d` was hit hardest for a second, independent reason: it scans
the whole padded grid, so at production sizes only **1.7%** of its threads land
in a boundary band and the other 98.3% exist purely to run that prologue. The
3-D path has had a band-only kernel for a while; 2-D never did.

## What this does

**1. `boundary_kernel2d_compact`** — one thread per boundary-band cell instead
of one per grid cell. Mirrors `boundary_kernel3d_compact`, plus DD cut-face
gating (a cut face's buffer is `numel=0`, so the `ctx.cut_*` gate is
load-bearing, not cosmetic). FP32 save/restore only: int8/fp16 keep the scan
because their per-256-cell scales make a corner cell's two buffer copies
numerically different, and the compact path writes them from two threads.
`SWEEP_BOUNDARY_NO_COMPACT=1` forces the scan (used by the parity test).

**2. Cached `phys_*` bounds** — resolved once on the host in `refresh()`, so the
device accessors are bare loads. One place, every equation. The cache cannot go
stale by construction: the 15 geometry members are `const` (a post-construction
write is a compile error), `fs_faces`/`pad_lo`/`pad_hi`/`cut_mask` are private
behind refreshing setters, and there is no default constructor. Three
`static_assert`s pin trivial copyability (kernels take the context by value),
non-default-constructibility and non-assignability. The constructor's parameter
list matches the leading 15 members in order, so all 77 brace-init sites compile
unchanged.

## Numbers (RTX 6000 Ada, alternating rounds, cv>0.02 rounds dropped)

| | v0.1.0 | v0.2.0 | this PR |
|---|---|---|---|
| Marmousi 141x681, 8 shots | 0.1732 | 0.1982 | **0.1697** (-14.4% vs v0.2.0, -2.0% vs v0.1.0) |
| + free surface | 0.1309 | 0.1517 | **0.1291** (-14.9%, -1.4%) |
| Elastic 2D | 0.2022 | 0.2088 | **0.1825** (-12.6%, -9.8%) |
| Acoustic 2D | 0.0510 | 0.0570 | **0.0491** (-13.9%, -3.8%) |
| AcousticVRZ 2D | 0.0772 | 0.0850 | **0.0755** (-11.3%, -2.3%) |
| Acoustic 3D | 0.6666 | 0.6648 | 0.6691 (never regressed) |

`boundary_kernel2d` itself: 10.21 -> 2.24 us (-78%); whole-iteration GPU time -16.7%.

## Verification

- **Bit-exact gradients, 13 equation configurations**: acoustic 2-D (+-FS, incl.
  production-scale Marmousi) / 3-D, VRZ 2-D/3-D, elastic 2-D (+-FS) / 3-D,
  DAS-Mu 2-D/3-D, DASZhao 2-D, VTI-1st 2-D/3-D, ElasticTTI-SG 2-D. Compared as
  raw bytes: loss, gradient, recorded traces, gradient L2.
  `DASZhao` is excluded from the bit criterion because its adjoint is
  run-to-run non-deterministic (`scatter` + `atomicAdd`); it is checked against
  the run-to-run floor instead (9.572e-07 vs a 9.574e-07 floor).
- **Every criterion was checked for attainability first.** The bit comparison
  passes trivially on a zero gradient, and it initially did — the perturbation
  sat too deep for the reflection to return within `nt`. Fixed, and the new test
  asserts a nonzero loss/gradient on both sides before comparing; removing the
  perturbation makes all 9 cases fail as it should.
- **Test suite**: 69 files. The 2 with failures (`test_das_equations`,
  `test_topography_elastic2d`) fail identically on `dev` — same test IDs.
- **Notebooks**: all 28 `docs/notebooks` executed against both trees, outputs
  compared verbatim after scrubbing timings/memory — **28/28 identical**. A
  probe cell in every notebook proves which tree was imported.

## Not addressed

- bf16 2-D still takes the scan (it *could* use compact — no per-block scale —
  it just needs the `_compact_bf16` variant the 3-D side already has).
- `AcousticVRZ3D` remains ~10% slower than v0.1.0. Unrelated to this PR: it comes
  from the DD commits (`73cb22d`, `9f34e5f`, `7850997`), 74% of it in
  `calculate_grad_vrz3d_fused`, whose 6 accessors inline the interior test at
  every stencil tap. Restoring the pre-DD bounds recovers only 2.4pp of it — the
  rest tracks `SolverContext` growing by 112 bytes, which that kernel embeds by
  value six times. Register pressure, DRAM bandwidth and caching `x_end` were all
  tested and ruled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
