### PR TITLE
perf(vrz): pass stencil accessors a GridBounds view, not the whole context

### DIFF
--- a/src/sweep/csrc/cuda/common/context.h
+++ b/src/sweep/csrc/cuda/common/context.h
@@ -37,6 +37,28 @@
 // IF YOU ADD A MEMBER THAT phys_*() DEPENDS ON, IT MUST GO IN THE PRIVATE
 // SECTION WITH A REFRESHING SETTER, OR BE const.
 // ============================================================================
+// A read-only view of just the launch geometry a stencil accessor needs.
+//
+// SolverContext is 240 bytes and grew there honestly (per-edge free surface, DD
+// cut faces, CPML aux slabs, the cached bounds).  That is fine for a kernel
+// parameter -- it is passed once and amortised over the whole kernel.  It is
+// NOT fine inside a functor that gets inlined once per stencil tap: the VRZ
+// gradient kernels build six accessors and each one is expanded 2M times, so
+// every byte of state is paid for 24 times over at order 4.  Those accessors
+// read six-to-twelve ints; this is that subset.
+struct GridBounds {
+    int nx, ny, nz, B, M;
+    int x_end;
+    int phys_lo[3], phys_hi[3];   // [z, y, x], same axis order as SolverContext
+
+    __host__ __device__ inline int phys_x0() const { return phys_lo[2]; }
+    __host__ __device__ inline int phys_x1() const { return phys_hi[2]; }
+    __host__ __device__ inline int phys_y0() const { return phys_lo[1]; }
+    __host__ __device__ inline int phys_y1() const { return phys_hi[1]; }
+    __host__ __device__ inline int phys_z0() const { return phys_lo[0]; }
+    __host__ __device__ inline int phys_z1() const { return phys_hi[0]; }
+};
+
 struct SolverContext {
 
     // ---- Geometry & physics: immutable after construction ----------------
@@ -193,6 +215,14 @@ struct SolverContext {
     __host__ __device__ inline int phys_y1() const { return phys_hi_[1]; }
     __host__ __device__ inline int phys_z0() const { return phys_lo_[0]; }
     __host__ __device__ inline int phys_z1() const { return phys_hi_[0]; }
+
+    // Hand a stencil accessor only what it reads (see GridBounds above).
+    __host__ __device__ inline GridBounds bounds() const {
+        GridBounds g;
+        g.nx = nx; g.ny = ny; g.nz = nz; g.B = B; g.M = M; g.x_end = x_end();
+        for (int a = 0; a < 3; ++a) { g.phys_lo[a] = phys_lo_[a]; g.phys_hi[a] = phys_hi_[a]; }
+        return g;
+    }
 
     __host__ __device__ inline int nx_phys() const { return phys_hi_[2] - phys_lo_[2]; }
     __host__ __device__ inline int ny_phys() const { return phys_hi_[1] - phys_lo_[1]; }

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz2d/kernels.cuh
@@ -163,7 +163,7 @@ __global__ void calculate_grad_vrz2d(
 
 template<int Order, int Direction>
 __device__ __forceinline__ bool vrz2d_grad_product_interior(
-    SolverContext solver,
+    GridBounds solver,
     int ix,
     int iz
 ) {
@@ -186,7 +186,7 @@ __device__ __forceinline__ float vrz2d_q_gradp(
     int ix,
     int iz,
     GradParam grad_ctx,
-    SolverContext solver
+    GridBounds solver
 ) {
     if (!vrz2d_grad_product_interior<Order, Direction>(solver, ix, iz))
         return 0.f;
@@ -204,7 +204,7 @@ struct VRZ2DGradientProductAccessor {
     int sx;
     int sz;
     GradParam grad_ctx;
-    SolverContext solver;
+    GridBounds solver;          // not SolverContext: this is inlined per tap
 
     __device__ __forceinline__
     float operator()(int offset) const
@@ -242,7 +242,7 @@ __device__ __forceinline__ float vrz2d_fused_grad_q_gradp(
 
     return centered_gradient_stencil<Order>(
         VRZ2DGradientProductAccessor<Order, Direction>{
-            q, p, ix, iz, sx, sz, grad_ctx, solver
+            q, p, ix, iz, sx, sz, grad_ctx, solver.bounds()
         },
         solver.M,
         grad_ctx.coeff,
@@ -257,7 +257,7 @@ __device__ __forceinline__ float vrz2d_split_grad_q_gradp(
     int ix,
     int iz,
     GradParam grad_ctx,
-    SolverContext solver
+    GridBounds solver
 ) {
     if (!vrz2d_grad_product_interior<Order, Direction>(solver, ix, iz))
         return 0.f;

--- a/src/sweep/csrc/cuda/equations/acoustic_vrz3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vrz3d/kernels.cuh
@@ -174,6 +174,22 @@ __device__ inline void vrz3d_index(
     iz = iz_global % solver.nz;
 }
 
+// GridBounds overload: used by the gradient accessors, which are inlined once
+// per stencil tap.  The SolverContext version below stays for the kernel-level
+// callers (one call per thread, not per tap).
+template<int Order>
+__device__ __forceinline__ bool vrz3d_interior(GridBounds solver, int ix, int iy, int iz, int b)
+{
+    if (b >= solver.B || ix >= solver.x_end || iy >= solver.ny || iz >= solver.nz)
+        return false;
+    constexpr bool is_runtime = (Order == -1);
+    constexpr int m_static = is_runtime ? 0 : (Order / 2);
+    int halo = is_runtime ? solver.M : m_static;
+    return ix >= halo && ix < solver.nx - halo
+        && iy >= halo && iy < solver.ny - halo
+        && iz >= halo && iz < solver.nz - halo;
+}
+
 template<int Order>
 __device__ inline bool vrz3d_interior(SolverContext solver, int ix, int iy, int iz, int b)
 {
@@ -193,7 +209,7 @@ __device__ inline bool vrz3d_interior(SolverContext solver, int ix, int iy, int 
 
 template<int Order, int Direction>
 __device__ __forceinline__ bool vrz3d_grad_product_interior(
-    SolverContext solver,
+    GridBounds solver,
     int ix,
     int iy,
     int iz
@@ -241,7 +257,7 @@ struct VRZ3DGradientProductAccessor {
     int sy;
     int sz;
     GradParam grad_ctx;
-    SolverContext solver;
+    GridBounds solver;          // not SolverContext: this is inlined per tap
 
     __device__ __forceinline__
     float operator()(int offset) const
@@ -284,7 +300,7 @@ __device__ __forceinline__ float vrz3d_grad_q_gradp(
 
     return centered_gradient_stencil<Order>(
         VRZ3DGradientProductAccessor<Order, Direction>{
-            q, p, ix, iy, iz, sx, sy, sz, grad_ctx, solver
+            q, p, ix, iy, iz, sx, sy, sz, grad_ctx, solver.bounds()
         },
         solver.M,
         grad_ctx.coeff,
@@ -1030,7 +1046,7 @@ struct VrzGradAccessor3D {
     const float* __restrict__ vp;
     const float* __restrict__ z;
     int ix, iy, iz, b;
-    SolverContext solver;
+    GridBounds solver;          // not SolverContext: this is inlined per tap
     GradParam grad_ctx;
 
     __device__ __forceinline__ float operator()(int off) const
@@ -1099,15 +1115,15 @@ __global__ void calculate_grad_vrz3d_fused(
     float z1y = gradient<3, Order, Y>(inv_z_b, ix, iy, iz, grad_ctx);
     float z1z = gradient<3, Order, Z>(inv_z_b, ix, iy, iz, grad_ctx);
 
-    VrzGradAccessor3D<Order, X, false> cx{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
-    VrzGradAccessor3D<Order, Y, false> cy{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
-    VrzGradAccessor3D<Order, Z, false> cz{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
+    VrzGradAccessor3D<Order, X, false> cx{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver.bounds(), grad_ctx};
+    VrzGradAccessor3D<Order, Y, false> cy{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver.bounds(), grad_ctx};
+    VrzGradAccessor3D<Order, Z, false> cz{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver.bounds(), grad_ctx};
     float div_c = centered_gradient_stencil<Order>(cx, solver.M, grad_ctx.coeff, grad_ctx.dx)
                 + centered_gradient_stencil<Order>(cy, solver.M, grad_ctx.coeff, grad_ctx.dy)
                 + centered_gradient_stencil<Order>(cz, solver.M, grad_ctx.coeff, grad_ctx.dz);
-    VrzGradAccessor3D<Order, X, true> ex{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
-    VrzGradAccessor3D<Order, Y, true> ey{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
-    VrzGradAccessor3D<Order, Z, true> ez{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver, grad_ctx};
+    VrzGradAccessor3D<Order, X, true> ex{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver.bounds(), grad_ctx};
+    VrzGradAccessor3D<Order, Y, true> ey{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver.bounds(), grad_ctx};
+    VrzGradAccessor3D<Order, Z, true> ez{p_b, lambda_b, vp_b, z_b, ix, iy, iz, b, solver.bounds(), grad_ctx};
     float div_e = centered_gradient_stencil<Order>(ex, solver.M, grad_ctx.coeff, grad_ctx.dx)
                 + centered_gradient_stencil<Order>(ey, solver.M, grad_ctx.coeff, grad_ctx.dy)
                 + centered_gradient_stencil<Order>(ez, solver.M, grad_ctx.coeff, grad_ctx.dz);


### PR DESCRIPTION
Recovers 8.8 of the 13.4 points the DD work cost `AcousticVRZ3D`, by not
handing a per-tap functor state it never reads. Gradients unchanged.

## The problem

`VrzGradAccessor3D`, `VRZ3DGradientProductAccessor` and
`VRZ2DGradientProductAccessor` embed `SolverContext` **by value**, and
`calculate_grad_vrz3d_fused` builds six accessors.
`centered_gradient_stencil` then inlines `operator()` once per stencil tap, so
at order 4 that state is touched 24 times per thread — and each call also runs
the interior predicate off it.

`SolverContext` is **240 bytes**. It grew from 104 for good reasons (per-edge
free surface, DD cut faces, CPML aux slabs, the cached `phys_*`), and that is
fine for a *kernel parameter*: passed once, amortised over the kernel. It is
not fine for a functor inlined per tap. Those accessors read **twelve ints**.

This is why the DD commits (`73cb22d`, `9f34e5f`, `7850997`) cost this kernel
so much while the same predicate change was free for `Acoustic3D` — acoustic
has no 6×4 amplification structure.

## The change

`GridBounds` — `nx/ny/nz/B/M/x_end` plus the six `phys_*` bounds, 48 bytes —
and `SolverContext::bounds()` to produce it. Field names match `SolverContext`,
so **the accessor bodies are untouched**; what changes is three member
declarations, the leaf helpers they call (`vrz{2,3}d_q_gradp`,
`*_grad_product_interior`, each with a single caller), and six construction
sites. `vrz3d_interior` keeps its `SolverContext` form for the seven
kernel-level callers (once per thread, not per tap) and gains a `GridBounds`
overload for the accessors.

`SolverContext` itself, the DD semantics, the cut-aware predicates and the aux
slabs are not touched.

## Numbers — idle V100, 4 alternating rounds, every round cv <= 0.02

| | v0.1.0 | dev | this PR |
|---|---|---|---|
| AcousticVRZ3D | 2.5256 | 2.8646 (+13.4%) | **2.6427 (+4.6%)** — −7.7% vs dev |
| AcousticVRZ 2D | 0.2572 | 0.2512 (−2.3%) | 0.2512 (−2.3%) — unchanged |

Measured on ibex rather than the dev box: on a shared machine the slim rounds
came back cv = 0.026/0.112/0.039 while the baselines sat at 0.003, which is
what contention looks like. The V100 gains more than the Ada probe predicted
(5pp) because it has no uniform datapath — and V100 is what production runs on.

## Verification

**All three memory strategies**, not just boundary saving — `full`,
`boundary` and `ckpt` take different backward paths (kept wavefield / reverse
reconstruction / recompute) and this kernel is called on all of them:

- 10 of 12 (`{vrz 2D, vrz 3D, acoustic 2D, elastic 2D}` × 3) are bit-identical.
- The other two — `acoustic_2d::ckpt` and `vrz_3d::ckpt` — are **not
  bit-reproducible run to run on an unchanged tree**, so a bit criterion is
  unattainable there. Judged by distribution instead, five runs per side: the
  within-group spread (up to 6.9e-06) covers the between-group spread (up to
  6.3e-06). `acoustic_2d`'s three kernels also compile to byte-identical SASS
  across the two trees, confirming the change cannot reach it.
- Bit-identical across the 13 equation configurations of the existing probe
  (acoustic 2D ±FS incl. production Marmousi, 3D, VRZ 2D/3D, elastic 2D ±FS/3D,
  DAS-Mu 2D/3D, DASZhao 2D, VTI-1st 2D/3D, ElasticTTI-SG 2D).
- Every criterion is checked for attainability before use: a zero gradient
  makes a byte comparison pass regardless, so each case asserts a nonzero loss
  and gradient first.
- 19 test files pass, including `test_boundary_compact_kernel` and the full
  `test_dd_*` set.

## Note

This also closed a gap in #70: that PR's bit-exactness was only ever checked
under boundary saving. Re-checked here — `full` and `boundary` are bit-identical
before vs after #70, and the two `ckpt` configurations are same-distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
