### PR TITLE
fix(cuda): widen record and source time-series indices to 64-bit

### DIFF
--- a/src/sweep/csrc/cuda/common/common.cu
+++ b/src/sweep/csrc/cuda/common/common.cu
@@ -24,9 +24,9 @@ __global__ void add_source(
     if (ix < 0 || ix >= solver.nx || iz < 0 || iz >= solver.nz)
         return;
 
-    int spatial_size = solver.nx * solver.nz;
-    int u_idx = b * spatial_size + iz * solver.nx + ix;
-    int src_idx = (b * nsrc + s) * solver.nt + it;
+    long long spatial_size = (long long)solver.nx * solver.nz;
+    long long u_idx = (long long)b * spatial_size + (long long)iz * solver.nx + ix;
+    long long src_idx = ((long long)b * nsrc + s) * solver.nt + it;
 
     atomicAdd(&u[u_idx], source[src_idx]);
 
@@ -60,10 +60,10 @@ __global__ void add_body_force_rho_grad_correction(
     if (loc_dim == 3 && (iy < 0 || iy >= solver.ny))
         return;
 
-    int spatial_size = solver.nx * solver.nz * (loc_dim == 3 ? solver.ny : 1);
+    long long spatial_size = (long long)solver.nx * solver.nz * (loc_dim == 3 ? solver.ny : 1);
     int row = (loc_dim == 3) ? (iz * solver.ny + iy) : iz;
-    int u_idx = b * spatial_size + row * solver.nx + ix;
-    int src_idx = (b * nsrc + s) * solver.nt + amp_it;
+    long long u_idx = (long long)b * spatial_size + (long long)row * solver.nx + ix;
+    long long src_idx = ((long long)b * nsrc + s) * solver.nt + amp_it;
 
     atomicAdd(&grad_rho[u_idx],
               adj_field[u_idx] * source[src_idx] / rho[u_idx]);
@@ -102,10 +102,10 @@ __global__ void sub_receiver_rho_grad_correction(
     if (loc_dim == 3 && (iy < halo || iy >= solver.ny - halo))
         return;
 
-    int spatial_size = solver.nx * solver.nz * (loc_dim == 3 ? solver.ny : 1);
+    long long spatial_size = (long long)solver.nx * solver.nz * (loc_dim == 3 ? solver.ny : 1);
     int row = (loc_dim == 3) ? (iz * solver.ny + iy) : iz;
-    int u_idx = b * spatial_size + row * solver.nx + ix;
-    int src_idx = (b * nrec + s) * solver.nt + it;
+    long long u_idx = (long long)b * spatial_size + (long long)row * solver.nx + ix;
+    long long src_idx = ((long long)b * nrec + s) * solver.nt + it;
 
     atomicAdd(&grad_rho[u_idx],
               -adjoint_source[src_idx] * (fv_now[u_idx] - fv_next[u_idx]) / rho[u_idx]);
@@ -132,9 +132,9 @@ __global__ void record_kernel(
     if (ix < 0 || ix >= solver.nx || iz < 0 || iz >= solver.nz)
         return;
 
-    int spatial_size = solver.nx * solver.nz;
-    int u_idx = b * spatial_size + iz * solver.nx + ix;
-    int rec_idx = (b * nrec + r) * solver.nt + it;
+    long long spatial_size = (long long)solver.nx * solver.nz;
+    long long u_idx = (long long)b * spatial_size + (long long)iz * solver.nx + ix;
+    long long rec_idx = ((long long)b * nrec + r) * solver.nt + it;
 
     record[rec_idx] = u[u_idx];
 }
@@ -163,14 +163,14 @@ __global__ void add_source_3d(
         iz < 0 || iz >= solver.nz)
         return;
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
 
-    int u_idx = b * spatial_size
-              + iz * solver.ny * solver.nx
+    long long u_idx = (long long)b * spatial_size
+              + (long long)iz * solver.ny * solver.nx
               + iy * solver.nx
               + ix;
 
-    int src_idx = (b * nsrc + s) * solver.nt + it;
+    long long src_idx = ((long long)b * nsrc + s) * solver.nt + it;
 
     atomicAdd(&u[u_idx], source[src_idx]);
 }
@@ -200,14 +200,14 @@ __global__ void record_kernel_3d(
         iz < 0 || iz >= solver.nz)
         return;
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
 
-    int u_idx = b * spatial_size
-              + iz * solver.ny * solver.nx
+    long long u_idx = (long long)b * spatial_size
+              + (long long)iz * solver.ny * solver.nx
               + iy * solver.nx
               + ix;
 
-    int rec_idx = (b * nrec + r) * solver.nt + it;
+    long long rec_idx = ((long long)b * nrec + r) * solver.nt + it;
 
     record[rec_idx] = u[u_idx];
 }

--- a/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic2d/kernels.cu
@@ -15,7 +15,7 @@ __global__ void calculate_grad(
     if (ix >= nx || iz >= nz)
         return;
 
-    int spatial_size = nx * nz;
+    long long spatial_size = (long long)nx * nz;
     int idx = iz * nx + ix;
 
     const float* u_forward_b  = u_forward  + b * spatial_size;
@@ -47,7 +47,7 @@ __global__ void calculate_grad_utt(
     if (ix >= nx || iz >= nz)
         return;
 
-    int spatial_size = nx * nz;
+    long long spatial_size = (long long)nx * nz;
     int idx = iz * nx + ix;
 
     const float* u_next_b  = u_forward_next  + b * spatial_size;
@@ -84,7 +84,7 @@ __global__ void accumulate_rtm_image_2d(
     if (ix >= nx || iz >= nz)
         return;
 
-    int spatial_size = nx * nz;
+    long long spatial_size = (long long)nx * nz;
     int idx = iz * nx + ix;
 
     const float* u_forward_b = u_forward + b * spatial_size;
@@ -162,9 +162,9 @@ __global__ void accumulate_source_grad_2d(
         return;
     }
 
-    int spatial_size = solver.nx * solver.nz;
-    int u_idx = b * spatial_size + iz * solver.nx + ix;
-    int grad_idx = (b * nsrc + s) * solver.nt + it;
+    long long spatial_size = (long long)solver.nx * solver.nz;
+    long long u_idx = (long long)b * spatial_size + (long long)iz * solver.nx + ix;
+    long long grad_idx = ((long long)b * nsrc + s) * solver.nt + it;
 
     grad_source[grad_idx] += u_backward[u_idx];
 }

--- a/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/kernels.cu
@@ -20,7 +20,7 @@ __global__ void calculate_grad_3d(
 
     int stride_y = nx;
     int stride_z = nx * ny;
-    int spatial_size = nx * ny * nz;
+    long long spatial_size = (long long)nx * ny * nz;
 
     int idx = iz * stride_z + iy * stride_y + ix;
 
@@ -57,7 +57,7 @@ __global__ void calculate_grad_utt_3d(
 
     int stride_y = nx;
     int stride_z = nx * ny;
-    int spatial_size = nx * ny * nz;
+    long long spatial_size = (long long)nx * ny * nz;
 
     int idx = iz * stride_z + iy * stride_y + ix;
 
@@ -100,7 +100,7 @@ __global__ void accumulate_rtm_image_3d(
 
     int stride_y = nx;
     int stride_z = nx * ny;
-    int spatial_size = nx * ny * nz;
+    long long spatial_size = (long long)nx * ny * nz;
 
     int idx = iz * stride_z + iy * stride_y + ix;
 
@@ -186,9 +186,9 @@ __global__ void accumulate_source_grad_3d(
         return;
     }
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
-    int u_idx = b * spatial_size + iz * (solver.nx * solver.ny) + iy * solver.nx + ix;
-    int grad_idx = (b * nsrc + s) * solver.nt + it;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
+    long long u_idx = (long long)b * spatial_size + iz * (solver.nx * solver.ny) + iy * solver.nx + ix;
+    long long grad_idx = ((long long)b * nsrc + s) * solver.nt + it;
 
     // "+=" for 2D parity and for Python-bound grads_out accumulators:
     // each (b, s, it) is written exactly once per backward onto zeros, so

--- a/src/sweep/csrc/cuda/equations/acoustic_vti_1st_2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vti_1st_2d/kernels.cuh
@@ -109,7 +109,7 @@ __global__ void velocity_kernel(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
 
     auto f = wf.offset(b, spatial_size);
@@ -186,7 +186,7 @@ __global__ void stress_kernel(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
 
     auto f = wf.offset(b, spatial_size);
@@ -262,7 +262,7 @@ __global__ void velocity_kernel_nopml(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
 
     auto f = wf.offset(b, spatial_size);
@@ -300,7 +300,7 @@ __global__ void stress_kernel_nopml(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
 
     auto f = wf.offset(b, spatial_size);
@@ -423,9 +423,9 @@ __global__ void adjoint_premultiply_stress_kernel(
 
     // No halo guard: the stencil in kernel A reads these cells, so they must be
     // filled everywhere, not just where kernel A writes.
-    int spatial_size = solver.nx * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
-    int u_idx = b * spatial_size + idx;
+    long long u_idx = (long long)b * spatial_size + idx;
 
     auto a = adj.offset(b, spatial_size);
     const float lSH = a.sH[idx];
@@ -452,9 +452,9 @@ __global__ void adjoint_premultiply_vel_kernel(
     int b  = blockIdx.z;
     if (ix >= solver.nx || iz >= solver.nz) return;
 
-    int spatial_size = solver.nx * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
-    int u_idx = b * spatial_size + idx;
+    long long u_idx = (long long)b * spatial_size + idx;
 
     auto a = adj.offset(b, spatial_size);
     qx[u_idx] = inv_rho[u_idx] * a.vx[idx];
@@ -488,7 +488,7 @@ __global__ void adjoint_stress_to_vel_kernel(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
 
     auto a = adj.offset(b, spatial_size);
@@ -529,7 +529,7 @@ __global__ void adjoint_vel_to_stress_kernel(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
 
     auto a = adj.offset(b, spatial_size);
@@ -601,7 +601,7 @@ __global__ void calculate_grad_kernel(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
 
     const float* fvx_b = fvx_now  + b * spatial_size;

--- a/src/sweep/csrc/cuda/equations/acoustic_vti_1st_3d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/acoustic_vti_1st_3d/kernels.cuh
@@ -152,7 +152,7 @@ __global__ void velocity_kernel_3d(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
     int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
 
     auto f = wf.offset(b, spatial_size);
@@ -243,7 +243,7 @@ __global__ void stress_kernel_3d(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
     int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
 
     auto f = wf.offset(b, spatial_size);
@@ -333,7 +333,7 @@ __global__ void velocity_kernel_3d_nopml(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
     int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
 
     auto f = wf.offset(b, spatial_size);
@@ -377,7 +377,7 @@ __global__ void stress_kernel_3d_nopml(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
     int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
 
     auto f = wf.offset(b, spatial_size);
@@ -495,9 +495,9 @@ __global__ void adjoint_premultiply_stress_kernel_3d(
     int iz = iz_global % solver.nz;
 
     // No halo guard: kernel A's stencil reads these cells.
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
     int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
-    int u_idx = b * spatial_size + idx;
+    long long u_idx = (long long)b * spatial_size + idx;
 
     auto a = adj.offset(b, spatial_size);
     const float lSH = a.sH[idx];
@@ -527,9 +527,9 @@ __global__ void adjoint_premultiply_vel_kernel_3d(
     int b  = iz_global / solver.nz;
     int iz = iz_global % solver.nz;
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
     int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
-    int u_idx = b * spatial_size + idx;
+    long long u_idx = (long long)b * spatial_size + idx;
 
     auto a = adj.offset(b, spatial_size);
     const float ir = inv_rho[u_idx];
@@ -567,7 +567,7 @@ __global__ void adjoint_stress_to_vel_kernel_3d(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
     int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
 
     auto a = adj.offset(b, spatial_size);
@@ -616,7 +616,7 @@ __global__ void adjoint_vel_to_stress_kernel_3d(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
     int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
 
     auto a = adj.offset(b, spatial_size);
@@ -683,7 +683,7 @@ __global__ void calculate_grad_kernel_3d(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.ny * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.ny * solver.nz;
     int idx = iz * solver.nx * solver.ny + iy * solver.nx + ix;
 
     const float* fvx_b = fvx_now  + b * spatial_size;

--- a/src/sweep/csrc/cuda/equations/elastic2d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/elastic2d/backward.cu
@@ -50,10 +50,10 @@ static __global__ void sub_receiver_rho_grad_correction_apm_2d(
         iz < halo || iz >= solver.nz - halo)
         return;
 
-    int spatial_size = solver.nx * solver.nz;
+    long long spatial_size = (long long)solver.nx * solver.nz;
     int idx = iz * solver.nx + ix;
-    int u_idx = b * spatial_size + idx;
-    int src_idx = (b * nrec + s) * solver.nt + it;
+    long long u_idx = (long long)b * spatial_size + idx;
+    long long src_idx = ((long long)b * nrec + s) * solver.nt + it;
 
     float drho_x_drho, drho_z_drho;
     apm_rho_jacobian(category[idx], &drho_x_drho, &drho_z_drho);

--- a/src/sweep/csrc/cuda/equations/elastic_tti_2nd2d/kernels.cuh
+++ b/src/sweep/csrc/cuda/equations/elastic_tti_2nd2d/kernels.cuh
@@ -677,7 +677,7 @@ static __global__ void tti2nd_rho_grad_source_correction(
     if (ix < 0 || ix >= solver.nx || iz < 0 || iz >= solver.nz) return;
 
     const int idx = b * spatial_size + iz * solver.nx + ix;
-    const float s = source[(b * nsrc + isrc) * solver.nt + it];
+    const float s = source[((long long)b * nsrc + isrc) * solver.nt + it];
     atomicAdd(&grad_rho[idx], adj_field[idx] * s / rho[idx]);
 }
 


### PR DESCRIPTION
`(b * n + i) * solver.nt + it` was computed in int32. With a full-survey
receiver set (106,615 cells) and the long window a 615-bin frequency-selection
comb needs (nt = 47,397), the product reaches 5.05e9 — past int32 — wraps
negative, and the kernel writes outside the record buffer:

```
sweep/propagator/_c.py:51 in _cuda_record_to_canonical
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

### Why it stayed hidden

Domain decomposition splits the receivers: each rank only owns its tile's
cells, which kept the per-rank product under the limit. The same seven-band
615-bin cascade that runs fine on DD 2x2 overflows on a single GPU.

The trigger is `B * nrec * nt >= 2^31`, with `nrec` counted **per rank**:

| configuration | B x nrec x nt | / 2^31 | |
|---|---|---|---|
| 48-bin comb, single GPU | 5.6e8 | 0.26 | fine |
| 615-bin comb, single GPU | 5.05e9 | 2.35 | **overflows** |
| 615-bin comb, DD 2x2 | 1.26e9 | 0.59 | fine |

So it also fires on: fewer DD tiles for a configuration that used to run, a
larger shot batch (`B` enters the product directly), or a finer receiver
aggregation grid.

Worth noting the failure is not always a crash. A negative index lands before
the buffer; if that address belongs to another live allocation, nothing faults
and the write silently corrupts it. Getting `illegal memory access` was luck.

Same class as the boundary-saver overflow fixed in
`bug/boundary-kernel-int-idx-overflow`, in the record and source kernels
instead.

### The change

Multiplications are promoted before they can wrap, not cast afterwards.
`spatial_size` / `u_idx` are widened alongside in the same kernel family so the
index width does not vary within it. Every `(...) * nt + it` site in `csrc` is
covered — all 18 equation directories were audited; the ones not touched here
record through the shared `common.cu` kernels.

### Verification

* Bit-exact where nothing overflowed: record, gradient and loss hashes identical
  to `dev` on a 3-D acoustic forward+backward (`REC e61049e6…`,
  `GRAD 2ee3b36e…`, `LOSS 2.282984642079e-04`). The criterion was shown
  attainable first — the same tree twice gives the same hashes — so the
  cross-tree comparison means something.
* Full suite on both trees, **run sequentially**: 712 passed / 1 failed on each,
  the same pre-existing `test_datasets_registry` failure. Running the two
  suites concurrently on one GPU produces three spurious failures, since
  `test_boundary_int_idx_overflow` alone needs ~23 GiB and two of the
  `boundary_saving_reduces_memory` cases assert on peak memory.

### Not in this PR

`int spatial_size` remains in 152 places. That is a different overflow with a
different trigger — `b * spatial_size` reaches 1.93x int32 at B=16 and is
already at 90% of the limit at B=8 on the finest grid in use. It deserves its
own branch and its own A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
