### PR TITLE
fix(guard): topography= bypassed the anisotropic free-surface refusal

### DIFF
--- a/src/sweep/propagator/base.py
+++ b/src/sweep/propagator/base.py
@@ -160,16 +160,22 @@ class PropBase:
         # Anisotropic equations have no correct free-surface implementation:
         # the anisotropic stress-free condition is NOT the isotropic image
         # condition these solvers implement.  Fail loud on ANY free-surface
-        # request (bool, per-edge list, topography-implied) rather than
-        # silently produce wrong surface physics.
-        if any(self.fs_faces) and not getattr(equation, "supports_free_surface", True):
+        # request rather than silently produce wrong surface physics.  Checked
+        # twice: here for the explicit request (bool / per-edge list), and again
+        # after ``_resolve_topo_method`` -- ``topography=`` implies a free
+        # surface, and that is only known once the method has been resolved.
+        def _refuse_free_surface_if_anisotropic(requested, how):
+            if not requested or getattr(equation, "supports_free_surface", True):
+                return
             raise NotImplementedError(
-                f"{type(equation).__name__} does not support a free surface: the "
-                "anisotropic stress-free boundary condition couples through the "
-                "stiffness tensor and is not the isotropic image method this "
-                "solver implements. Use free_surface=False (absorbing top) or an "
-                "isotropic equation."
+                f"{type(equation).__name__} does not support a free surface "
+                f"({how}): the anisotropic stress-free boundary condition "
+                "couples through the stiffness tensor and is not the isotropic "
+                "image method this solver implements. Use free_surface=False "
+                "(absorbing top) or an isotropic equation."
             )
+
+        _refuse_free_surface_if_anisotropic(any(self.fs_faces), "free_surface=")
         self._abcn_arg = abcn
         self.pad = normalize_pad(abcn, self.fs_faces, self.ndim)
         # ``self.abcn`` stays a representative uniform PML width for the legacy
@@ -219,6 +225,9 @@ class PropBase:
                 free_surface=any(self.fs_faces),
             )
         )
+        # ``topography=`` implies a free surface even with free_surface=False --
+        # image method or APM alike, both of them isotropic constructions.
+        _refuse_free_surface_if_anisotropic(self.free_surface, "implied by topography=")
         # ``_resolve_topo_method`` can turn the TOP free surface on implicitly
         # (topography= implies an image-method free surface even with
         # free_surface=False).  Fold that back into the canonical fs_faces/pad so

--- a/test/test_aniso_free_surface_guard.py
+++ b/test/test_aniso_free_surface_guard.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA requ
 DEV = "cuda"
 
 
-def _build(cls, free_surface, ndim=2):
+def _build(cls, free_surface, ndim=2, **extra):
     from sweep.propagator.torch import PropTorch
     from sweep.propagator.options import EagerOptions
 
@@ -28,7 +28,7 @@ def _build(cls, free_surface, ndim=2):
     shape = (48, 56) if ndim == 2 else (24, 20, 24)
     return PropTorch(eq, impl="eager", eager_options=EagerOptions(use_compile=False),
                      use_ckpt=False, dev=DEV, shape=shape, abcn=16, dh=10.0, dt=8e-4,
-                     free_surface=free_surface, nt=100, B=1)
+                     free_surface=free_surface, nt=100, B=1, **extra)
 
 
 def _cases():
@@ -53,6 +53,20 @@ def test_per_edge_top_also_raises():
         _build(ElasticTTISG, ["top"])
 
 
+@pytest.mark.parametrize("cls,ndim", [c for c in _cases() if c[1] == 2],
+                         ids=lambda c: getattr(c, "__name__", c))
+def test_topography_also_raises(cls, ndim):
+    """``topography=`` implies a free surface even with free_surface=False, so
+    it has to hit the same guard.  It used to slip through: the guard ran on
+    fs_faces before _resolve_topo_method folded the topography-implied top face
+    in, and the isotropic image mirror then ran on the anisotropic solver --
+    measured 29% wavefield difference against the no-topography run."""
+    import numpy as np
+
+    with pytest.raises(NotImplementedError, match="anisotropic"):
+        _build(cls, False, ndim, topography=np.zeros(56, dtype=np.int64))
+
+
 @pytest.mark.parametrize("cls,ndim", _cases(), ids=lambda c: getattr(c, "__name__", c))
 def test_no_free_surface_still_constructs(cls, ndim):
     _build(cls, False, ndim)
@@ -61,6 +75,9 @@ def test_no_free_surface_still_constructs(cls, ndim):
 def test_isotropic_free_surface_unaffected():
     from sweep.equations import Acoustic, Elastic
 
+    import numpy as np
+
     _build(Elastic, True)
     _build(Elastic, ["top", "left"])
     _build(Acoustic, True)
+    _build(Elastic, False, topography=np.zeros(56, dtype=np.int64))


### PR DESCRIPTION
`topography=` implies a free surface even when `free_surface=False`, and it was slipping
past the anisotropic free-surface refusal.

The guard ran on `self.fs_faces` — the *explicit* request — before
`_resolve_topo_method` folds the topography-implied top face in. So
`PropTorch(ElasticTTISG(...), free_surface=False, topography=...)` constructed happily
and then ran the **isotropic image mirror** on an anisotropic solver, where the
stress-free condition couples through the stiffness tensor and the image condition does
not hold. Measured 29% wavefield difference against the same run without topography, so
this was live, not theoretical.

Fix: the refusal is now a closure called twice — once on the explicit request, once
after `_resolve_topo_method` resolves the implied one — and the message says which of
the two tripped. Isotropic equations are unaffected, asserted in the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
