### PR TITLE
fix(dd): staged boundary prefetched before the buffer; inherit the staging knobs

### DIFF
--- a/src/sweep/csrc/cuda/common/boundary/runtime.cuh
+++ b/src/sweep/csrc/cuda/common/boundary/runtime.cuh
@@ -796,6 +796,18 @@ public:
         int chunk_len = buf_idx0 + 1;
         backward_nt_ = nt;
         backward_active_ = true;
+        // Nothing precedes step 0.  The monolithic backward primes the ring
+        // once with it_hi == nt, so chunk_start lands at nt-2 and this never
+        // trips.  The DD backward is driven one step per call, so the last
+        // call arrives with it_hi == 1: it0 is 0, and chunk_start goes to -1 --
+        // a staged copy from one chunk BEFORE the buffer, which segfaults the
+        // host thread inside cudaMemcpyAsync.  The step it primes for is
+        // already in the ring by then; there is nothing left to fetch.
+        if (chunk_start < 0) {
+            profile_compute_start_ = Clock::now();
+            profile_have_compute_start_ = true;
+            return;
+        }
         prefetch_backward_chunk(chunk_start, chunk_len, backward_slot_for_chunk(chunk_start));
         profile_compute_start_ = Clock::now();
     }

--- a/src/sweep/csrc/cuda/common/boundary/saver.cuh
+++ b/src/sweep/csrc/cuda/common/boundary/saver.cuh
@@ -1,5 +1,6 @@
 #pragma once
 #include <cuda_runtime.h>
+#include <cstdlib>
 #include <exception>
 #include <mutex>
 #include <stdexcept>
@@ -28,8 +29,43 @@ static inline BoundaryDtype boundary_dtype_from_tensor(const torch::Tensor& t) {
 // Byte pointer into a boundary tensor at element offset `off_elems`, honoring
 // the tensor's dtype width.  Used so the gpu<->cpu<->disk byte copies work for
 // fp16/bf16 staging/storage, not just fp32.
+// A DD tile drops its cut faces to numel 0 (Layout(cut_mask=...) on the Python
+// side).  Faces come in pairs that share one stride, so the byte count is taken
+// from whichever face of the pair is live and stays non-zero -- the copy goes
+// out anyway carrying the empty face's null data_ptr(), and segfaults the host
+// thread inside cudaMemcpyAsync.  Report an empty face as null here; the two
+// copy primitives below skip it.  Non-DD never sees this: every face is backed
+// there, so nothing returns null.
 static inline char* boundary_byte_ptr(const torch::Tensor& t, int64_t off_elems) {
+    if (!t.defined() || t.numel() == 0) return nullptr;
     return static_cast<char*>(t.data_ptr()) + off_elems * t.element_size();
+}
+
+// Staging copy that tolerates a cut-away face on either end.
+static inline cudaError_t boundary_memcpy_async(
+    void* dst, const void* src, size_t bytes, cudaMemcpyKind kind,
+    cudaStream_t stream) {
+    if (dst == nullptr || src == nullptr) return cudaSuccess;
+    return cudaMemcpyAsync(dst, src, bytes, kind, stream);
+}
+
+// Diagnostic (SWEEP_BOUNDARY_BOUNDS=1): turn the segfault inside
+// cudaMemcpyAsync into a named, numbered failure.  A staged copy that walks
+// off one of its two buffers is invisible until the driver dereferences it,
+// and the stack then only says "cudaMemcpyAsync".
+static inline void boundary_bounds_check(
+    const char* what, const torch::Tensor& t, int64_t off_elems, size_t bytes) {
+    static const bool on = std::getenv("SWEEP_BOUNDARY_BOUNDS") != nullptr;
+    if (!on || !t.defined() || t.numel() == 0) return;
+    const int64_t es = t.element_size();
+    const int64_t have = t.numel() * es;
+    const int64_t want = off_elems * es + (int64_t)bytes;
+    TORCH_CHECK(off_elems >= 0 && want <= have,
+                "boundary staging out of range on ", what,
+                ": offset ", off_elems, " elems (", off_elems * es,
+                " B) + ", bytes, " B = ", want,
+                " B, buffer holds ", t.numel(), " elems (", have,
+                " B), sizes ", t.sizes(), " strides ", t.strides());
 }
 
 struct EffectiveBoundarySaver {
@@ -691,6 +727,7 @@ struct EffectiveBoundarySaver {
         cudaStream_t stream
     ) const
     {
+        if (dst == nullptr || src == nullptr) return;   // DD cut face
         if (nvar == 1) {
             cudaMemcpyAsync(dst, src, bytes, kind, stream);
         } else {
@@ -765,9 +802,9 @@ struct EffectiveBoundarySaver {
             char* cpu_p = boundary_byte_ptr(cpu_t, (int64_t)cpu_start * nvar * cpu_block);
             char* gpu_p = boundary_byte_ptr(gpu_t, (int64_t)gpu_offset);
             if (d2h)
-                cudaMemcpyAsync(cpu_p, gpu_p, elems * es, kind, stream);
+                boundary_memcpy_async(cpu_p, gpu_p, elems * es, kind, stream);
             else
-                cudaMemcpyAsync(gpu_p, cpu_p, elems * es, kind, stream);
+                boundary_memcpy_async(gpu_p, cpu_p, elems * es, kind, stream);
         };
         face(top_scale_t, top_scale_gpu, top_block, top_gpu_offset, top_elems);
         face(bottom_scale_t, bottom_scale_gpu, top_block, top_gpu_offset, top_elems);
@@ -860,7 +897,7 @@ struct EffectiveBoundarySaver {
 
         TORCH_CHECK(left_t.dtype() == torch::kFloat32 || left_t.dtype() == torch::kHalf || left_t.dtype() == torch::kBFloat16 || left_t.dtype() == torch::kUInt8, "Boundary storage must be float32 / float16 / bfloat16 / uint8.");
         size_t es = left_t.element_size();
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(left_t, (int64_t)start * nvar * left_block),
             boundary_byte_ptr(left_gpu, (int64_t)left_gpu_offset),
             left_elems * es,
@@ -868,7 +905,7 @@ struct EffectiveBoundarySaver {
             stream
         );
 
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(right_t, (int64_t)start * nvar * left_block),
             boundary_byte_ptr(right_gpu, (int64_t)left_gpu_offset),
             left_elems * es,
@@ -876,7 +913,7 @@ struct EffectiveBoundarySaver {
             stream
         );
 
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(front_t, (int64_t)start * nvar * front_block),
             boundary_byte_ptr(front_gpu, (int64_t)front_gpu_offset),
             front_elems * es,
@@ -884,7 +921,7 @@ struct EffectiveBoundarySaver {
             stream
         );
 
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(back_t, (int64_t)start * nvar * front_block),
             boundary_byte_ptr(back_gpu, (int64_t)front_gpu_offset),
             front_elems * es,
@@ -892,7 +929,7 @@ struct EffectiveBoundarySaver {
             stream
         );
 
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(top_t, (int64_t)start * nvar * bottom_block),
             boundary_byte_ptr(top_gpu, (int64_t)bottom_gpu_offset),
             bottom_elems * es,
@@ -900,7 +937,7 @@ struct EffectiveBoundarySaver {
             stream
         );
 
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(bottom_t, (int64_t)start * nvar * bottom_block),
             boundary_byte_ptr(bottom_gpu, (int64_t)bottom_gpu_offset),
             bottom_elems * es,
@@ -1057,42 +1094,42 @@ struct EffectiveBoundarySaver {
         size_t front_gpu_offset = static_cast<size_t>(gpu_start) * nvar * front_gpu_block;
         size_t left_gpu_offset = static_cast<size_t>(gpu_start) * nvar * left_gpu_block;
 
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(top_t, (int64_t)top_stage_offset),
             boundary_byte_ptr(top_gpu, (int64_t)top_gpu_offset),
             top_elems * es,
             cudaMemcpyDeviceToHost,
             stream
         );
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(bottom_t, (int64_t)top_stage_offset),
             boundary_byte_ptr(bottom_gpu, (int64_t)top_gpu_offset),
             top_elems * es,
             cudaMemcpyDeviceToHost,
             stream
         );
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(front_t, (int64_t)front_stage_offset),
             boundary_byte_ptr(front_gpu, (int64_t)front_gpu_offset),
             front_elems * es,
             cudaMemcpyDeviceToHost,
             stream
         );
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(back_t, (int64_t)front_stage_offset),
             boundary_byte_ptr(back_gpu, (int64_t)front_gpu_offset),
             front_elems * es,
             cudaMemcpyDeviceToHost,
             stream
         );
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(left_t, (int64_t)left_stage_offset),
             boundary_byte_ptr(left_gpu, (int64_t)left_gpu_offset),
             left_elems * es,
             cudaMemcpyDeviceToHost,
             stream
         );
-        cudaMemcpyAsync(
+        boundary_memcpy_async(
             boundary_byte_ptr(right_t, (int64_t)left_stage_offset),
             boundary_byte_ptr(right_gpu, (int64_t)left_gpu_offset),
             left_elems * es,
@@ -1362,6 +1399,8 @@ struct EffectiveBoundarySaver {
             size_t left_gpu_time_block = left_gpu.stride(1);
 
             TORCH_CHECK(top_t.dtype() == torch::kFloat32 || top_t.dtype() == torch::kHalf || top_t.dtype() == torch::kBFloat16 || top_t.dtype() == torch::kUInt8, "Boundary storage must be float32 / float16 / bfloat16 / uint8.");
+            boundary_bounds_check("top_t", top_t, (int64_t)start * top_time_block, top_bytes);
+            boundary_bounds_check("top_gpu", top_gpu, (int64_t)gpu_start * top_gpu_time_block, top_bytes);
             copy_2d_chunk_async(
                 boundary_byte_ptr(top_gpu, (int64_t)gpu_start * top_gpu_time_block),
                 top_gpu_var_block,
@@ -1372,6 +1411,8 @@ struct EffectiveBoundarySaver {
                 cudaMemcpyHostToDevice,
                 stream
             );
+            boundary_bounds_check("bottom_t", bottom_t, (int64_t)start * top_time_block, top_bytes);
+            boundary_bounds_check("bottom_gpu", bottom_gpu, (int64_t)gpu_start * top_gpu_time_block, top_bytes);
             copy_2d_chunk_async(
                 boundary_byte_ptr(bottom_gpu, (int64_t)gpu_start * top_gpu_time_block),
                 top_gpu_var_block,
@@ -1382,6 +1423,8 @@ struct EffectiveBoundarySaver {
                 cudaMemcpyHostToDevice,
                 stream
             );
+            boundary_bounds_check("left_t", left_t, (int64_t)start * left_time_block, left_bytes);
+            boundary_bounds_check("left_gpu", left_gpu, (int64_t)gpu_start * left_gpu_time_block, left_bytes);
             copy_2d_chunk_async(
                 boundary_byte_ptr(left_gpu, (int64_t)gpu_start * left_gpu_time_block),
                 left_gpu_var_block,
@@ -1392,6 +1435,8 @@ struct EffectiveBoundarySaver {
                 cudaMemcpyHostToDevice,
                 stream
             );
+            boundary_bounds_check("right_t", right_t, (int64_t)start * left_time_block, left_bytes);
+            boundary_bounds_check("right_gpu", right_gpu, (int64_t)gpu_start * left_gpu_time_block, left_bytes);
             copy_2d_chunk_async(
                 boundary_byte_ptr(right_gpu, (int64_t)gpu_start * left_gpu_time_block),
                 left_gpu_var_block,
@@ -1421,7 +1466,9 @@ struct EffectiveBoundarySaver {
 
         TORCH_CHECK(top_t.dtype() == torch::kFloat32 || top_t.dtype() == torch::kHalf || top_t.dtype() == torch::kBFloat16 || top_t.dtype() == torch::kUInt8, "Boundary storage must be float32 / float16 / bfloat16 / uint8.");
         size_t es = top_t.element_size();
-        cudaMemcpyAsync(
+        boundary_bounds_check("top_t", top_t, (int64_t)(start * nvar * top_block), top_elems * es);
+        boundary_bounds_check("top_gpu", top_gpu, (int64_t)(top_gpu_offset), top_elems * es);
+        boundary_memcpy_async(
             boundary_byte_ptr(top_gpu, (int64_t)top_gpu_offset),
             boundary_byte_ptr(top_t, (int64_t)start * nvar * top_block),
             top_elems * es,
@@ -1429,7 +1476,9 @@ struct EffectiveBoundarySaver {
             stream
         );
 
-        cudaMemcpyAsync(
+        boundary_bounds_check("bottom_t", bottom_t, (int64_t)(start * nvar * top_block), top_elems * es);
+        boundary_bounds_check("bottom_gpu", bottom_gpu, (int64_t)(top_gpu_offset), top_elems * es);
+        boundary_memcpy_async(
             boundary_byte_ptr(bottom_gpu, (int64_t)top_gpu_offset),
             boundary_byte_ptr(bottom_t, (int64_t)start * nvar * top_block),
             top_elems * es,
@@ -1437,7 +1486,9 @@ struct EffectiveBoundarySaver {
             stream
         );
 
-        cudaMemcpyAsync(
+        boundary_bounds_check("front_t", front_t, (int64_t)(start * nvar * front_block), front_elems * es);
+        boundary_bounds_check("front_gpu", front_gpu, (int64_t)(front_gpu_offset), front_elems * es);
+        boundary_memcpy_async(
             boundary_byte_ptr(front_gpu, (int64_t)front_gpu_offset),
             boundary_byte_ptr(front_t, (int64_t)start * nvar * front_block),
             front_elems * es,
@@ -1445,7 +1496,9 @@ struct EffectiveBoundarySaver {
             stream
         );
 
-        cudaMemcpyAsync(
+        boundary_bounds_check("back_t", back_t, (int64_t)(start * nvar * front_block), front_elems * es);
+        boundary_bounds_check("back_gpu", back_gpu, (int64_t)(front_gpu_offset), front_elems * es);
+        boundary_memcpy_async(
             boundary_byte_ptr(back_gpu, (int64_t)front_gpu_offset),
             boundary_byte_ptr(back_t, (int64_t)start * nvar * front_block),
             front_elems * es,
@@ -1453,7 +1506,9 @@ struct EffectiveBoundarySaver {
             stream
         );
 
-        cudaMemcpyAsync(
+        boundary_bounds_check("left_t", left_t, (int64_t)(start * nvar * left_block), left_elems * es);
+        boundary_bounds_check("left_gpu", left_gpu, (int64_t)(left_gpu_offset), left_elems * es);
+        boundary_memcpy_async(
             boundary_byte_ptr(left_gpu, (int64_t)left_gpu_offset),
             boundary_byte_ptr(left_t, (int64_t)start * nvar * left_block),
             left_elems * es,
@@ -1461,7 +1516,9 @@ struct EffectiveBoundarySaver {
             stream
         );
 
-        cudaMemcpyAsync(
+        boundary_bounds_check("right_t", right_t, (int64_t)(start * nvar * left_block), left_elems * es);
+        boundary_bounds_check("right_gpu", right_gpu, (int64_t)(left_gpu_offset), left_elems * es);
+        boundary_memcpy_async(
             boundary_byte_ptr(right_gpu, (int64_t)left_gpu_offset),
             boundary_byte_ptr(right_t, (int64_t)start * nvar * left_block),
             left_elems * es,

--- a/src/sweep/parallel/dd_propagator.py
+++ b/src/sweep/parallel/dd_propagator.py
@@ -249,6 +249,16 @@ class ModelParallel:
         # prop's config, which is what keeps the truncated reverse loop's stop
         # step globally consistent across ranks (see _run_adjoint).
         self._btail = int(_bcfg.get("tail_steps") or 0)
+        # Staging batch/overlap knobs, inherited the same way.  These used to be
+        # pinned at transfer_interval=1 with no ring, which turns storage='cpu'
+        # into one un-overlapped PCIe round trip PER TIME STEP: measured ~15x
+        # slower than boundary-in-VRAM on the 2-16 Hz band (29,475 steps), against
+        # +22% for the same staging on a single tile with interval=32/ring=4.
+        # The defaults below reproduce the old behaviour when the wrapped prop
+        # says nothing.
+        self._bti = int(_bcfg.get("transfer_interval") or 1)
+        self._bring = int(_bcfg.get("ring_buffers") or 1)
+        self._bpinned = bool(_bcfg.get("pinned_memory") or False)
 
         self.topo = model_parallel
         self.global_shape = tuple(int(s) for s in global_shape)
@@ -331,7 +341,11 @@ class ModelParallel:
                 # last tail_steps steps (None = full length); the C++ side
                 # indexes it in shifted saved-step coordinates either way.
                 "tail_steps": self._btail or None,
-                "transfer_interval": 1, "pinned_memory": False},
+                # batching + ring depth decide whether the staged copies can
+                # overlap compute at all; 1/1 serialises them per step.
+                "transfer_interval": self._bti,
+                "ring_buffers": self._bring,
+                "pinned_memory": self._bpinned},
             model_parallel=self.topo,
         )
 

--- a/test/test_dd_backward_two_tile.py
+++ b/test/test_dd_backward_two_tile.py
@@ -54,6 +54,7 @@ cut-placement guard), unlike the abcn=30 canonical suite default.
 from __future__ import annotations
 
 from pathlib import Path
+import os
 import sys
 
 import numpy as np
@@ -64,6 +65,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
+
+# The staged-copy bounds check is read once into a static on first use, so it
+# has to be set before the extension loads.  Without it the off-by-one this
+# file regresses against is silent at test sizes: a chunk_start of -1 lands a
+# few bytes before a small host buffer, still inside the allocator's mapping,
+# and the chunk it prefetches is never consumed -- so it neither faults nor
+# changes a gradient.  It only segfaults once the buffer is big enough for -1
+# to fall off the mapping, which is not a size a unit test should need.
+os.environ.setdefault("SWEEP_BOUNDARY_BOUNDS", "1")
 
 from sweep.equations import Acoustic  # noqa: E402
 from sweep.parallel import MeshTopology  # noqa: E402
@@ -107,7 +117,7 @@ def vp_global():
     return vp
 
 
-def make_prop(shape, topo=None):
+def make_prop(shape, topo=None, storage="gpu", ti=1, ring=1):
     equation = Acoustic(spatial_order=SO, device=DEV, backend="torch")
     kwargs = dict(
         backend="torch",
@@ -125,8 +135,9 @@ def make_prop(shape, topo=None):
         B=1,
         use_ckpt=False,
         boundary_saving_config={
-            "enabled": True, "storage": "gpu",
-            "transfer_interval": 1, "pinned_memory": False,
+            "enabled": True, "storage": storage,
+            "transfer_interval": ti, "ring_buffers": ring,
+            "pinned_memory": False,
         },
     )
     if topo is not None:
@@ -234,7 +245,7 @@ def build_reference():
     return TileState(cap)
 
 
-def build_tiles(residual_raw):
+def build_tiles(residual_raw, storage="gpu", ti=1, ring=1):
     """Two tile TileStates; per-tile adjoint_source filled from the shared
     synthetic residual (reference raw record), split by receiver ownership."""
     vp = vp_global()
@@ -261,7 +272,7 @@ def build_tiles(residual_raw):
             [[[gx - x0, REC_GZ] for gx in own_rec]], dtype=np.int32
         )
 
-        prop = make_prop((NZ, NXP), topo=topo)
+        prop = make_prop((NZ, NXP), topo=topo, storage=storage, ti=ti, ring=ring)
         cap = capture_both(prop)
         run_public_once(prop, tile_wavelet, tile_sources, tile_receivers, vp_tile)
         t = TileState(cap)
@@ -443,3 +454,47 @@ def test_dd_backward_guards():
         func(bp)
     bp.boundary_on_disk = False
     bp.cut_face_mask = 0
+
+
+@cuda_only
+def test_dd_backward_two_tile_cpu_staged_matches_gpu():
+    """Host-staged boundary must give the SAME gradient as the in-VRAM ring.
+
+    Regression for two defects that only DD reaches:
+
+    * ``prefetch_initial_backward_chunk`` put chunk_start at it0-1.  The
+      monolithic backward primes the ring once with it_hi == nt, so it lands at
+      nt-2; the DD backward is driven one step per call, so its last call
+      (it_hi == 1) asked for chunk -1 and staged a copy from one chunk BEFORE
+      the host buffer -- a host-side segfault inside cudaMemcpyAsync that
+      compute-sanitizer cannot see and that surfaced as a hang about as often
+      as a crash.
+    * ``ModelParallel`` pinned transfer_interval at 1 and dropped
+      ring_buffers, so the staging never batched.  ti/ring are varied here so
+      a regression to the hardcoded 1/1 changes what is exercised.
+
+    Bitwise, not approximate: staging moves where the boundary lives, not what
+    it holds, so every gradient buffer must match element for element.
+    """
+    ref = build_reference()
+    residual_raw = ref.fwd_record_raw.clone()
+
+    def run(storage, ti, ring):
+        tiles = build_tiles(residual_raw, storage=storage, ti=ti, ring=ring)
+        replay_dd_forward(tiles, ref.fp.models[0])
+        replay_dd_backward(tiles)
+        return tiles
+
+    base = run("gpu", 1, 1)
+    for ti, ring in ((1, 1), (8, 2), (16, 4)):
+        staged = run("cpu", ti, ring)
+        for t, (a, b) in enumerate(zip(base, staged)):
+            assert len(a.gbufs) == len(b.gbufs) and len(a.ibufs) == len(b.ibufs)
+            for k in range(len(a.gbufs)):
+                assert torch.equal(a.gbufs[k], b.gbufs[k]), (
+                    f"tile{t} gbufs[{k}] differs with storage=cpu "
+                    f"(transfer_interval={ti}, ring_buffers={ring})")
+            for k in range(len(a.ibufs)):
+                assert torch.equal(a.ibufs[k], b.ibufs[k]), (
+                    f"tile{t} ibufs[{k}] differs with storage=cpu "
+                    f"(transfer_interval={ti}, ring_buffers={ring})")


### PR DESCRIPTION
Two defects that only domain decomposition reaches, plus the diagnostic that
found the first one and a regression test that would have caught both.

### The crash

`prefetch_initial_backward_chunk` lands `chunk_start` at `it0 - 1`. The
monolithic backward primes the ring once with `it_hi == nt`, so that is `nt-2`
and the arithmetic never approaches zero. The DD backward is driven one step
per call from Python, so its last call arrives with `it_hi == 1`: `it0` is 0,
`chunk_start` is -1, and `load_cpu_to_gpu` stages a copy from one chunk
**before** the host buffer. Traced, the walk ends `1, 0, 0, -1`.

```
#10 cudaMemcpyAsync
#11 EffectiveBoundarySaver::load_cpu_to_gpu
#12 BoundaryRuntime::prefetch_backward_chunk
#13 acoustic3d::run_bs_imaging
```

Only DD with boundary `storage='cpu'`/`'disk'` gets there — a single tile
never walks the arithmetic that far down, and `storage='gpu'` does not stage.

It is a nasty one to see. The bad pointer is on the host, so
compute-sanitizer reports nothing and passes clean. The copy is async, so the
fault surfaces at whichever synchronisation comes next — it presented as a
hang about as often as a segfault, and which rank died moved between runs.
An earlier encounter cost about 48 minutes of no output before the job was
killed, and was abandoned without a diagnosis.

### The staging knobs

`ModelParallel` inherits `storage`, `storage_dtype` and `tail_steps` from the
wrapped propagator but pinned `transfer_interval` at 1 and never passed
`ring_buffers`, so every tile staged one time step per copy with nothing in
flight. The ring machinery in `BoundaryRuntime` was present and unreachable.

### Why the test needs the bounds check

At test sizes the off-by-one is silent: `chunk_start = -1` lands a few bytes
before a small host buffer, still inside the allocator's mapping, and the
chunk it prefetches is never consumed — so it neither faults nor changes a
gradient. It only segfaults once the buffer is large enough for -1 to fall off
the mapping, which is not a size a unit test should need.

So the test turns `SWEEP_BOUNDARY_BOUNDS` on before importing sweep, and the
check reports the offset against the buffer's own size. Reverting the first
commit fails it with

```
boundary staging out of range on top_t: offset -84 elems + 336 B,
buffer holds 10080 elems, sizes [1, 120, 1, 3, 28]
```

A first attempt at this test passed against the unfixed build. That is what
sent me looking for the paragraph above.

### Verification

* Full suite, both trees, **run sequentially** — concurrent runs OOM each
  other and fake three failures. `origin/dev` 712 passed / 1 failed;
  this branch 713 passed / 1 failed, the extra one being the new test, and
  the failing set identical (a pre-existing `test_datasets_registry`).
* The new test compares `storage='cpu'` against `storage='gpu'` with
  `torch.equal` over every gradient and illumination buffer, across three
  `(transfer_interval, ring_buffers)` settings.
* Gradients on the 2-GPU repro are unchanged before and after, on both ranks.

### What this does not fix

Host staging is still slow for long records. `cudaMemcpyAsync` to a pageable
destination is synchronous with respect to the host, so the copy stream cannot
run ahead however deep the ring is; pinning the whole host buffer is the only
switch available today and is not viable at scale — 126 GB of unswappable
pages for one band here, measured as an OOM kill. Making staging overlap for
real needs a small pinned bounce buffer plus a host-side copy into the large
pageable one. Not attempted here.

Concretely: the band that motivated this fits in memory on 4x H100 (46 GB of
80) but takes >37 min/iteration against 219 s with the boundary in VRAM, and
holds GPU utilisation around 60% with one card near idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
