### PR TITLE
feat(dd): persistent boundary staging session + non-blocking copy stream

### DIFF
--- a/src/sweep/csrc/bindings/module.cpp
+++ b/src/sweep/csrc/bindings/module.cpp
@@ -61,6 +61,18 @@ auto dispatch_backward(Func cuda_func, sweep_cpu::EquationKind kind, sweep_cpu::
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    // Persistent boundary-staging session.  Python owns it and hands the SAME
+    // object to every per-step call of a DD time loop, so the copy stream and
+    // the ring events survive between steps and a transfer can actually overlap
+    // the next step's compute.  Leaving it unset keeps the per-call behaviour.
+    py::class_<BoundarySession, std::shared_ptr<BoundarySession>>(m, "BoundarySession")
+        .def(py::init<>())
+        .def("finish", &BoundarySession::finish,
+             "Let every outstanding copy land and close the current phase.")
+        .def_property_readonly("used", &BoundarySession::used,
+             "False means no call site ever bound it (staging fell back to the "
+             "per-call path).");
+
     using EK = sweep_cpu::EquationKind;
     using BM = sweep_cpu::BackwardMode;
     m.def("acoustic2d_forward", wrap_forward(dispatch_forward(acoustic2d::forward, EK::Acoustic2D)));
@@ -229,6 +241,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def_readwrite("spacing", &ForwardInput::spacing)
         .def_readwrite("transfer_interval", &ForwardInput::transfer_interval)
         .def_readwrite("boundary_ring_buffers", &ForwardInput::boundary_ring_buffers)
+        .def_readwrite("boundary_session", &ForwardInput::boundary_session)
         .def_readwrite("boundary_tail_steps", &ForwardInput::boundary_tail_steps)
         .def_readwrite("checkpoint_interval", &ForwardInput::checkpoint_interval)
         .def_readwrite("checkpoint_count", &ForwardInput::checkpoint_count)
@@ -282,6 +295,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def_readwrite("use_pinned_memory", &BackwardInput::use_pinned_memory)
         .def_readwrite("transfer_interval", &BackwardInput::transfer_interval)
         .def_readwrite("boundary_ring_buffers", &BackwardInput::boundary_ring_buffers)
+        .def_readwrite("boundary_session", &BackwardInput::boundary_session)
         .def_readwrite("boundary_tail_steps", &BackwardInput::boundary_tail_steps)
         .def_readwrite("checkpoint_interval", &BackwardInput::checkpoint_interval)
         .def_readwrite("checkpoint_count", &BackwardInput::checkpoint_count)

--- a/src/sweep/csrc/cuda/common/boundary/runtime.cuh
+++ b/src/sweep/csrc/cuda/common/boundary/runtime.cuh
@@ -578,10 +578,10 @@ public:
 
         cudaEventRecord(copy_ready_[chunk.ring_slot], copy_stream_);
         copy_pending_[chunk.ring_slot] = 1;
-        if (profile_enabled_ && boundary_on_disk_) {
+        if (profile_enabled_ && staged_)
             ++profile_forward_chunks_;
+        if (profile_enabled_ && boundary_on_disk_)
             forward_copy_profile_pending_[chunk.ring_slot] = 1;
-        }
     }
 
     inline void save_forward_2d(
@@ -872,7 +872,7 @@ public:
         int chunk_start = it - 1 - buf_idx;
         int slot_start = backward_slot_for_chunk(chunk_start) * transfer_interval_;
         int gpu_idx = slot_start + buf_idx;
-        if (!boundary_disk_async_read_)
+        if (boundary_on_disk_ && !boundary_disk_async_read_)
             gpu_idx = buf_idx;
 
         GeneralBoundaryPointer ptr{};
@@ -1295,8 +1295,20 @@ public:
             return;
 
         int buf_idx = (it - 1) % transfer_interval_;
-        if (buf_idx != 0)
-            return;
+        int cur_start = it - 1 - buf_idx;
+        // ring>=2: issue the next chunk on entry to the current one -- the same
+        // point as wait_before_backward_restore -- so the copy overlaps this
+        // chunk's transfer_interval steps of compute. ring==1 has a single slot
+        // where issuing early would overwrite data still being read, so it keeps
+        // the original "compute, then issue" (no overlap, but correct).
+        const bool early = (ring_buffers_ >= 2);
+        if (early) {
+            if (buf_idx != backward_chunk_len(cur_start) - 1)
+                return;
+        } else {
+            if (buf_idx != 0)
+                return;
+        }
 
         int chunk_id = (it - 1) / transfer_interval_;
         int next_chunk = chunk_id - 1;
@@ -1306,7 +1318,8 @@ public:
         int next_start = next_chunk * transfer_interval_;
         int remain = nt - next_start;
         int next_len = remain < transfer_interval_ ? remain : transfer_interval_;
-        prefetch_backward_chunk(next_start, next_len, 0);
+        prefetch_backward_chunk(next_start, next_len,
+                                backward_slot_for_chunk(next_start));
     }
 
     inline void synchronize()
@@ -1406,7 +1419,12 @@ private:
 
     inline int backward_slot_for_chunk(int chunk_start) const
     {
-        if (!boundary_disk_async_read_)
+        // The SYNCHRONOUS disk path has to stay single-slot: its
+        // load_disk_to_cpu_* and load_cpu_to_gpu(0, ...) both hard-code the
+        // staging offset to 0 and reuse one CPU scratch block. Host staging has
+        // no such constraint, and allowing several slots there is exactly what
+        // lets the backward H2D overlap compute.
+        if (boundary_on_disk_ && !boundary_disk_async_read_)
             return 0;
         int chunk_id = chunk_start / transfer_interval_;
         return chunk_id % ring_buffers_;
@@ -1451,14 +1469,31 @@ private:
                     backward_copy_profile_pending_[slot] = 1;
             }
         } else {
-            saver_->load_cpu_to_gpu(start, len, copy_stream_);
+            // write-after-read: this slot's previous contents may still be
+            // under read by compute. With ring>=2 the next chunk lands in a
+            // different slot, so this event has long completed -- no stall, real
+            // overlap; with ring==1 it correctly orders the H2D after the read
+            // (no overlap, but no corruption).
+            cudaStreamWaitEvent(copy_stream_, compute_ready_[slot], 0);
+            // ...into that slot's own GPU ring interval; the old default
+            // gpu_start=0 packed every chunk into slot 0, which left
+            // ring_buffers doing nothing at all on the backward path.
+            saver_->load_cpu_to_gpu(start, len, copy_stream_, slot * transfer_interval_);
             cudaEventRecord(copy_ready_[slot], copy_stream_);
+            if (profile_enabled_ && staged_)
+                ++profile_chunks_;
         }
     }
 
     inline void record_backward_restore_done(int it)
     {
-        if (!boundary_disk_async_read_)
+        // With a non-blocking copy_stream the write-after-read must be stated
+        // explicitly: compute has to finish reading this slot before the next
+        // H2D may write into it. Host staging used to just return here and lean
+        // on the implicit sync between a blocking cudaStreamCreate stream and
+        // the default stream -- that cover is gone once the stream is
+        // NonBlocking.
+        if (!enabled_ || !staged_)
             return;
         int buf_idx = (it - 1) % transfer_interval_;
         int chunk_start = it - 1 - buf_idx;
@@ -1643,7 +1678,7 @@ private:
 
     inline void print_profile_if_needed()
     {
-        if (!profile_enabled_ || profile_printed_ || !boundary_on_disk_)
+        if (!profile_enabled_ || profile_printed_ || !staged_)
             return;
         profile_printed_ = true;
         accumulate_all_forward_copy_time();

--- a/src/sweep/csrc/cuda/common/boundary/runtime.cuh
+++ b/src/sweep/csrc/cuda/common/boundary/runtime.cuh
@@ -86,7 +86,7 @@ public:
         cudaStream_t compute_stream,
         cudaStream_t copy_stream
     )
-        : saver_(saver),
+        : saver_(&saver),
           dim_(dim),
           enabled_(use_boundary_saving),
           staged_(boundary_on_cpu || boundary_on_disk),
@@ -94,7 +94,7 @@ public:
           boundary_disk_async_read_(boundary_on_disk && boundary_disk_async_read),
           transfer_interval_(transfer_interval > 0 ? transfer_interval : 1),
           ring_buffers_(ring_buffers > 0 ? ring_buffers : 1),
-          disk_files_(disk_files),
+          disk_files_(&disk_files),
           compute_stream_(compute_stream),
           copy_stream_(copy_stream)
     {
@@ -162,6 +162,16 @@ public:
         }
     }
 
+    // Rebind the two objects that only exist for one call. The persistent
+    // runtime calls this once on entry to forward/backward; the non-persistent
+    // path never calls it, so its behaviour is unchanged.
+    inline void rebind(EffectiveBoundarySaver& saver,
+                       const std::vector<std::string>& disk_files)
+    {
+        saver_ = &saver;
+        disk_files_ = &disk_files;
+    }
+
     inline bool enabled() const { return enabled_; }
     inline bool staged() const { return staged_; }
 
@@ -222,75 +232,75 @@ public:
     }
     inline void quantize_step_2d(const GeneralBoundaryPointer& b, int64_t step_idx)
     {
-        int64_t c_top = saver_.top_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t c_bot = saver_.bottom_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t c_lef = saver_.left_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t c_rig = saver_.right_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t s_top = saver_.top_scale_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t s_bot = saver_.bottom_scale_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t s_lef = saver_.left_scale_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t s_rig = saver_.right_scale_t.stride(saver_.dim == 3 ? 0 : 1);
-        quantize_face(saver_.top_t,    b.top,   b.top_q,   b.top_h,   b.top_scale,   b.dtype, step_idx, c_top, s_top);
-        quantize_face(saver_.bottom_t, b.bottom,b.bottom_q,b.bottom_h,b.bottom_scale,b.dtype, step_idx, c_bot, s_bot);
-        quantize_face(saver_.left_t,   b.left,  b.left_q,  b.left_h,  b.left_scale,  b.dtype, step_idx, c_lef, s_lef);
-        quantize_face(saver_.right_t,  b.right, b.right_q, b.right_h, b.right_scale, b.dtype, step_idx, c_rig, s_rig);
+        int64_t c_top = saver_->top_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t c_bot = saver_->bottom_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t c_lef = saver_->left_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t c_rig = saver_->right_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t s_top = saver_->top_scale_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t s_bot = saver_->bottom_scale_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t s_lef = saver_->left_scale_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t s_rig = saver_->right_scale_t.stride(saver_->dim == 3 ? 0 : 1);
+        quantize_face(saver_->top_t,    b.top,   b.top_q,   b.top_h,   b.top_scale,   b.dtype, step_idx, c_top, s_top);
+        quantize_face(saver_->bottom_t, b.bottom,b.bottom_q,b.bottom_h,b.bottom_scale,b.dtype, step_idx, c_bot, s_bot);
+        quantize_face(saver_->left_t,   b.left,  b.left_q,  b.left_h,  b.left_scale,  b.dtype, step_idx, c_lef, s_lef);
+        quantize_face(saver_->right_t,  b.right, b.right_q, b.right_h, b.right_scale, b.dtype, step_idx, c_rig, s_rig);
     }
     inline void dequantize_step_2d(const GeneralBoundaryPointer& b, int64_t step_idx)
     {
-        int64_t c_top = saver_.top_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t c_bot = saver_.bottom_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t c_lef = saver_.left_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t c_rig = saver_.right_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t s_top = saver_.top_scale_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t s_bot = saver_.bottom_scale_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t s_lef = saver_.left_scale_t.stride(saver_.dim == 3 ? 0 : 1);
-        int64_t s_rig = saver_.right_scale_t.stride(saver_.dim == 3 ? 0 : 1);
-        dequantize_face(saver_.top_t,    b.top,   b.top_q,   b.top_h,   b.top_scale,   b.dtype, step_idx, c_top, s_top);
-        dequantize_face(saver_.bottom_t, b.bottom,b.bottom_q,b.bottom_h,b.bottom_scale,b.dtype, step_idx, c_bot, s_bot);
-        dequantize_face(saver_.left_t,   b.left,  b.left_q,  b.left_h,  b.left_scale,  b.dtype, step_idx, c_lef, s_lef);
-        dequantize_face(saver_.right_t,  b.right, b.right_q, b.right_h, b.right_scale, b.dtype, step_idx, c_rig, s_rig);
+        int64_t c_top = saver_->top_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t c_bot = saver_->bottom_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t c_lef = saver_->left_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t c_rig = saver_->right_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t s_top = saver_->top_scale_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t s_bot = saver_->bottom_scale_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t s_lef = saver_->left_scale_t.stride(saver_->dim == 3 ? 0 : 1);
+        int64_t s_rig = saver_->right_scale_t.stride(saver_->dim == 3 ? 0 : 1);
+        dequantize_face(saver_->top_t,    b.top,   b.top_q,   b.top_h,   b.top_scale,   b.dtype, step_idx, c_top, s_top);
+        dequantize_face(saver_->bottom_t, b.bottom,b.bottom_q,b.bottom_h,b.bottom_scale,b.dtype, step_idx, c_bot, s_bot);
+        dequantize_face(saver_->left_t,   b.left,  b.left_q,  b.left_h,  b.left_scale,  b.dtype, step_idx, c_lef, s_lef);
+        dequantize_face(saver_->right_t,  b.right, b.right_q, b.right_h, b.right_scale, b.dtype, step_idx, c_rig, s_rig);
     }
     inline void quantize_step_3d(const GeneralBoundaryPointer& b, int64_t step_idx)
     {
-        int64_t c_top = saver_.top_t.stride(0);
-        int64_t c_bot = saver_.bottom_t.stride(0);
-        int64_t c_fro = saver_.front_t.stride(0);
-        int64_t c_bac = saver_.back_t.stride(0);
-        int64_t c_lef = saver_.left_t.stride(0);
-        int64_t c_rig = saver_.right_t.stride(0);
-        int64_t s_top = saver_.top_scale_t.stride(0);
-        int64_t s_bot = saver_.bottom_scale_t.stride(0);
-        int64_t s_fro = saver_.front_scale_t.stride(0);
-        int64_t s_bac = saver_.back_scale_t.stride(0);
-        int64_t s_lef = saver_.left_scale_t.stride(0);
-        int64_t s_rig = saver_.right_scale_t.stride(0);
-        quantize_face(saver_.top_t,    b.top,   b.top_q,   b.top_h,   b.top_scale,   b.dtype, step_idx, c_top, s_top);
-        quantize_face(saver_.bottom_t, b.bottom,b.bottom_q,b.bottom_h,b.bottom_scale,b.dtype, step_idx, c_bot, s_bot);
-        quantize_face(saver_.front_t,  b.front, b.front_q, b.front_h, b.front_scale, b.dtype, step_idx, c_fro, s_fro);
-        quantize_face(saver_.back_t,   b.back,  b.back_q,  b.back_h,  b.back_scale,  b.dtype, step_idx, c_bac, s_bac);
-        quantize_face(saver_.left_t,   b.left,  b.left_q,  b.left_h,  b.left_scale,  b.dtype, step_idx, c_lef, s_lef);
-        quantize_face(saver_.right_t,  b.right, b.right_q, b.right_h, b.right_scale, b.dtype, step_idx, c_rig, s_rig);
+        int64_t c_top = saver_->top_t.stride(0);
+        int64_t c_bot = saver_->bottom_t.stride(0);
+        int64_t c_fro = saver_->front_t.stride(0);
+        int64_t c_bac = saver_->back_t.stride(0);
+        int64_t c_lef = saver_->left_t.stride(0);
+        int64_t c_rig = saver_->right_t.stride(0);
+        int64_t s_top = saver_->top_scale_t.stride(0);
+        int64_t s_bot = saver_->bottom_scale_t.stride(0);
+        int64_t s_fro = saver_->front_scale_t.stride(0);
+        int64_t s_bac = saver_->back_scale_t.stride(0);
+        int64_t s_lef = saver_->left_scale_t.stride(0);
+        int64_t s_rig = saver_->right_scale_t.stride(0);
+        quantize_face(saver_->top_t,    b.top,   b.top_q,   b.top_h,   b.top_scale,   b.dtype, step_idx, c_top, s_top);
+        quantize_face(saver_->bottom_t, b.bottom,b.bottom_q,b.bottom_h,b.bottom_scale,b.dtype, step_idx, c_bot, s_bot);
+        quantize_face(saver_->front_t,  b.front, b.front_q, b.front_h, b.front_scale, b.dtype, step_idx, c_fro, s_fro);
+        quantize_face(saver_->back_t,   b.back,  b.back_q,  b.back_h,  b.back_scale,  b.dtype, step_idx, c_bac, s_bac);
+        quantize_face(saver_->left_t,   b.left,  b.left_q,  b.left_h,  b.left_scale,  b.dtype, step_idx, c_lef, s_lef);
+        quantize_face(saver_->right_t,  b.right, b.right_q, b.right_h, b.right_scale, b.dtype, step_idx, c_rig, s_rig);
     }
     inline void dequantize_step_3d(const GeneralBoundaryPointer& b, int64_t step_idx)
     {
-        int64_t c_top = saver_.top_t.stride(0);
-        int64_t c_bot = saver_.bottom_t.stride(0);
-        int64_t c_fro = saver_.front_t.stride(0);
-        int64_t c_bac = saver_.back_t.stride(0);
-        int64_t c_lef = saver_.left_t.stride(0);
-        int64_t c_rig = saver_.right_t.stride(0);
-        int64_t s_top = saver_.top_scale_t.stride(0);
-        int64_t s_bot = saver_.bottom_scale_t.stride(0);
-        int64_t s_fro = saver_.front_scale_t.stride(0);
-        int64_t s_bac = saver_.back_scale_t.stride(0);
-        int64_t s_lef = saver_.left_scale_t.stride(0);
-        int64_t s_rig = saver_.right_scale_t.stride(0);
-        dequantize_face(saver_.top_t,    b.top,   b.top_q,   b.top_h,   b.top_scale,   b.dtype, step_idx, c_top, s_top);
-        dequantize_face(saver_.bottom_t, b.bottom,b.bottom_q,b.bottom_h,b.bottom_scale,b.dtype, step_idx, c_bot, s_bot);
-        dequantize_face(saver_.front_t,  b.front, b.front_q, b.front_h, b.front_scale, b.dtype, step_idx, c_fro, s_fro);
-        dequantize_face(saver_.back_t,   b.back,  b.back_q,  b.back_h,  b.back_scale,  b.dtype, step_idx, c_bac, s_bac);
-        dequantize_face(saver_.left_t,   b.left,  b.left_q,  b.left_h,  b.left_scale,  b.dtype, step_idx, c_lef, s_lef);
-        dequantize_face(saver_.right_t,  b.right, b.right_q, b.right_h, b.right_scale, b.dtype, step_idx, c_rig, s_rig);
+        int64_t c_top = saver_->top_t.stride(0);
+        int64_t c_bot = saver_->bottom_t.stride(0);
+        int64_t c_fro = saver_->front_t.stride(0);
+        int64_t c_bac = saver_->back_t.stride(0);
+        int64_t c_lef = saver_->left_t.stride(0);
+        int64_t c_rig = saver_->right_t.stride(0);
+        int64_t s_top = saver_->top_scale_t.stride(0);
+        int64_t s_bot = saver_->bottom_scale_t.stride(0);
+        int64_t s_fro = saver_->front_scale_t.stride(0);
+        int64_t s_bac = saver_->back_scale_t.stride(0);
+        int64_t s_lef = saver_->left_scale_t.stride(0);
+        int64_t s_rig = saver_->right_scale_t.stride(0);
+        dequantize_face(saver_->top_t,    b.top,   b.top_q,   b.top_h,   b.top_scale,   b.dtype, step_idx, c_top, s_top);
+        dequantize_face(saver_->bottom_t, b.bottom,b.bottom_q,b.bottom_h,b.bottom_scale,b.dtype, step_idx, c_bot, s_bot);
+        dequantize_face(saver_->front_t,  b.front, b.front_q, b.front_h, b.front_scale, b.dtype, step_idx, c_fro, s_fro);
+        dequantize_face(saver_->back_t,   b.back,  b.back_q,  b.back_h,  b.back_scale,  b.dtype, step_idx, c_bac, s_bac);
+        dequantize_face(saver_->left_t,   b.left,  b.left_q,  b.left_h,  b.left_scale,  b.dtype, step_idx, c_lef, s_lef);
+        dequantize_face(saver_->right_t,  b.right, b.right_q, b.right_h, b.right_scale, b.dtype, step_idx, c_rig, s_rig);
     }
 
     inline void wait_before_forward_save(const BoundaryChunk& chunk)
@@ -320,31 +330,31 @@ public:
 
         int gpu_idx = chunk.ring_start + chunk.buf_idx;
         GeneralBoundaryPointer ptr{};
-        ptr.dtype = boundary_dtype_from_tensor(saver_.top_gpu);
+        ptr.dtype = boundary_dtype_from_tensor(saver_->top_gpu);
         ptr.last_two = direct.last_two;
         if (ptr.dtype == BoundaryDtype::INT8 || ptr.dtype == BoundaryDtype::FP16) {
             // Staged INT8: uint8 ring (cells/step) + scale ring (blocks/step)
             // + shared FP32 transient (direct.*).  Scale ring per-step stride
             // is its outer-time stride (dim 0 in 3D, dim 1 in 2D).
             const int sd = (dim_ == 3) ? 0 : 1;
-            BIND_STAGED_SCALED(ptr.dtype, saver_.top_gpu,    gpu_idx * saver_.top_stride,    saver_.top_scale_gpu,    gpu_idx * saver_.top_scale_gpu.stride(sd),    direct.top,    ptr.top_q,    ptr.top_h,    ptr.top_scale,    ptr.top);
-            BIND_STAGED_SCALED(ptr.dtype, saver_.bottom_gpu, gpu_idx * saver_.bottom_stride, saver_.bottom_scale_gpu, gpu_idx * saver_.bottom_scale_gpu.stride(sd), direct.bottom, ptr.bottom_q, ptr.bottom_h, ptr.bottom_scale, ptr.bottom);
-            BIND_STAGED_SCALED(ptr.dtype, saver_.left_gpu,   gpu_idx * saver_.left_stride,   saver_.left_scale_gpu,   gpu_idx * saver_.left_scale_gpu.stride(sd),   direct.left,   ptr.left_q,   ptr.left_h,   ptr.left_scale,   ptr.left);
-            BIND_STAGED_SCALED(ptr.dtype, saver_.right_gpu,  gpu_idx * saver_.right_stride,  saver_.right_scale_gpu,  gpu_idx * saver_.right_scale_gpu.stride(sd),  direct.right,  ptr.right_q,  ptr.right_h,  ptr.right_scale,  ptr.right);
+            BIND_STAGED_SCALED(ptr.dtype, saver_->top_gpu,    gpu_idx * saver_->top_stride,    saver_->top_scale_gpu,    gpu_idx * saver_->top_scale_gpu.stride(sd),    direct.top,    ptr.top_q,    ptr.top_h,    ptr.top_scale,    ptr.top);
+            BIND_STAGED_SCALED(ptr.dtype, saver_->bottom_gpu, gpu_idx * saver_->bottom_stride, saver_->bottom_scale_gpu, gpu_idx * saver_->bottom_scale_gpu.stride(sd), direct.bottom, ptr.bottom_q, ptr.bottom_h, ptr.bottom_scale, ptr.bottom);
+            BIND_STAGED_SCALED(ptr.dtype, saver_->left_gpu,   gpu_idx * saver_->left_stride,   saver_->left_scale_gpu,   gpu_idx * saver_->left_scale_gpu.stride(sd),   direct.left,   ptr.left_q,   ptr.left_h,   ptr.left_scale,   ptr.left);
+            BIND_STAGED_SCALED(ptr.dtype, saver_->right_gpu,  gpu_idx * saver_->right_stride,  saver_->right_scale_gpu,  gpu_idx * saver_->right_scale_gpu.stride(sd),  direct.right,  ptr.right_q,  ptr.right_h,  ptr.right_scale,  ptr.right);
             if (dim_ == 3) {
-                BIND_STAGED_SCALED(ptr.dtype, saver_.front_gpu, gpu_idx * saver_.front_stride, saver_.front_scale_gpu, gpu_idx * saver_.front_scale_gpu.stride(sd), direct.front, ptr.front_q, ptr.front_h, ptr.front_scale, ptr.front);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.back_gpu,  gpu_idx * saver_.back_stride,  saver_.back_scale_gpu,  gpu_idx * saver_.back_scale_gpu.stride(sd),  direct.back,  ptr.back_q,  ptr.back_h,  ptr.back_scale,  ptr.back);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->front_gpu, gpu_idx * saver_->front_stride, saver_->front_scale_gpu, gpu_idx * saver_->front_scale_gpu.stride(sd), direct.front, ptr.front_q, ptr.front_h, ptr.front_scale, ptr.front);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->back_gpu,  gpu_idx * saver_->back_stride,  saver_->back_scale_gpu,  gpu_idx * saver_->back_scale_gpu.stride(sd),  direct.back,  ptr.back_q,  ptr.back_h,  ptr.back_scale,  ptr.back);
             }
             return ptr;
         }
-        BIND_STAGED_FACE(saver_.top_gpu,    gpu_idx * saver_.top_stride,    ptr.top,    ptr.top_h,    ptr.top_bf);
-        BIND_STAGED_FACE(saver_.bottom_gpu, gpu_idx * saver_.bottom_stride, ptr.bottom, ptr.bottom_h, ptr.bottom_bf);
-        BIND_STAGED_FACE(saver_.left_gpu,   gpu_idx * saver_.left_stride,   ptr.left,   ptr.left_h,   ptr.left_bf);
-        BIND_STAGED_FACE(saver_.right_gpu,  gpu_idx * saver_.right_stride,  ptr.right,  ptr.right_h,  ptr.right_bf);
+        BIND_STAGED_FACE(saver_->top_gpu,    gpu_idx * saver_->top_stride,    ptr.top,    ptr.top_h,    ptr.top_bf);
+        BIND_STAGED_FACE(saver_->bottom_gpu, gpu_idx * saver_->bottom_stride, ptr.bottom, ptr.bottom_h, ptr.bottom_bf);
+        BIND_STAGED_FACE(saver_->left_gpu,   gpu_idx * saver_->left_stride,   ptr.left,   ptr.left_h,   ptr.left_bf);
+        BIND_STAGED_FACE(saver_->right_gpu,  gpu_idx * saver_->right_stride,  ptr.right,  ptr.right_h,  ptr.right_bf);
 
         if (dim_ == 3) {
-            BIND_STAGED_FACE(saver_.front_gpu, gpu_idx * saver_.front_stride, ptr.front, ptr.front_h, ptr.front_bf);
-            BIND_STAGED_FACE(saver_.back_gpu,  gpu_idx * saver_.back_stride,  ptr.back,  ptr.back_h,  ptr.back_bf);
+            BIND_STAGED_FACE(saver_->front_gpu, gpu_idx * saver_->front_stride, ptr.front, ptr.front_h, ptr.front_bf);
+            BIND_STAGED_FACE(saver_->back_gpu,  gpu_idx * saver_->back_stride,  ptr.back,  ptr.back_h,  ptr.back_bf);
         }
         return ptr;
     }
@@ -355,7 +365,7 @@ public:
         int field_idx
     )
     {
-        TORCH_CHECK(field_idx >= 0 && field_idx < saver_.nvar, "Invalid boundary field index.");
+        TORCH_CHECK(field_idx >= 0 && field_idx < saver_->nvar, "Invalid boundary field index.");
 
         if (dim_ == 2) {
             GeneralBoundaryPointer ptr{};
@@ -365,101 +375,101 @@ public:
 
             if (staged_) {
                 int gpu_idx = chunk.ring_start + chunk.buf_idx;
-                ptr.dtype = boundary_dtype_from_tensor(saver_.top_gpu);
+                ptr.dtype = boundary_dtype_from_tensor(saver_->top_gpu);
                 if (ptr.dtype == BoundaryDtype::INT8 || ptr.dtype == BoundaryDtype::FP16) {
-                    BIND_STAGED_SCALED(ptr.dtype, saver_.top_gpu,
-                        field_idx * saver_.top_gpu.stride(0) + gpu_idx * saver_.top_gpu.stride(1),
-                        saver_.top_scale_gpu,
-                        field_idx * saver_.top_scale_gpu.stride(0) + gpu_idx * saver_.top_scale_gpu.stride(1),
+                    BIND_STAGED_SCALED(ptr.dtype, saver_->top_gpu,
+                        field_idx * saver_->top_gpu.stride(0) + gpu_idx * saver_->top_gpu.stride(1),
+                        saver_->top_scale_gpu,
+                        field_idx * saver_->top_scale_gpu.stride(0) + gpu_idx * saver_->top_scale_gpu.stride(1),
                         direct.top, ptr.top_q, ptr.top_h, ptr.top_scale, ptr.top);
-                    BIND_STAGED_SCALED(ptr.dtype, saver_.bottom_gpu,
-                        field_idx * saver_.bottom_gpu.stride(0) + gpu_idx * saver_.bottom_gpu.stride(1),
-                        saver_.bottom_scale_gpu,
-                        field_idx * saver_.bottom_scale_gpu.stride(0) + gpu_idx * saver_.bottom_scale_gpu.stride(1),
+                    BIND_STAGED_SCALED(ptr.dtype, saver_->bottom_gpu,
+                        field_idx * saver_->bottom_gpu.stride(0) + gpu_idx * saver_->bottom_gpu.stride(1),
+                        saver_->bottom_scale_gpu,
+                        field_idx * saver_->bottom_scale_gpu.stride(0) + gpu_idx * saver_->bottom_scale_gpu.stride(1),
                         direct.bottom, ptr.bottom_q, ptr.bottom_h, ptr.bottom_scale, ptr.bottom);
-                    BIND_STAGED_SCALED(ptr.dtype, saver_.left_gpu,
-                        field_idx * saver_.left_gpu.stride(0) + gpu_idx * saver_.left_gpu.stride(1),
-                        saver_.left_scale_gpu,
-                        field_idx * saver_.left_scale_gpu.stride(0) + gpu_idx * saver_.left_scale_gpu.stride(1),
+                    BIND_STAGED_SCALED(ptr.dtype, saver_->left_gpu,
+                        field_idx * saver_->left_gpu.stride(0) + gpu_idx * saver_->left_gpu.stride(1),
+                        saver_->left_scale_gpu,
+                        field_idx * saver_->left_scale_gpu.stride(0) + gpu_idx * saver_->left_scale_gpu.stride(1),
                         direct.left, ptr.left_q, ptr.left_h, ptr.left_scale, ptr.left);
-                    BIND_STAGED_SCALED(ptr.dtype, saver_.right_gpu,
-                        field_idx * saver_.right_gpu.stride(0) + gpu_idx * saver_.right_gpu.stride(1),
-                        saver_.right_scale_gpu,
-                        field_idx * saver_.right_scale_gpu.stride(0) + gpu_idx * saver_.right_scale_gpu.stride(1),
+                    BIND_STAGED_SCALED(ptr.dtype, saver_->right_gpu,
+                        field_idx * saver_->right_gpu.stride(0) + gpu_idx * saver_->right_gpu.stride(1),
+                        saver_->right_scale_gpu,
+                        field_idx * saver_->right_scale_gpu.stride(0) + gpu_idx * saver_->right_scale_gpu.stride(1),
                         direct.right, ptr.right_q, ptr.right_h, ptr.right_scale, ptr.right);
                 } else {
-                BIND_STAGED_FACE(saver_.top_gpu,
-                    field_idx * saver_.top_gpu.stride(0) + gpu_idx * saver_.top_gpu.stride(1),
+                BIND_STAGED_FACE(saver_->top_gpu,
+                    field_idx * saver_->top_gpu.stride(0) + gpu_idx * saver_->top_gpu.stride(1),
                     ptr.top, ptr.top_h, ptr.top_bf);
-                BIND_STAGED_FACE(saver_.bottom_gpu,
-                    field_idx * saver_.bottom_gpu.stride(0) + gpu_idx * saver_.bottom_gpu.stride(1),
+                BIND_STAGED_FACE(saver_->bottom_gpu,
+                    field_idx * saver_->bottom_gpu.stride(0) + gpu_idx * saver_->bottom_gpu.stride(1),
                     ptr.bottom, ptr.bottom_h, ptr.bottom_bf);
-                BIND_STAGED_FACE(saver_.left_gpu,
-                    field_idx * saver_.left_gpu.stride(0) + gpu_idx * saver_.left_gpu.stride(1),
+                BIND_STAGED_FACE(saver_->left_gpu,
+                    field_idx * saver_->left_gpu.stride(0) + gpu_idx * saver_->left_gpu.stride(1),
                     ptr.left, ptr.left_h, ptr.left_bf);
-                BIND_STAGED_FACE(saver_.right_gpu,
-                    field_idx * saver_.right_gpu.stride(0) + gpu_idx * saver_.right_gpu.stride(1),
+                BIND_STAGED_FACE(saver_->right_gpu,
+                    field_idx * saver_->right_gpu.stride(0) + gpu_idx * saver_->right_gpu.stride(1),
                     ptr.right, ptr.right_h, ptr.right_bf);
                 }
             } else if (direct.dtype == BoundaryDtype::FP16) {
-                ptr.top_h    = direct.top_h    + field_idx * saver_.top_t.stride(0);
-                ptr.bottom_h = direct.bottom_h + field_idx * saver_.bottom_t.stride(0);
-                ptr.left_h   = direct.left_h   + field_idx * saver_.left_t.stride(0);
-                ptr.right_h  = direct.right_h  + field_idx * saver_.right_t.stride(0);
-                ptr.top_scale    = direct.top_scale    + field_idx * saver_.top_scale_t.stride(0);
-                ptr.bottom_scale = direct.bottom_scale + field_idx * saver_.bottom_scale_t.stride(0);
-                ptr.left_scale   = direct.left_scale   + field_idx * saver_.left_scale_t.stride(0);
-                ptr.right_scale  = direct.right_scale  + field_idx * saver_.right_scale_t.stride(0);
+                ptr.top_h    = direct.top_h    + field_idx * saver_->top_t.stride(0);
+                ptr.bottom_h = direct.bottom_h + field_idx * saver_->bottom_t.stride(0);
+                ptr.left_h   = direct.left_h   + field_idx * saver_->left_t.stride(0);
+                ptr.right_h  = direct.right_h  + field_idx * saver_->right_t.stride(0);
+                ptr.top_scale    = direct.top_scale    + field_idx * saver_->top_scale_t.stride(0);
+                ptr.bottom_scale = direct.bottom_scale + field_idx * saver_->bottom_scale_t.stride(0);
+                ptr.left_scale   = direct.left_scale   + field_idx * saver_->left_scale_t.stride(0);
+                ptr.right_scale  = direct.right_scale  + field_idx * saver_->right_scale_t.stride(0);
                 ptr.top    = direct.top;
                 ptr.bottom = direct.bottom;
                 ptr.left   = direct.left;
                 ptr.right  = direct.right;
             } else if (direct.dtype == BoundaryDtype::BF16) {
-                ptr.top_bf    = direct.top_bf    + field_idx * saver_.top_t.stride(0);
-                ptr.bottom_bf = direct.bottom_bf + field_idx * saver_.bottom_t.stride(0);
-                ptr.left_bf   = direct.left_bf   + field_idx * saver_.left_t.stride(0);
-                ptr.right_bf  = direct.right_bf  + field_idx * saver_.right_t.stride(0);
+                ptr.top_bf    = direct.top_bf    + field_idx * saver_->top_t.stride(0);
+                ptr.bottom_bf = direct.bottom_bf + field_idx * saver_->bottom_t.stride(0);
+                ptr.left_bf   = direct.left_bf   + field_idx * saver_->left_t.stride(0);
+                ptr.right_bf  = direct.right_bf  + field_idx * saver_->right_t.stride(0);
             } else if (direct.dtype == BoundaryDtype::INT8) {
-                ptr.top_q       = direct.top_q       + field_idx * saver_.top_t.stride(0);
-                ptr.bottom_q    = direct.bottom_q    + field_idx * saver_.bottom_t.stride(0);
-                ptr.left_q      = direct.left_q      + field_idx * saver_.left_t.stride(0);
-                ptr.right_q     = direct.right_q     + field_idx * saver_.right_t.stride(0);
-                ptr.top_scale    = direct.top_scale    + field_idx * saver_.top_scale_t.stride(0);
-                ptr.bottom_scale = direct.bottom_scale + field_idx * saver_.bottom_scale_t.stride(0);
-                ptr.left_scale   = direct.left_scale   + field_idx * saver_.left_scale_t.stride(0);
-                ptr.right_scale  = direct.right_scale  + field_idx * saver_.right_scale_t.stride(0);
+                ptr.top_q       = direct.top_q       + field_idx * saver_->top_t.stride(0);
+                ptr.bottom_q    = direct.bottom_q    + field_idx * saver_->bottom_t.stride(0);
+                ptr.left_q      = direct.left_q      + field_idx * saver_->left_t.stride(0);
+                ptr.right_q     = direct.right_q     + field_idx * saver_->right_t.stride(0);
+                ptr.top_scale    = direct.top_scale    + field_idx * saver_->top_scale_t.stride(0);
+                ptr.bottom_scale = direct.bottom_scale + field_idx * saver_->bottom_scale_t.stride(0);
+                ptr.left_scale   = direct.left_scale   + field_idx * saver_->left_scale_t.stride(0);
+                ptr.right_scale  = direct.right_scale  + field_idx * saver_->right_scale_t.stride(0);
                 ptr.top    = direct.top;
                 ptr.bottom = direct.bottom;
                 ptr.left   = direct.left;
                 ptr.right  = direct.right;
             } else {
-                ptr.top = direct.top + field_idx * saver_.top_t.stride(0);
-                ptr.bottom = direct.bottom + field_idx * saver_.bottom_t.stride(0);
-                ptr.left = direct.left + field_idx * saver_.left_t.stride(0);
-                ptr.right = direct.right + field_idx * saver_.right_t.stride(0);
+                ptr.top = direct.top + field_idx * saver_->top_t.stride(0);
+                ptr.bottom = direct.bottom + field_idx * saver_->bottom_t.stride(0);
+                ptr.left = direct.left + field_idx * saver_->left_t.stride(0);
+                ptr.right = direct.right + field_idx * saver_->right_t.stride(0);
             }
             return ptr;
         }
 
         int time_idx = staged_ ? (chunk.ring_start + chunk.buf_idx) : chunk.it;
-        int64_t flat_idx = static_cast<int64_t>(time_idx) * saver_.nvar + field_idx;
+        int64_t flat_idx = static_cast<int64_t>(time_idx) * saver_->nvar + field_idx;
 
         GeneralBoundaryPointer ptr{};
         ptr.use_fp16 = direct.use_fp16;
             ptr.dtype = direct.dtype;
         if (!staged_ && direct.dtype == BoundaryDtype::FP16) {
-            ptr.top_h    = direct.top_h    + flat_idx * saver_.top_stride;
-            ptr.bottom_h = direct.bottom_h + flat_idx * saver_.bottom_stride;
-            ptr.front_h  = direct.front_h  + flat_idx * saver_.front_stride;
-            ptr.back_h   = direct.back_h   + flat_idx * saver_.back_stride;
-            ptr.left_h   = direct.left_h   + flat_idx * saver_.left_stride;
-            ptr.right_h  = direct.right_h  + flat_idx * saver_.right_stride;
-            ptr.top_scale    = direct.top_scale    + flat_idx * saver_.top_scale_t.stride(0);
-            ptr.bottom_scale = direct.bottom_scale + flat_idx * saver_.bottom_scale_t.stride(0);
-            ptr.front_scale  = direct.front_scale  + flat_idx * saver_.front_scale_t.stride(0);
-            ptr.back_scale   = direct.back_scale   + flat_idx * saver_.back_scale_t.stride(0);
-            ptr.left_scale   = direct.left_scale   + flat_idx * saver_.left_scale_t.stride(0);
-            ptr.right_scale  = direct.right_scale  + flat_idx * saver_.right_scale_t.stride(0);
+            ptr.top_h    = direct.top_h    + flat_idx * saver_->top_stride;
+            ptr.bottom_h = direct.bottom_h + flat_idx * saver_->bottom_stride;
+            ptr.front_h  = direct.front_h  + flat_idx * saver_->front_stride;
+            ptr.back_h   = direct.back_h   + flat_idx * saver_->back_stride;
+            ptr.left_h   = direct.left_h   + flat_idx * saver_->left_stride;
+            ptr.right_h  = direct.right_h  + flat_idx * saver_->right_stride;
+            ptr.top_scale    = direct.top_scale    + flat_idx * saver_->top_scale_t.stride(0);
+            ptr.bottom_scale = direct.bottom_scale + flat_idx * saver_->bottom_scale_t.stride(0);
+            ptr.front_scale  = direct.front_scale  + flat_idx * saver_->front_scale_t.stride(0);
+            ptr.back_scale   = direct.back_scale   + flat_idx * saver_->back_scale_t.stride(0);
+            ptr.left_scale   = direct.left_scale   + flat_idx * saver_->left_scale_t.stride(0);
+            ptr.right_scale  = direct.right_scale  + flat_idx * saver_->right_scale_t.stride(0);
             ptr.top    = direct.top;
             ptr.bottom = direct.bottom;
             ptr.front  = direct.front;
@@ -467,29 +477,29 @@ public:
             ptr.left   = direct.left;
             ptr.right  = direct.right;
         } else if (!staged_ && direct.dtype == BoundaryDtype::BF16) {
-            ptr.top_bf    = direct.top_bf    + flat_idx * saver_.top_stride;
-            ptr.bottom_bf = direct.bottom_bf + flat_idx * saver_.bottom_stride;
-            ptr.front_bf  = direct.front_bf  + flat_idx * saver_.front_stride;
-            ptr.back_bf   = direct.back_bf   + flat_idx * saver_.back_stride;
-            ptr.left_bf   = direct.left_bf   + flat_idx * saver_.left_stride;
-            ptr.right_bf  = direct.right_bf  + flat_idx * saver_.right_stride;
+            ptr.top_bf    = direct.top_bf    + flat_idx * saver_->top_stride;
+            ptr.bottom_bf = direct.bottom_bf + flat_idx * saver_->bottom_stride;
+            ptr.front_bf  = direct.front_bf  + flat_idx * saver_->front_stride;
+            ptr.back_bf   = direct.back_bf   + flat_idx * saver_->back_stride;
+            ptr.left_bf   = direct.left_bf   + flat_idx * saver_->left_stride;
+            ptr.right_bf  = direct.right_bf  + flat_idx * saver_->right_stride;
         } else if (!staged_ && direct.dtype == BoundaryDtype::INT8) {
             // 3D persistent uint8 buffer: outermost index = time*nvar + field.
             // top_stride/bottom_stride/... already track per-(time×field)
             // cell counts (compute_time_strides → tensor.stride(0)).
-            ptr.top_q    = direct.top_q    + flat_idx * saver_.top_stride;
-            ptr.bottom_q = direct.bottom_q + flat_idx * saver_.bottom_stride;
-            ptr.front_q  = direct.front_q  + flat_idx * saver_.front_stride;
-            ptr.back_q   = direct.back_q   + flat_idx * saver_.back_stride;
-            ptr.left_q   = direct.left_q   + flat_idx * saver_.left_stride;
-            ptr.right_q  = direct.right_q  + flat_idx * saver_.right_stride;
+            ptr.top_q    = direct.top_q    + flat_idx * saver_->top_stride;
+            ptr.bottom_q = direct.bottom_q + flat_idx * saver_->bottom_stride;
+            ptr.front_q  = direct.front_q  + flat_idx * saver_->front_stride;
+            ptr.back_q   = direct.back_q   + flat_idx * saver_->back_stride;
+            ptr.left_q   = direct.left_q   + flat_idx * saver_->left_stride;
+            ptr.right_q  = direct.right_q  + flat_idx * saver_->right_stride;
             // Scale buffer outermost stride.
-            ptr.top_scale    = direct.top_scale    + flat_idx * saver_.top_scale_t.stride(0);
-            ptr.bottom_scale = direct.bottom_scale + flat_idx * saver_.bottom_scale_t.stride(0);
-            ptr.front_scale  = direct.front_scale  + flat_idx * saver_.front_scale_t.stride(0);
-            ptr.back_scale   = direct.back_scale   + flat_idx * saver_.back_scale_t.stride(0);
-            ptr.left_scale   = direct.left_scale   + flat_idx * saver_.left_scale_t.stride(0);
-            ptr.right_scale  = direct.right_scale  + flat_idx * saver_.right_scale_t.stride(0);
+            ptr.top_scale    = direct.top_scale    + flat_idx * saver_->top_scale_t.stride(0);
+            ptr.bottom_scale = direct.bottom_scale + flat_idx * saver_->bottom_scale_t.stride(0);
+            ptr.front_scale  = direct.front_scale  + flat_idx * saver_->front_scale_t.stride(0);
+            ptr.back_scale   = direct.back_scale   + flat_idx * saver_->back_scale_t.stride(0);
+            ptr.left_scale   = direct.left_scale   + flat_idx * saver_->left_scale_t.stride(0);
+            ptr.right_scale  = direct.right_scale  + flat_idx * saver_->right_scale_t.stride(0);
             // Staging shared across (time, field) — no offset.
             ptr.top    = direct.top;
             ptr.bottom = direct.bottom;
@@ -498,31 +508,31 @@ public:
             ptr.left   = direct.left;
             ptr.right  = direct.right;
         } else if (staged_) {
-            ptr.dtype = boundary_dtype_from_tensor(saver_.top_gpu);
+            ptr.dtype = boundary_dtype_from_tensor(saver_->top_gpu);
             if (ptr.dtype == BoundaryDtype::INT8 || ptr.dtype == BoundaryDtype::FP16) {
                 // 3D staged INT8: uint8 ring + scale ring indexed by the same
                 // flat (gpu_time*nvar + field) index; shared FP32 transient.
-                BIND_STAGED_SCALED(ptr.dtype, saver_.top_gpu,    flat_idx * saver_.top_stride,    saver_.top_scale_gpu,    flat_idx * saver_.top_scale_gpu.stride(0),    direct.top,    ptr.top_q,    ptr.top_h,    ptr.top_scale,    ptr.top);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.bottom_gpu, flat_idx * saver_.bottom_stride, saver_.bottom_scale_gpu, flat_idx * saver_.bottom_scale_gpu.stride(0), direct.bottom, ptr.bottom_q, ptr.bottom_h, ptr.bottom_scale, ptr.bottom);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.front_gpu,  flat_idx * saver_.front_stride,  saver_.front_scale_gpu,  flat_idx * saver_.front_scale_gpu.stride(0),  direct.front,  ptr.front_q,  ptr.front_h,  ptr.front_scale,  ptr.front);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.back_gpu,   flat_idx * saver_.back_stride,   saver_.back_scale_gpu,   flat_idx * saver_.back_scale_gpu.stride(0),   direct.back,   ptr.back_q,   ptr.back_h,   ptr.back_scale,   ptr.back);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.left_gpu,   flat_idx * saver_.left_stride,   saver_.left_scale_gpu,   flat_idx * saver_.left_scale_gpu.stride(0),   direct.left,   ptr.left_q,   ptr.left_h,   ptr.left_scale,   ptr.left);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.right_gpu,  flat_idx * saver_.right_stride,  saver_.right_scale_gpu,  flat_idx * saver_.right_scale_gpu.stride(0),  direct.right,  ptr.right_q,  ptr.right_h,  ptr.right_scale,  ptr.right);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->top_gpu,    flat_idx * saver_->top_stride,    saver_->top_scale_gpu,    flat_idx * saver_->top_scale_gpu.stride(0),    direct.top,    ptr.top_q,    ptr.top_h,    ptr.top_scale,    ptr.top);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->bottom_gpu, flat_idx * saver_->bottom_stride, saver_->bottom_scale_gpu, flat_idx * saver_->bottom_scale_gpu.stride(0), direct.bottom, ptr.bottom_q, ptr.bottom_h, ptr.bottom_scale, ptr.bottom);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->front_gpu,  flat_idx * saver_->front_stride,  saver_->front_scale_gpu,  flat_idx * saver_->front_scale_gpu.stride(0),  direct.front,  ptr.front_q,  ptr.front_h,  ptr.front_scale,  ptr.front);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->back_gpu,   flat_idx * saver_->back_stride,   saver_->back_scale_gpu,   flat_idx * saver_->back_scale_gpu.stride(0),   direct.back,   ptr.back_q,   ptr.back_h,   ptr.back_scale,   ptr.back);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->left_gpu,   flat_idx * saver_->left_stride,   saver_->left_scale_gpu,   flat_idx * saver_->left_scale_gpu.stride(0),   direct.left,   ptr.left_q,   ptr.left_h,   ptr.left_scale,   ptr.left);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->right_gpu,  flat_idx * saver_->right_stride,  saver_->right_scale_gpu,  flat_idx * saver_->right_scale_gpu.stride(0),  direct.right,  ptr.right_q,  ptr.right_h,  ptr.right_scale,  ptr.right);
             } else {
-            BIND_STAGED_FACE(saver_.top_gpu,    flat_idx * saver_.top_stride,    ptr.top,    ptr.top_h,    ptr.top_bf);
-            BIND_STAGED_FACE(saver_.bottom_gpu, flat_idx * saver_.bottom_stride, ptr.bottom, ptr.bottom_h, ptr.bottom_bf);
-            BIND_STAGED_FACE(saver_.front_gpu,  flat_idx * saver_.front_stride,  ptr.front,  ptr.front_h,  ptr.front_bf);
-            BIND_STAGED_FACE(saver_.back_gpu,   flat_idx * saver_.back_stride,   ptr.back,   ptr.back_h,   ptr.back_bf);
-            BIND_STAGED_FACE(saver_.left_gpu,   flat_idx * saver_.left_stride,   ptr.left,   ptr.left_h,   ptr.left_bf);
-            BIND_STAGED_FACE(saver_.right_gpu,  flat_idx * saver_.right_stride,  ptr.right,  ptr.right_h,  ptr.right_bf);
+            BIND_STAGED_FACE(saver_->top_gpu,    flat_idx * saver_->top_stride,    ptr.top,    ptr.top_h,    ptr.top_bf);
+            BIND_STAGED_FACE(saver_->bottom_gpu, flat_idx * saver_->bottom_stride, ptr.bottom, ptr.bottom_h, ptr.bottom_bf);
+            BIND_STAGED_FACE(saver_->front_gpu,  flat_idx * saver_->front_stride,  ptr.front,  ptr.front_h,  ptr.front_bf);
+            BIND_STAGED_FACE(saver_->back_gpu,   flat_idx * saver_->back_stride,   ptr.back,   ptr.back_h,   ptr.back_bf);
+            BIND_STAGED_FACE(saver_->left_gpu,   flat_idx * saver_->left_stride,   ptr.left,   ptr.left_h,   ptr.left_bf);
+            BIND_STAGED_FACE(saver_->right_gpu,  flat_idx * saver_->right_stride,  ptr.right,  ptr.right_h,  ptr.right_bf);
             }
         } else {
-            ptr.top = direct.top + flat_idx * saver_.top_stride;
-            ptr.bottom = direct.bottom + flat_idx * saver_.bottom_stride;
-            ptr.front = direct.front + flat_idx * saver_.front_stride;
-            ptr.back = direct.back + flat_idx * saver_.back_stride;
-            ptr.left = direct.left + flat_idx * saver_.left_stride;
-            ptr.right = direct.right + flat_idx * saver_.right_stride;
+            ptr.top = direct.top + flat_idx * saver_->top_stride;
+            ptr.bottom = direct.bottom + flat_idx * saver_->bottom_stride;
+            ptr.front = direct.front + flat_idx * saver_->front_stride;
+            ptr.back = direct.back + flat_idx * saver_->back_stride;
+            ptr.left = direct.left + flat_idx * saver_->left_stride;
+            ptr.right = direct.right + flat_idx * saver_->right_stride;
         }
         ptr.last_two = direct.last_two;
         return ptr;
@@ -549,16 +559,16 @@ public:
             cudaEventRecord(forward_copy_start_[chunk.ring_slot], copy_stream_);
 
         if (boundary_on_disk_) {
-            saver_.flush_gpu_to_disk(
+            saver_->flush_gpu_to_disk(
                 chunk.chunk_start,
                 chunk.chunk_len,
-                disk_files_,
+                (*disk_files_),
                 copy_stream_,
                 chunk.ring_start,
                 chunk.ring_start
             );
         } else {
-            saver_.flush_gpu_to_cpu(
+            saver_->flush_gpu_to_cpu(
                 chunk.chunk_start,
                 chunk.chunk_len,
                 copy_stream_,
@@ -866,28 +876,28 @@ public:
             gpu_idx = buf_idx;
 
         GeneralBoundaryPointer ptr{};
-        ptr.dtype = boundary_dtype_from_tensor(saver_.top_gpu);
+        ptr.dtype = boundary_dtype_from_tensor(saver_->top_gpu);
         ptr.last_two = direct.last_two;
         if (ptr.dtype == BoundaryDtype::INT8 || ptr.dtype == BoundaryDtype::FP16) {
             const int sd = (dim_ == 3) ? 0 : 1;
-            BIND_STAGED_SCALED(ptr.dtype, saver_.top_gpu,    gpu_idx * saver_.top_stride,    saver_.top_scale_gpu,    gpu_idx * saver_.top_scale_gpu.stride(sd),    direct.top,    ptr.top_q,    ptr.top_h,    ptr.top_scale,    ptr.top);
-            BIND_STAGED_SCALED(ptr.dtype, saver_.bottom_gpu, gpu_idx * saver_.bottom_stride, saver_.bottom_scale_gpu, gpu_idx * saver_.bottom_scale_gpu.stride(sd), direct.bottom, ptr.bottom_q, ptr.bottom_h, ptr.bottom_scale, ptr.bottom);
-            BIND_STAGED_SCALED(ptr.dtype, saver_.left_gpu,   gpu_idx * saver_.left_stride,   saver_.left_scale_gpu,   gpu_idx * saver_.left_scale_gpu.stride(sd),   direct.left,   ptr.left_q,   ptr.left_h,   ptr.left_scale,   ptr.left);
-            BIND_STAGED_SCALED(ptr.dtype, saver_.right_gpu,  gpu_idx * saver_.right_stride,  saver_.right_scale_gpu,  gpu_idx * saver_.right_scale_gpu.stride(sd),  direct.right,  ptr.right_q,  ptr.right_h,  ptr.right_scale,  ptr.right);
+            BIND_STAGED_SCALED(ptr.dtype, saver_->top_gpu,    gpu_idx * saver_->top_stride,    saver_->top_scale_gpu,    gpu_idx * saver_->top_scale_gpu.stride(sd),    direct.top,    ptr.top_q,    ptr.top_h,    ptr.top_scale,    ptr.top);
+            BIND_STAGED_SCALED(ptr.dtype, saver_->bottom_gpu, gpu_idx * saver_->bottom_stride, saver_->bottom_scale_gpu, gpu_idx * saver_->bottom_scale_gpu.stride(sd), direct.bottom, ptr.bottom_q, ptr.bottom_h, ptr.bottom_scale, ptr.bottom);
+            BIND_STAGED_SCALED(ptr.dtype, saver_->left_gpu,   gpu_idx * saver_->left_stride,   saver_->left_scale_gpu,   gpu_idx * saver_->left_scale_gpu.stride(sd),   direct.left,   ptr.left_q,   ptr.left_h,   ptr.left_scale,   ptr.left);
+            BIND_STAGED_SCALED(ptr.dtype, saver_->right_gpu,  gpu_idx * saver_->right_stride,  saver_->right_scale_gpu,  gpu_idx * saver_->right_scale_gpu.stride(sd),  direct.right,  ptr.right_q,  ptr.right_h,  ptr.right_scale,  ptr.right);
             if (dim_ == 3) {
-                BIND_STAGED_SCALED(ptr.dtype, saver_.front_gpu, gpu_idx * saver_.front_stride, saver_.front_scale_gpu, gpu_idx * saver_.front_scale_gpu.stride(sd), direct.front, ptr.front_q, ptr.front_h, ptr.front_scale, ptr.front);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.back_gpu,  gpu_idx * saver_.back_stride,  saver_.back_scale_gpu,  gpu_idx * saver_.back_scale_gpu.stride(sd),  direct.back,  ptr.back_q,  ptr.back_h,  ptr.back_scale,  ptr.back);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->front_gpu, gpu_idx * saver_->front_stride, saver_->front_scale_gpu, gpu_idx * saver_->front_scale_gpu.stride(sd), direct.front, ptr.front_q, ptr.front_h, ptr.front_scale, ptr.front);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->back_gpu,  gpu_idx * saver_->back_stride,  saver_->back_scale_gpu,  gpu_idx * saver_->back_scale_gpu.stride(sd),  direct.back,  ptr.back_q,  ptr.back_h,  ptr.back_scale,  ptr.back);
             }
             return ptr;
         }
-        BIND_STAGED_FACE(saver_.top_gpu,    gpu_idx * saver_.top_stride,    ptr.top,    ptr.top_h,    ptr.top_bf);
-        BIND_STAGED_FACE(saver_.bottom_gpu, gpu_idx * saver_.bottom_stride, ptr.bottom, ptr.bottom_h, ptr.bottom_bf);
-        BIND_STAGED_FACE(saver_.left_gpu,   gpu_idx * saver_.left_stride,   ptr.left,   ptr.left_h,   ptr.left_bf);
-        BIND_STAGED_FACE(saver_.right_gpu,  gpu_idx * saver_.right_stride,  ptr.right,  ptr.right_h,  ptr.right_bf);
+        BIND_STAGED_FACE(saver_->top_gpu,    gpu_idx * saver_->top_stride,    ptr.top,    ptr.top_h,    ptr.top_bf);
+        BIND_STAGED_FACE(saver_->bottom_gpu, gpu_idx * saver_->bottom_stride, ptr.bottom, ptr.bottom_h, ptr.bottom_bf);
+        BIND_STAGED_FACE(saver_->left_gpu,   gpu_idx * saver_->left_stride,   ptr.left,   ptr.left_h,   ptr.left_bf);
+        BIND_STAGED_FACE(saver_->right_gpu,  gpu_idx * saver_->right_stride,  ptr.right,  ptr.right_h,  ptr.right_bf);
 
         if (dim_ == 3) {
-            BIND_STAGED_FACE(saver_.front_gpu, gpu_idx * saver_.front_stride, ptr.front, ptr.front_h, ptr.front_bf);
-            BIND_STAGED_FACE(saver_.back_gpu,  gpu_idx * saver_.back_stride,  ptr.back,  ptr.back_h,  ptr.back_bf);
+            BIND_STAGED_FACE(saver_->front_gpu, gpu_idx * saver_->front_stride, ptr.front, ptr.front_h, ptr.front_bf);
+            BIND_STAGED_FACE(saver_->back_gpu,  gpu_idx * saver_->back_stride,  ptr.back,  ptr.back_h,  ptr.back_bf);
         }
         return ptr;
     }
@@ -898,7 +908,7 @@ public:
         int field_idx
     )
     {
-        TORCH_CHECK(field_idx >= 0 && field_idx < saver_.nvar, "Invalid boundary field index.");
+        TORCH_CHECK(field_idx >= 0 && field_idx < saver_->nvar, "Invalid boundary field index.");
 
         if (dim_ == 2) {
             GeneralBoundaryPointer ptr{};
@@ -914,78 +924,78 @@ public:
                 if (!boundary_disk_async_read_)
                     gpu_idx = buf_idx;
 
-                ptr.dtype = boundary_dtype_from_tensor(saver_.top_gpu);
+                ptr.dtype = boundary_dtype_from_tensor(saver_->top_gpu);
                 if (ptr.dtype == BoundaryDtype::INT8 || ptr.dtype == BoundaryDtype::FP16) {
-                    BIND_STAGED_SCALED(ptr.dtype, saver_.top_gpu,
-                        field_idx * saver_.top_gpu.stride(0) + gpu_idx * saver_.top_gpu.stride(1),
-                        saver_.top_scale_gpu,
-                        field_idx * saver_.top_scale_gpu.stride(0) + gpu_idx * saver_.top_scale_gpu.stride(1),
+                    BIND_STAGED_SCALED(ptr.dtype, saver_->top_gpu,
+                        field_idx * saver_->top_gpu.stride(0) + gpu_idx * saver_->top_gpu.stride(1),
+                        saver_->top_scale_gpu,
+                        field_idx * saver_->top_scale_gpu.stride(0) + gpu_idx * saver_->top_scale_gpu.stride(1),
                         direct.top, ptr.top_q, ptr.top_h, ptr.top_scale, ptr.top);
-                    BIND_STAGED_SCALED(ptr.dtype, saver_.bottom_gpu,
-                        field_idx * saver_.bottom_gpu.stride(0) + gpu_idx * saver_.bottom_gpu.stride(1),
-                        saver_.bottom_scale_gpu,
-                        field_idx * saver_.bottom_scale_gpu.stride(0) + gpu_idx * saver_.bottom_scale_gpu.stride(1),
+                    BIND_STAGED_SCALED(ptr.dtype, saver_->bottom_gpu,
+                        field_idx * saver_->bottom_gpu.stride(0) + gpu_idx * saver_->bottom_gpu.stride(1),
+                        saver_->bottom_scale_gpu,
+                        field_idx * saver_->bottom_scale_gpu.stride(0) + gpu_idx * saver_->bottom_scale_gpu.stride(1),
                         direct.bottom, ptr.bottom_q, ptr.bottom_h, ptr.bottom_scale, ptr.bottom);
-                    BIND_STAGED_SCALED(ptr.dtype, saver_.left_gpu,
-                        field_idx * saver_.left_gpu.stride(0) + gpu_idx * saver_.left_gpu.stride(1),
-                        saver_.left_scale_gpu,
-                        field_idx * saver_.left_scale_gpu.stride(0) + gpu_idx * saver_.left_scale_gpu.stride(1),
+                    BIND_STAGED_SCALED(ptr.dtype, saver_->left_gpu,
+                        field_idx * saver_->left_gpu.stride(0) + gpu_idx * saver_->left_gpu.stride(1),
+                        saver_->left_scale_gpu,
+                        field_idx * saver_->left_scale_gpu.stride(0) + gpu_idx * saver_->left_scale_gpu.stride(1),
                         direct.left, ptr.left_q, ptr.left_h, ptr.left_scale, ptr.left);
-                    BIND_STAGED_SCALED(ptr.dtype, saver_.right_gpu,
-                        field_idx * saver_.right_gpu.stride(0) + gpu_idx * saver_.right_gpu.stride(1),
-                        saver_.right_scale_gpu,
-                        field_idx * saver_.right_scale_gpu.stride(0) + gpu_idx * saver_.right_scale_gpu.stride(1),
+                    BIND_STAGED_SCALED(ptr.dtype, saver_->right_gpu,
+                        field_idx * saver_->right_gpu.stride(0) + gpu_idx * saver_->right_gpu.stride(1),
+                        saver_->right_scale_gpu,
+                        field_idx * saver_->right_scale_gpu.stride(0) + gpu_idx * saver_->right_scale_gpu.stride(1),
                         direct.right, ptr.right_q, ptr.right_h, ptr.right_scale, ptr.right);
                 } else {
-                BIND_STAGED_FACE(saver_.top_gpu,
-                    field_idx * saver_.top_gpu.stride(0) + gpu_idx * saver_.top_gpu.stride(1),
+                BIND_STAGED_FACE(saver_->top_gpu,
+                    field_idx * saver_->top_gpu.stride(0) + gpu_idx * saver_->top_gpu.stride(1),
                     ptr.top, ptr.top_h, ptr.top_bf);
-                BIND_STAGED_FACE(saver_.bottom_gpu,
-                    field_idx * saver_.bottom_gpu.stride(0) + gpu_idx * saver_.bottom_gpu.stride(1),
+                BIND_STAGED_FACE(saver_->bottom_gpu,
+                    field_idx * saver_->bottom_gpu.stride(0) + gpu_idx * saver_->bottom_gpu.stride(1),
                     ptr.bottom, ptr.bottom_h, ptr.bottom_bf);
-                BIND_STAGED_FACE(saver_.left_gpu,
-                    field_idx * saver_.left_gpu.stride(0) + gpu_idx * saver_.left_gpu.stride(1),
+                BIND_STAGED_FACE(saver_->left_gpu,
+                    field_idx * saver_->left_gpu.stride(0) + gpu_idx * saver_->left_gpu.stride(1),
                     ptr.left, ptr.left_h, ptr.left_bf);
-                BIND_STAGED_FACE(saver_.right_gpu,
-                    field_idx * saver_.right_gpu.stride(0) + gpu_idx * saver_.right_gpu.stride(1),
+                BIND_STAGED_FACE(saver_->right_gpu,
+                    field_idx * saver_->right_gpu.stride(0) + gpu_idx * saver_->right_gpu.stride(1),
                     ptr.right, ptr.right_h, ptr.right_bf);
                 }
             } else if (direct.dtype == BoundaryDtype::FP16) {
-                ptr.top_h    = direct.top_h    + field_idx * saver_.top_t.stride(0);
-                ptr.bottom_h = direct.bottom_h + field_idx * saver_.bottom_t.stride(0);
-                ptr.left_h   = direct.left_h   + field_idx * saver_.left_t.stride(0);
-                ptr.right_h  = direct.right_h  + field_idx * saver_.right_t.stride(0);
-                ptr.top_scale    = direct.top_scale    + field_idx * saver_.top_scale_t.stride(0);
-                ptr.bottom_scale = direct.bottom_scale + field_idx * saver_.bottom_scale_t.stride(0);
-                ptr.left_scale   = direct.left_scale   + field_idx * saver_.left_scale_t.stride(0);
-                ptr.right_scale  = direct.right_scale  + field_idx * saver_.right_scale_t.stride(0);
+                ptr.top_h    = direct.top_h    + field_idx * saver_->top_t.stride(0);
+                ptr.bottom_h = direct.bottom_h + field_idx * saver_->bottom_t.stride(0);
+                ptr.left_h   = direct.left_h   + field_idx * saver_->left_t.stride(0);
+                ptr.right_h  = direct.right_h  + field_idx * saver_->right_t.stride(0);
+                ptr.top_scale    = direct.top_scale    + field_idx * saver_->top_scale_t.stride(0);
+                ptr.bottom_scale = direct.bottom_scale + field_idx * saver_->bottom_scale_t.stride(0);
+                ptr.left_scale   = direct.left_scale   + field_idx * saver_->left_scale_t.stride(0);
+                ptr.right_scale  = direct.right_scale  + field_idx * saver_->right_scale_t.stride(0);
                 ptr.top    = direct.top;
                 ptr.bottom = direct.bottom;
                 ptr.left   = direct.left;
                 ptr.right  = direct.right;
             } else if (direct.dtype == BoundaryDtype::BF16) {
-                ptr.top_bf    = direct.top_bf    + field_idx * saver_.top_t.stride(0);
-                ptr.bottom_bf = direct.bottom_bf + field_idx * saver_.bottom_t.stride(0);
-                ptr.left_bf   = direct.left_bf   + field_idx * saver_.left_t.stride(0);
-                ptr.right_bf  = direct.right_bf  + field_idx * saver_.right_t.stride(0);
+                ptr.top_bf    = direct.top_bf    + field_idx * saver_->top_t.stride(0);
+                ptr.bottom_bf = direct.bottom_bf + field_idx * saver_->bottom_t.stride(0);
+                ptr.left_bf   = direct.left_bf   + field_idx * saver_->left_t.stride(0);
+                ptr.right_bf  = direct.right_bf  + field_idx * saver_->right_t.stride(0);
             } else if (direct.dtype == BoundaryDtype::INT8) {
-                ptr.top_q       = direct.top_q       + field_idx * saver_.top_t.stride(0);
-                ptr.bottom_q    = direct.bottom_q    + field_idx * saver_.bottom_t.stride(0);
-                ptr.left_q      = direct.left_q      + field_idx * saver_.left_t.stride(0);
-                ptr.right_q     = direct.right_q     + field_idx * saver_.right_t.stride(0);
-                ptr.top_scale    = direct.top_scale    + field_idx * saver_.top_scale_t.stride(0);
-                ptr.bottom_scale = direct.bottom_scale + field_idx * saver_.bottom_scale_t.stride(0);
-                ptr.left_scale   = direct.left_scale   + field_idx * saver_.left_scale_t.stride(0);
-                ptr.right_scale  = direct.right_scale  + field_idx * saver_.right_scale_t.stride(0);
+                ptr.top_q       = direct.top_q       + field_idx * saver_->top_t.stride(0);
+                ptr.bottom_q    = direct.bottom_q    + field_idx * saver_->bottom_t.stride(0);
+                ptr.left_q      = direct.left_q      + field_idx * saver_->left_t.stride(0);
+                ptr.right_q     = direct.right_q     + field_idx * saver_->right_t.stride(0);
+                ptr.top_scale    = direct.top_scale    + field_idx * saver_->top_scale_t.stride(0);
+                ptr.bottom_scale = direct.bottom_scale + field_idx * saver_->bottom_scale_t.stride(0);
+                ptr.left_scale   = direct.left_scale   + field_idx * saver_->left_scale_t.stride(0);
+                ptr.right_scale  = direct.right_scale  + field_idx * saver_->right_scale_t.stride(0);
                 ptr.top    = direct.top;
                 ptr.bottom = direct.bottom;
                 ptr.left   = direct.left;
                 ptr.right  = direct.right;
             } else {
-                ptr.top = direct.top + field_idx * saver_.top_t.stride(0);
-                ptr.bottom = direct.bottom + field_idx * saver_.bottom_t.stride(0);
-                ptr.left = direct.left + field_idx * saver_.left_t.stride(0);
-                ptr.right = direct.right + field_idx * saver_.right_t.stride(0);
+                ptr.top = direct.top + field_idx * saver_->top_t.stride(0);
+                ptr.bottom = direct.bottom + field_idx * saver_->bottom_t.stride(0);
+                ptr.left = direct.left + field_idx * saver_->left_t.stride(0);
+                ptr.right = direct.right + field_idx * saver_->right_t.stride(0);
             }
             return ptr;
         }
@@ -999,24 +1009,24 @@ public:
             if (!boundary_disk_async_read_)
                 time_idx = buf_idx;
         }
-        int64_t flat_idx = static_cast<int64_t>(time_idx) * saver_.nvar + field_idx;
+        int64_t flat_idx = static_cast<int64_t>(time_idx) * saver_->nvar + field_idx;
 
         GeneralBoundaryPointer ptr{};
         ptr.use_fp16 = direct.use_fp16;
             ptr.dtype = direct.dtype;
         if (!staged_ && direct.dtype == BoundaryDtype::FP16) {
-            ptr.top_h    = direct.top_h    + flat_idx * saver_.top_stride;
-            ptr.bottom_h = direct.bottom_h + flat_idx * saver_.bottom_stride;
-            ptr.front_h  = direct.front_h  + flat_idx * saver_.front_stride;
-            ptr.back_h   = direct.back_h   + flat_idx * saver_.back_stride;
-            ptr.left_h   = direct.left_h   + flat_idx * saver_.left_stride;
-            ptr.right_h  = direct.right_h  + flat_idx * saver_.right_stride;
-            ptr.top_scale    = direct.top_scale    + flat_idx * saver_.top_scale_t.stride(0);
-            ptr.bottom_scale = direct.bottom_scale + flat_idx * saver_.bottom_scale_t.stride(0);
-            ptr.front_scale  = direct.front_scale  + flat_idx * saver_.front_scale_t.stride(0);
-            ptr.back_scale   = direct.back_scale   + flat_idx * saver_.back_scale_t.stride(0);
-            ptr.left_scale   = direct.left_scale   + flat_idx * saver_.left_scale_t.stride(0);
-            ptr.right_scale  = direct.right_scale  + flat_idx * saver_.right_scale_t.stride(0);
+            ptr.top_h    = direct.top_h    + flat_idx * saver_->top_stride;
+            ptr.bottom_h = direct.bottom_h + flat_idx * saver_->bottom_stride;
+            ptr.front_h  = direct.front_h  + flat_idx * saver_->front_stride;
+            ptr.back_h   = direct.back_h   + flat_idx * saver_->back_stride;
+            ptr.left_h   = direct.left_h   + flat_idx * saver_->left_stride;
+            ptr.right_h  = direct.right_h  + flat_idx * saver_->right_stride;
+            ptr.top_scale    = direct.top_scale    + flat_idx * saver_->top_scale_t.stride(0);
+            ptr.bottom_scale = direct.bottom_scale + flat_idx * saver_->bottom_scale_t.stride(0);
+            ptr.front_scale  = direct.front_scale  + flat_idx * saver_->front_scale_t.stride(0);
+            ptr.back_scale   = direct.back_scale   + flat_idx * saver_->back_scale_t.stride(0);
+            ptr.left_scale   = direct.left_scale   + flat_idx * saver_->left_scale_t.stride(0);
+            ptr.right_scale  = direct.right_scale  + flat_idx * saver_->right_scale_t.stride(0);
             ptr.top    = direct.top;
             ptr.bottom = direct.bottom;
             ptr.front  = direct.front;
@@ -1024,29 +1034,29 @@ public:
             ptr.left   = direct.left;
             ptr.right  = direct.right;
         } else if (!staged_ && direct.dtype == BoundaryDtype::BF16) {
-            ptr.top_bf    = direct.top_bf    + flat_idx * saver_.top_stride;
-            ptr.bottom_bf = direct.bottom_bf + flat_idx * saver_.bottom_stride;
-            ptr.front_bf  = direct.front_bf  + flat_idx * saver_.front_stride;
-            ptr.back_bf   = direct.back_bf   + flat_idx * saver_.back_stride;
-            ptr.left_bf   = direct.left_bf   + flat_idx * saver_.left_stride;
-            ptr.right_bf  = direct.right_bf  + flat_idx * saver_.right_stride;
+            ptr.top_bf    = direct.top_bf    + flat_idx * saver_->top_stride;
+            ptr.bottom_bf = direct.bottom_bf + flat_idx * saver_->bottom_stride;
+            ptr.front_bf  = direct.front_bf  + flat_idx * saver_->front_stride;
+            ptr.back_bf   = direct.back_bf   + flat_idx * saver_->back_stride;
+            ptr.left_bf   = direct.left_bf   + flat_idx * saver_->left_stride;
+            ptr.right_bf  = direct.right_bf  + flat_idx * saver_->right_stride;
         } else if (!staged_ && direct.dtype == BoundaryDtype::INT8) {
             // 3D persistent uint8 buffer: outermost index = time*nvar + field.
             // top_stride/bottom_stride/... already track per-(time×field)
             // cell counts (compute_time_strides → tensor.stride(0)).
-            ptr.top_q    = direct.top_q    + flat_idx * saver_.top_stride;
-            ptr.bottom_q = direct.bottom_q + flat_idx * saver_.bottom_stride;
-            ptr.front_q  = direct.front_q  + flat_idx * saver_.front_stride;
-            ptr.back_q   = direct.back_q   + flat_idx * saver_.back_stride;
-            ptr.left_q   = direct.left_q   + flat_idx * saver_.left_stride;
-            ptr.right_q  = direct.right_q  + flat_idx * saver_.right_stride;
+            ptr.top_q    = direct.top_q    + flat_idx * saver_->top_stride;
+            ptr.bottom_q = direct.bottom_q + flat_idx * saver_->bottom_stride;
+            ptr.front_q  = direct.front_q  + flat_idx * saver_->front_stride;
+            ptr.back_q   = direct.back_q   + flat_idx * saver_->back_stride;
+            ptr.left_q   = direct.left_q   + flat_idx * saver_->left_stride;
+            ptr.right_q  = direct.right_q  + flat_idx * saver_->right_stride;
             // Scale buffer outermost stride.
-            ptr.top_scale    = direct.top_scale    + flat_idx * saver_.top_scale_t.stride(0);
-            ptr.bottom_scale = direct.bottom_scale + flat_idx * saver_.bottom_scale_t.stride(0);
-            ptr.front_scale  = direct.front_scale  + flat_idx * saver_.front_scale_t.stride(0);
-            ptr.back_scale   = direct.back_scale   + flat_idx * saver_.back_scale_t.stride(0);
-            ptr.left_scale   = direct.left_scale   + flat_idx * saver_.left_scale_t.stride(0);
-            ptr.right_scale  = direct.right_scale  + flat_idx * saver_.right_scale_t.stride(0);
+            ptr.top_scale    = direct.top_scale    + flat_idx * saver_->top_scale_t.stride(0);
+            ptr.bottom_scale = direct.bottom_scale + flat_idx * saver_->bottom_scale_t.stride(0);
+            ptr.front_scale  = direct.front_scale  + flat_idx * saver_->front_scale_t.stride(0);
+            ptr.back_scale   = direct.back_scale   + flat_idx * saver_->back_scale_t.stride(0);
+            ptr.left_scale   = direct.left_scale   + flat_idx * saver_->left_scale_t.stride(0);
+            ptr.right_scale  = direct.right_scale  + flat_idx * saver_->right_scale_t.stride(0);
             // Staging shared across (time, field) — no offset.
             ptr.top    = direct.top;
             ptr.bottom = direct.bottom;
@@ -1055,29 +1065,29 @@ public:
             ptr.left   = direct.left;
             ptr.right  = direct.right;
         } else if (staged_) {
-            ptr.dtype = boundary_dtype_from_tensor(saver_.top_gpu);
+            ptr.dtype = boundary_dtype_from_tensor(saver_->top_gpu);
             if (ptr.dtype == BoundaryDtype::INT8 || ptr.dtype == BoundaryDtype::FP16) {
-                BIND_STAGED_SCALED(ptr.dtype, saver_.top_gpu,    flat_idx * saver_.top_stride,    saver_.top_scale_gpu,    flat_idx * saver_.top_scale_gpu.stride(0),    direct.top,    ptr.top_q,    ptr.top_h,    ptr.top_scale,    ptr.top);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.bottom_gpu, flat_idx * saver_.bottom_stride, saver_.bottom_scale_gpu, flat_idx * saver_.bottom_scale_gpu.stride(0), direct.bottom, ptr.bottom_q, ptr.bottom_h, ptr.bottom_scale, ptr.bottom);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.front_gpu,  flat_idx * saver_.front_stride,  saver_.front_scale_gpu,  flat_idx * saver_.front_scale_gpu.stride(0),  direct.front,  ptr.front_q,  ptr.front_h,  ptr.front_scale,  ptr.front);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.back_gpu,   flat_idx * saver_.back_stride,   saver_.back_scale_gpu,   flat_idx * saver_.back_scale_gpu.stride(0),   direct.back,   ptr.back_q,   ptr.back_h,   ptr.back_scale,   ptr.back);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.left_gpu,   flat_idx * saver_.left_stride,   saver_.left_scale_gpu,   flat_idx * saver_.left_scale_gpu.stride(0),   direct.left,   ptr.left_q,   ptr.left_h,   ptr.left_scale,   ptr.left);
-                BIND_STAGED_SCALED(ptr.dtype, saver_.right_gpu,  flat_idx * saver_.right_stride,  saver_.right_scale_gpu,  flat_idx * saver_.right_scale_gpu.stride(0),  direct.right,  ptr.right_q,  ptr.right_h,  ptr.right_scale,  ptr.right);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->top_gpu,    flat_idx * saver_->top_stride,    saver_->top_scale_gpu,    flat_idx * saver_->top_scale_gpu.stride(0),    direct.top,    ptr.top_q,    ptr.top_h,    ptr.top_scale,    ptr.top);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->bottom_gpu, flat_idx * saver_->bottom_stride, saver_->bottom_scale_gpu, flat_idx * saver_->bottom_scale_gpu.stride(0), direct.bottom, ptr.bottom_q, ptr.bottom_h, ptr.bottom_scale, ptr.bottom);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->front_gpu,  flat_idx * saver_->front_stride,  saver_->front_scale_gpu,  flat_idx * saver_->front_scale_gpu.stride(0),  direct.front,  ptr.front_q,  ptr.front_h,  ptr.front_scale,  ptr.front);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->back_gpu,   flat_idx * saver_->back_stride,   saver_->back_scale_gpu,   flat_idx * saver_->back_scale_gpu.stride(0),   direct.back,   ptr.back_q,   ptr.back_h,   ptr.back_scale,   ptr.back);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->left_gpu,   flat_idx * saver_->left_stride,   saver_->left_scale_gpu,   flat_idx * saver_->left_scale_gpu.stride(0),   direct.left,   ptr.left_q,   ptr.left_h,   ptr.left_scale,   ptr.left);
+                BIND_STAGED_SCALED(ptr.dtype, saver_->right_gpu,  flat_idx * saver_->right_stride,  saver_->right_scale_gpu,  flat_idx * saver_->right_scale_gpu.stride(0),  direct.right,  ptr.right_q,  ptr.right_h,  ptr.right_scale,  ptr.right);
             } else {
-            BIND_STAGED_FACE(saver_.top_gpu,    flat_idx * saver_.top_stride,    ptr.top,    ptr.top_h,    ptr.top_bf);
-            BIND_STAGED_FACE(saver_.bottom_gpu, flat_idx * saver_.bottom_stride, ptr.bottom, ptr.bottom_h, ptr.bottom_bf);
-            BIND_STAGED_FACE(saver_.front_gpu,  flat_idx * saver_.front_stride,  ptr.front,  ptr.front_h,  ptr.front_bf);
-            BIND_STAGED_FACE(saver_.back_gpu,   flat_idx * saver_.back_stride,   ptr.back,   ptr.back_h,   ptr.back_bf);
-            BIND_STAGED_FACE(saver_.left_gpu,   flat_idx * saver_.left_stride,   ptr.left,   ptr.left_h,   ptr.left_bf);
-            BIND_STAGED_FACE(saver_.right_gpu,  flat_idx * saver_.right_stride,  ptr.right,  ptr.right_h,  ptr.right_bf);
+            BIND_STAGED_FACE(saver_->top_gpu,    flat_idx * saver_->top_stride,    ptr.top,    ptr.top_h,    ptr.top_bf);
+            BIND_STAGED_FACE(saver_->bottom_gpu, flat_idx * saver_->bottom_stride, ptr.bottom, ptr.bottom_h, ptr.bottom_bf);
+            BIND_STAGED_FACE(saver_->front_gpu,  flat_idx * saver_->front_stride,  ptr.front,  ptr.front_h,  ptr.front_bf);
+            BIND_STAGED_FACE(saver_->back_gpu,   flat_idx * saver_->back_stride,   ptr.back,   ptr.back_h,   ptr.back_bf);
+            BIND_STAGED_FACE(saver_->left_gpu,   flat_idx * saver_->left_stride,   ptr.left,   ptr.left_h,   ptr.left_bf);
+            BIND_STAGED_FACE(saver_->right_gpu,  flat_idx * saver_->right_stride,  ptr.right,  ptr.right_h,  ptr.right_bf);
             }
         } else {
-            ptr.top = direct.top + flat_idx * saver_.top_stride;
-            ptr.bottom = direct.bottom + flat_idx * saver_.bottom_stride;
-            ptr.front = direct.front + flat_idx * saver_.front_stride;
-            ptr.back = direct.back + flat_idx * saver_.back_stride;
-            ptr.left = direct.left + flat_idx * saver_.left_stride;
-            ptr.right = direct.right + flat_idx * saver_.right_stride;
+            ptr.top = direct.top + flat_idx * saver_->top_stride;
+            ptr.bottom = direct.bottom + flat_idx * saver_->bottom_stride;
+            ptr.front = direct.front + flat_idx * saver_->front_stride;
+            ptr.back = direct.back + flat_idx * saver_->back_stride;
+            ptr.left = direct.left + flat_idx * saver_->left_stride;
+            ptr.right = direct.right + flat_idx * saver_->right_stride;
         }
         ptr.last_two = direct.last_two;
         return ptr;
@@ -1313,7 +1323,10 @@ public:
 private:
     using Clock = std::chrono::steady_clock;
 
-    EffectiveBoundarySaver& saver_;
+    // Pointers, not references: the persistent runtime outlives a single call
+    // while saver/disk_files are per-call locals, so they must be rebindable.
+    // See rebind().
+    EffectiveBoundarySaver* saver_ = nullptr;
     int dim_ = 2;
     bool enabled_ = false;
     bool staged_ = false;
@@ -1322,7 +1335,7 @@ private:
     int transfer_interval_ = 1;
     int ring_buffers_ = 1;
     int backward_nt_ = 0;
-    const std::vector<std::string>& disk_files_;
+    const std::vector<std::string>* disk_files_ = nullptr;
     cudaStream_t compute_stream_ = nullptr;
     cudaStream_t copy_stream_ = nullptr;
     bool profile_enabled_ = false;
@@ -1412,7 +1425,7 @@ private:
                 start_async_disk_read(start, len, slot);
             } else {
                 // The synchronous disk read below overwrites the shared CPU
-                // staging buffer (boundary_cpu / saver_.*_t).  The previous
+                // staging buffer (boundary_cpu / saver_->*_t).  The previous
                 // chunk's H2D copy reads that same buffer, so we must wait for
                 // it to finish before clobbering it — otherwise the host races
                 // ahead of the (possibly backlogged) copy stream and the
@@ -1422,23 +1435,23 @@ private:
                 cudaStreamSynchronize(copy_stream_);
                 auto read_start = Clock::now();
                 if (dim_ == 2)
-                    saver_.load_disk_to_cpu_2d(start, len, disk_files_);
+                    saver_->load_disk_to_cpu_2d(start, len, (*disk_files_));
                 else
-                    saver_.load_disk_to_cpu_3d(start, len, disk_files_);
+                    saver_->load_disk_to_cpu_3d(start, len, (*disk_files_));
                 add_disk_read_time(elapsed_seconds(read_start, Clock::now()));
                 if (profile_enabled_ && boundary_on_disk_) {
                     cudaEventRecord(backward_copy_start_[slot], copy_stream_);
                     cudaEventRecord(backward_h2d_start_[slot], copy_stream_);
                 }
                 auto enqueue_start = Clock::now();
-                saver_.load_cpu_to_gpu(0, len, copy_stream_);
+                saver_->load_cpu_to_gpu(0, len, copy_stream_);
                 add_backward_h2d_enqueue_time(elapsed_seconds(enqueue_start, Clock::now()));
                 cudaEventRecord(copy_ready_[slot], copy_stream_);
                 if (profile_enabled_ && boundary_on_disk_)
                     backward_copy_profile_pending_[slot] = 1;
             }
         } else {
-            saver_.load_cpu_to_gpu(start, len, copy_stream_);
+            saver_->load_cpu_to_gpu(start, len, copy_stream_);
             cudaEventRecord(copy_ready_[slot], copy_stream_);
         }
     }
@@ -1537,9 +1550,9 @@ private:
         cudaEventSynchronize(copy_ready_[slot]);
         auto read_start = Clock::now();
         if (dim_ == 2)
-            saver_.load_disk_to_cpu_2d(start, len, disk_files_, stage_start);
+            saver_->load_disk_to_cpu_2d(start, len, (*disk_files_), stage_start);
         else
-            saver_.load_disk_to_cpu_3d(start, len, disk_files_, stage_start);
+            saver_->load_disk_to_cpu_3d(start, len, (*disk_files_), stage_start);
         add_disk_read_time(elapsed_seconds(read_start, Clock::now()));
 
         if (profile_enabled_ && boundary_on_disk_)
@@ -1548,7 +1561,7 @@ private:
         if (profile_enabled_ && boundary_on_disk_)
             cudaEventRecord(backward_h2d_start_[slot], copy_stream_);
         auto enqueue_start = Clock::now();
-        saver_.load_cpu_to_gpu(stage_start, len, copy_stream_, stage_start);
+        saver_->load_cpu_to_gpu(stage_start, len, copy_stream_, stage_start);
         add_backward_h2d_enqueue_time(elapsed_seconds(enqueue_start, Clock::now()));
         cudaEventRecord(copy_ready_[slot], copy_stream_);
         if (profile_enabled_ && boundary_on_disk_) {

--- a/src/sweep/csrc/cuda/common/boundary/session.cu
+++ b/src/sweep/csrc/cuda/common/boundary/session.cu
@@ -1,0 +1,22 @@
+#include "session.cuh"
+
+// The public handle is a thin pimpl over BoundarySessionImpl so that the pybind
+// translation unit (host compiler) never sees CUDA types.
+
+BoundarySession::BoundarySession()
+    : impl_(std::make_unique<BoundarySessionImpl>())
+{
+}
+
+BoundarySession::~BoundarySession() = default;
+
+void BoundarySession::finish()
+{
+    if (impl_)
+        impl_->finish();
+}
+
+bool BoundarySession::used() const
+{
+    return impl_ && impl_->used();
+}

--- a/src/sweep/csrc/cuda/common/boundary/session.cuh
+++ b/src/sweep/csrc/cuda/common/boundary/session.cuh
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "runtime.cuh"
+#include "../cudautils.h"
+#include "../../../shared/boundary_session.h"
+
+// A boundary-staging session that OUTLIVES a single forward/backward call.
+//
+// WHY THIS EXISTS.  Under domain decomposition the time loop lives in Python
+// (``dd_propagator``: ``for it in range(nt): runner.run_to(it+1); exchange()``),
+// so every time step is a separate call into this extension.  Both the copy
+// stream (``AsyncCopyContext``) and the ``BoundaryRuntime``'s events used to be
+// locals of that call, which means every step ended with
+//   * ``cudaStreamDestroy(copy_stream)`` -- an implicit barrier, and
+//   * the forward's trailing ``boundary_runtime.synchronize()``.
+// A copy therefore could never still be in flight when the next step ran, so
+// ``transfer_interval`` / ``ring_buffers`` overlapped nothing under DD:
+// ``storage='cpu'`` measured ~15x slower than boundary-in-VRAM on the 2-16 Hz
+// band (29,475 steps), against +22% for the SAME staging on a single tile with
+// interval=32 / ring=4.  The knobs were not the problem; the per-step teardown
+// was.
+//
+// Holding the stream and the events in a Python-owned session removes both
+// barriers: the copy issued in step ``it`` may still be in flight while step
+// ``it+1`` computes, and the synchronize moves to the end of the phase.
+//
+// SAFETY.  Forgetting to end a phase must not corrupt results, so ``bind()``
+// synchronizes whenever the phase changes (forward -> backward) and the
+// destructor synchronizes as well.  A session bound with a DIFFERENT staging
+// configuration than the one it was created with raises rather than silently
+// reusing mismatched events/rings.
+class BoundarySessionImpl {
+public:
+    enum class Phase { None, Forward, Backward };
+
+    BoundarySessionImpl() = default;
+    BoundarySessionImpl(const BoundarySessionImpl&) = delete;
+    BoundarySessionImpl& operator=(const BoundarySessionImpl&) = delete;
+
+    ~BoundarySessionImpl() { finish(); }
+
+    // Bind the per-call objects and return the persistent runtime.  The first
+    // call builds the stream + events; later calls only re-point the runtime at
+    // this call's saver / disk-file list.
+    BoundaryRuntime& bind(
+        Phase phase,
+        EffectiveBoundarySaver& saver,
+        int dim,
+        bool use_boundary_saving,
+        bool boundary_on_cpu,
+        bool boundary_on_disk,
+        bool boundary_disk_async_read,
+        int transfer_interval,
+        int ring_buffers,
+        const std::vector<std::string>& disk_files)
+    {
+        const bool staged = boundary_on_cpu || boundary_on_disk;
+        if (!rt_.has_value()) {
+            cfg_ = Cfg{dim, use_boundary_saving, boundary_on_cpu, boundary_on_disk,
+                       boundary_disk_async_read, transfer_interval, ring_buffers};
+            async_.emplace(staged);
+            rt_.emplace(saver, dim, use_boundary_saving, boundary_on_cpu,
+                        boundary_on_disk, boundary_disk_async_read,
+                        transfer_interval, ring_buffers, disk_files,
+                        async_->compute_stream, async_->copy_stream);
+        } else {
+            Cfg want{dim, use_boundary_saving, boundary_on_cpu, boundary_on_disk,
+                     boundary_disk_async_read, transfer_interval, ring_buffers};
+            TORCH_CHECK(
+                want == cfg_,
+                "BoundarySession reused with a different staging configuration "
+                "(dim/use_bs/cpu/disk/async_read/transfer_interval/ring_buffers). "
+                "The persistent events and ring bookkeeping are sized for the "
+                "first binding; make a new session instead of rebinding.");
+            // A phase change means the previous phase's copies must land before
+            // the next phase reads the same buffers.  Doing it here (rather
+            // than trusting the caller to call finish()) keeps a forgotten
+            // end-of-phase from silently corrupting the reconstruction.
+            if (phase != phase_)
+                rt_->synchronize();
+            rt_->rebind(saver, disk_files);
+        }
+        phase_ = phase;
+        used_ = true;
+        return *rt_;
+    }
+
+    // End the current phase: let every outstanding copy land.  Python calls
+    // this after the DD time loop; the destructor repeats it so an early exit
+    // cannot leave a copy in flight.
+    void finish()
+    {
+        if (rt_.has_value())
+            rt_->synchronize();
+        phase_ = Phase::None;
+    }
+
+    // BoundaryScope needs the stream context; it is only valid after the
+    // first bind() built it.
+    AsyncCopyContext& async_ctx()
+    {
+        TORCH_CHECK(async_.has_value(),
+                    "BoundarySession::async_ctx() before the first bind()");
+        return *async_;
+    }
+
+    // Diagnostics for the tests: a session that was never bound means the call
+    // site silently fell back to the per-call path.
+    bool used() const { return used_; }
+
+private:
+    struct Cfg {
+        int dim = 0;
+        bool use_bs = false, on_cpu = false, on_disk = false, disk_async = false;
+        int transfer_interval = 0, ring_buffers = 0;
+        bool operator==(const Cfg& o) const
+        {
+            return dim == o.dim && use_bs == o.use_bs && on_cpu == o.on_cpu
+                && on_disk == o.on_disk && disk_async == o.disk_async
+                && transfer_interval == o.transfer_interval
+                && ring_buffers == o.ring_buffers;
+        }
+    };
+
+    std::optional<AsyncCopyContext> async_;
+    std::optional<BoundaryRuntime> rt_;
+    Cfg cfg_;
+    Phase phase_ = Phase::None;
+    bool used_ = false;
+};
+
+// Call-site helper: use the caller's session when one was supplied, otherwise
+// build the per-call stream + runtime exactly as before.  ``owns()`` tells the
+// call site whether the trailing synchronize is its responsibility (per-call
+// path) or the session's (persistent path).
+class BoundaryScope {
+public:
+    BoundaryScope(
+        BoundarySessionImpl* session,
+        BoundarySessionImpl::Phase phase,
+        EffectiveBoundarySaver& saver,
+        int dim,
+        bool use_boundary_saving,
+        bool boundary_on_cpu,
+        bool boundary_on_disk,
+        bool boundary_disk_async_read,
+        int transfer_interval,
+        int ring_buffers,
+        const std::vector<std::string>& disk_files)
+    {
+        const bool staged = boundary_on_cpu || boundary_on_disk;
+        if (session != nullptr) {
+            rt_ = &session->bind(phase, saver, dim, use_boundary_saving,
+                                 boundary_on_cpu, boundary_on_disk,
+                                 boundary_disk_async_read, transfer_interval,
+                                 ring_buffers, disk_files);
+            async_ = &session->async_ctx();
+            owns_ = false;
+        } else {
+            local_async_.emplace(staged);
+            local_rt_.emplace(saver, dim, use_boundary_saving, boundary_on_cpu,
+                              boundary_on_disk, boundary_disk_async_read,
+                              transfer_interval, ring_buffers, disk_files,
+                              local_async_->compute_stream,
+                              local_async_->copy_stream);
+            rt_ = &*local_rt_;
+            async_ = &*local_async_;
+            owns_ = true;
+        }
+    }
+
+    BoundaryRuntime& runtime() { return *rt_; }
+    AsyncCopyContext& async() { return *async_; }
+    bool owns() const { return owns_; }
+
+private:
+    std::optional<AsyncCopyContext> local_async_;
+    std::optional<BoundaryRuntime> local_rt_;
+    BoundaryRuntime* rt_ = nullptr;
+    AsyncCopyContext* async_ = nullptr;
+    bool owns_ = true;
+};

--- a/src/sweep/csrc/cuda/common/cudautils.h
+++ b/src/sweep/csrc/cuda/common/cudautils.h
@@ -104,7 +104,19 @@ struct AsyncCopyContext {
           enabled(enable)
     {
         if (!enabled) return;
-        cudaStreamCreate(&copy_stream);
+        // cudaStreamCreate makes a BLOCKING stream, which is implicitly
+        // synchronised against the legacy default stream. compute_stream is
+        // at::cuda::getCurrentCUDAStream(), and PyTorch's default IS the legacy
+        // default stream -- so every operation on copy_stream serialised against
+        // all compute and this "async copy stream" was never concurrent.
+        // The real dependencies are stated explicitly by ready_event /
+        // wait_for_compute / wait_for_copy below, so dropping the implicit sync
+        // does not affect correctness (checked by the bit-exact gates).
+        // This is also why non-DD gains only +22% while DD gains 15x: non-DD runs
+        // the whole time loop inside one extension call and hits few
+        // serialisation points, whereas DD calls in once per time step and hits
+        // this implicit sync on every one of them.
+        cudaStreamCreateWithFlags(&copy_stream, cudaStreamNonBlocking);
         cudaEventCreateWithFlags(&ready_event, cudaEventDisableTiming);
     }
 

--- a/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/backward.cu
@@ -7,6 +7,7 @@
 #include "../../common/context.h"
 #include "../../common/acoustic.h"
 #include "../../common/checkpoint_runtime.cuh"
+#include "../../common/boundary/session.cuh"
 #include "../../common/cudautils.h"
 #include "../../common/wavetypes.h"
 #include "../../common/boundarysaver.cuh"
@@ -890,8 +891,9 @@ void run_bs_imaging(
     GradParam grad_ctx_y{1, 0, 0, p.M, p.grad_coes.data_ptr<float>(), dy, 0.f, 0.f};
     GradParam grad_ctx_z{1, 0, 0, p.M, p.grad_coes.data_ptr<float>(), dz, 0.f, 0.f};
 
-    AsyncCopyContext async_copy(staged_boundary);
-    BoundaryRuntime boundary_runtime(
+    BoundaryScope boundary_scope(
+        p.boundary_session ? p.boundary_session->impl() : nullptr,
+        BoundarySessionImpl::Phase::Backward,
         boundary_saver,
         3,
         true,
@@ -900,10 +902,9 @@ void run_bs_imaging(
         p.boundary_disk_async_read,
         p.transfer_interval,
         p.boundary_ring_buffers,
-        p.boundary_disk_files,
-        async_copy.compute_stream,
-        async_copy.copy_stream
-    );
+        p.boundary_disk_files);
+    AsyncCopyContext& async_copy = boundary_scope.async();
+    BoundaryRuntime& boundary_runtime = boundary_scope.runtime();
     // Boundary tail truncation -- see acoustic2d/backward.cu (stepped/DD
     // segments and cut faces compose; the driver must not issue segments
     // entirely below bs_stop).

--- a/src/sweep/csrc/cuda/equations/acoustic3d/forward.cu
+++ b/src/sweep/csrc/cuda/equations/acoustic3d/forward.cu
@@ -10,6 +10,7 @@
 #include "../../common/context.h"
 #include "../../common/acoustic.h"
 #include "../../common/checkpoint_runtime.cuh"
+#include "../../common/boundary/session.cuh"
 #include "../../common/cudautils.h"
 #include "../../common/wavetypes.h"
 #include "../../common/boundarysaver.cuh"
@@ -185,12 +186,9 @@ ForwardOutput forward(const ForwardInput& in)
     GradParam grad_ctx_y{1, 0, 0, M, p.grad_coes.data_ptr<float>(), dy, 0.f, 0.f};
     GradParam grad_ctx_z{1, 0, 0, M, p.grad_coes.data_ptr<float>(), dz, 0.f, 0.f};
 
-    AsyncCopyContext async_copy(staged_boundary && p.use_boundary_saving);
-    // Boundary tail truncation -- see acoustic2d/forward.cu (stepped/DD
-    // segments compose: global ``it``, tail-shrunk Python-bound ring).
-    const int bs_it0 = (p.use_boundary_saving && p.boundary_tail_steps > 0)
-        ? std::max(0, (int)nt - p.boundary_tail_steps) : 0;
-    BoundaryRuntime boundary_runtime(
+    BoundaryScope boundary_scope(
+        p.boundary_session ? p.boundary_session->impl() : nullptr,
+        BoundarySessionImpl::Phase::Forward,
         boundary_saver,
         3,
         p.use_boundary_saving,
@@ -199,10 +197,13 @@ ForwardOutput forward(const ForwardInput& in)
         p.boundary_disk_async_read,
         p.transfer_interval,
         p.boundary_ring_buffers,
-        p.boundary_disk_files,
-        async_copy.compute_stream,
-        async_copy.copy_stream
-    );
+        p.boundary_disk_files);
+    AsyncCopyContext& async_copy = boundary_scope.async();
+    BoundaryRuntime& boundary_runtime = boundary_scope.runtime();
+    // Boundary tail truncation -- see acoustic2d/forward.cu (stepped/DD
+    // segments compose: global ``it``, tail-shrunk Python-bound ring).
+    const int bs_it0 = (p.use_boundary_saving && p.boundary_tail_steps > 0)
+        ? std::max(0, (int)nt - p.boundary_tail_steps) : 0;
     // ============================================================
     // time stepping
     // ============================================================
@@ -321,7 +322,10 @@ ForwardOutput forward(const ForwardInput& in)
         boundary_saver.last_two_t.select(1,1).copy_(wavefield.u_now_t);
     }
 
-    boundary_runtime.synchronize();
+    // With a persistent session the trailing sync belongs to the phase,
+    // not to this one step -- Python calls session.finish().
+    if (boundary_scope.owns())
+        boundary_runtime.synchronize();
 
     out.wavefield = u_allt;
     out.last_two = boundary_saver.last_two_t;

--- a/src/sweep/csrc/shared/boundary_session.h
+++ b/src/sweep/csrc/shared/boundary_session.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <memory>
+
+// Handle for a boundary-staging session that outlives a single forward/backward
+// call.  Declared here (plain C++, no CUDA) so the pybind translation unit --
+// compiled by the host compiler -- can bind it; the implementation lives in
+// cuda/common/boundary/session.cu.
+//
+// See cuda/common/boundary/session.cuh for WHY this exists: under domain
+// decomposition every time step is a separate call into the extension, so a
+// per-call copy stream can never keep a transfer in flight across steps.
+class BoundarySessionImpl;
+
+class BoundarySession {
+public:
+    BoundarySession();
+    ~BoundarySession();
+    BoundarySession(const BoundarySession&) = delete;
+    BoundarySession& operator=(const BoundarySession&) = delete;
+
+    // Let every outstanding copy land and close the current phase.  Python
+    // calls this after a DD time loop; the destructor repeats it.
+    void finish();
+
+    // False means no call site ever bound this session -- i.e. the staging
+    // silently fell back to the per-call path.  Tests assert on it.
+    bool used() const;
+
+    BoundarySessionImpl* impl() const { return impl_.get(); }
+
+private:
+    std::unique_ptr<BoundarySessionImpl> impl_;
+};

--- a/src/sweep/csrc/shared/wavetypes.h
+++ b/src/sweep/csrc/shared/wavetypes.h
@@ -3,6 +3,7 @@
 #include <torch/extension.h>
 #include <string>
 #include <vector>
+#include "boundary_session.h"
 
 
 struct ForwardInput {
@@ -87,6 +88,11 @@ struct ForwardInput {
     // shrinks.  0 = disabled (bit-exact legacy behaviour).  Both directions
     // MUST share the same value or the reconstruction misaligns.
     int boundary_tail_steps = 0;
+    // Optional persistent staging session.  Null (the default) keeps the
+    // per-call copy stream + BoundaryRuntime, i.e. exactly the old
+    // behaviour.  DD sets it so a transfer can stay in flight across the
+    // per-step calls.
+    std::shared_ptr<BoundarySession> boundary_session;
     int checkpoint_interval = 1;
     int checkpoint_count = 0;
 
@@ -230,6 +236,11 @@ struct BackwardInput {
     int transfer_interval = 1; // Transfer every time step by default
     int boundary_ring_buffers = 1;
     int boundary_tail_steps = 0;   // see ForwardInput::boundary_tail_steps
+    // Optional persistent staging session.  Null (the default) keeps the
+    // per-call copy stream + BoundaryRuntime, i.e. exactly the old
+    // behaviour.  DD sets it so a transfer can stay in flight across the
+    // per-step calls.
+    std::shared_ptr<BoundarySession> boundary_session;
     int checkpoint_interval = 1;
     int checkpoint_count = 0;
 

--- a/src/sweep/parallel/dd_propagator.py
+++ b/src/sweep/parallel/dd_propagator.py
@@ -437,6 +437,16 @@ class ModelParallel:
             self._halo_sl_cache[(field.ndim, ax)] = sl
         return field[sl]
 
+    def _finish_boundary_phase(self):
+        """Let the phase's outstanding boundary copies land.
+
+        Belt and braces: ``BoundarySession::bind`` already synchronizes when the
+        phase flips (forward -> backward), so forgetting this cannot corrupt the
+        reconstruction -- it only leaves the last copies in flight a bit longer.
+        """
+        if getattr(self, "_bsession", None) is not None:
+            self._bsession.finish()
+
     def _exchange(self, halo, tensor):
         if halo is not None:
             for ax, hs in halo.items():
@@ -633,6 +643,26 @@ class ModelParallel:
             impl.forward_func, impl.backward_bs_func = f_orig, b_orig
 
         self.fp, self.bp = cap["fp"], cap.get("bp")
+        # Persistent boundary-staging session.  Under DD every time step is a
+        # separate call into the extension, so a per-call copy stream can never
+        # keep a transfer in flight across steps -- transfer_interval /
+        # ring_buffers then overlap nothing and storage='cpu' degenerates into
+        # one un-overlapped PCIe round trip per step.  Handing the SAME session
+        # to every step lets the copy issued in step ``it`` still be in flight
+        # while step ``it+1`` computes.  Only built for staged storage; the
+        # VRAM path is untouched (session stays None -> old behaviour).
+        self._bsession = None
+        if self._bstorage != "gpu":
+            try:
+                from sweep import _C as _sweep_C
+                self._bsession = _sweep_C.BoundarySession()
+            except AttributeError:
+                # Extension predates the session API: fall back silently to the
+                # per-call path, which is correct, just not overlapped.
+                self._bsession = None
+        for _p in (self.fp, self.bp):
+            if _p is not None and self._bsession is not None:
+                _p.boundary_session = self._bsession
         self.f_func, self.b_func = f_orig, b_orig
         self._cuda_ndim = cap["fraw"][2].ndim
 

--- a/test/dd_session_bench.py
+++ b/test/dd_session_bench.py
@@ -43,9 +43,20 @@ PY, PX = int(os.environ.get("MESH_PY", 2)), int(os.environ.get("MESH_PX", world 
 assert PY * PX == world, (PY, PX, world)
 # Keep nt large: the staging cost scales with the step count, and 140 steps
 # is too few to show a trend.
-dh, dt, nt, abcn, order = 10.0, 0.001, int(os.environ.get("NT", 1200)), 12, 8
-nz, ny, nx = 48, int(os.environ.get("MESH_NY", 96)), 48 * PX
+_e = lambda k, d, f=int: f(os.environ.get(k, d))
+# The whole geometry is an env knob: only at production's boundary-bytes per
+# grid-point ratio does the measured staging cost match what production sees.
+# The original bench (48x96x48PX, order 8) is ~55 kB of boundary per step over
+# 110 k points = 0.5; production (384x518x240, order 4) is 1.66 MB over 47.5 M
+# = 0.035, a factor of 14 -- the small case AMPLIFIES the staging cost.
+dh, dt = _e("DH", 10.0, float), _e("DT", 0.001, float)
+nt, abcn, order = _e("NT", 1200), _e("ABCN", 12), _e("ORDER", 8)
+nz = _e("MESH_NZ", 48)
+ny = _e("MESH_NY", 96)
+nx = _e("MESH_NX_PER", 48) * PX
 shape = (nz, ny, nx)
+BDTYPE = os.environ.get("BDTYPE", "fp32")
+PINNED = os.environ.get("PINNED", "1") == "1"   # default matches production
 
 zramp = np.linspace(0, 1, nz, dtype=np.float32)
 vp_true = (2000.0 + 700.0 * np.linspace(0, 1, int(np.prod(shape)), dtype=np.float32)
@@ -63,8 +74,16 @@ rec = np.stack([gx.ravel(), gy.ravel(), np.ones(gx.size, np.int32)], -1)[None].a
 def run(storage, interval=1, ring=1):
     torch.cuda.empty_cache()
     torch.cuda.reset_peak_memory_stats()
-    cfg = {"enabled": True, "storage": storage, "storage_dtype": "fp32",
-           "transfer_interval": interval, "ring_buffers": ring}
+    # PINNED has to be passed explicitly: dd_propagator.py:261 reads
+    #   self._bpinned = bool(_bcfg.get("pinned_memory") or False)
+    # straight off the raw dict, so a missing key is False and sweep's
+    # cpu_pinned_memory=True default is bypassed. An unpinned cudaMemcpyAsync is
+    # synchronous, so no overlap is possible at all. Production sets
+    # pinned_memory: True, which is why earlier benches were not comparable to
+    # production along this axis.
+    cfg = {"enabled": True, "storage": storage, "storage_dtype": BDTYPE,
+           "transfer_interval": interval, "ring_buffers": ring,
+           "pinned_memory": PINNED}
     prop = PropTorch(Acoustic3D(spatial_order=order, device=dev), backend="torch",
                      impl="c", shape=shape, dh=dh, dt=dt, nt=nt, abcn=abcn,
                      source_type=["h1"], receiver_type=["h1"], dev=dev,
@@ -92,11 +111,18 @@ def agree(ga, gb):
 
 P = (lambda *a: print(*a, flush=True)) if rank == 0 else (lambda *a: None)
 P(f"tree = {os.path.dirname(os.path.dirname(__import__('sweep').__file__))}")
-P(f"mesh {PY}x{PX}  shape {shape}  nt {nt}  world {world}")
+P(f"mesh {PY}x{PX}  shape {shape}  nt {nt}  order {order}  abcn {abcn}  "
+  f"dtype {BDTYPE}  pinned {PINNED}  world {world}")
+_cells = (shape[0] * (shape[1] // PY) * (shape[2] // PX))
+P(f"points per rank {_cells/1e6:.1f}M   (production 2-14 Hz band is 47.7M)")
+_steps = 3 * nt   # obs forward + gradient forward + backward
+P(f"~{_steps} steps per run; production measures 27.7 ms/step -> at the same\n"
+  f"   scale one run is ~{_steps*0.0277:.0f} s")
 
 gref, pref, tref, _ = run("gpu")
 P(f"\n{'config':>26} {'sec':>8} {'vs gpu':>8} {'peak GB':>8} {'bitex':>6} {'session.used':>13}")
-P(f"{'gpu (baseline)':>26} {tref:>8.2f} {1.0:>8.2f} {pref:>8.2f} {'-':>6} {'-':>13}")
+P(f"{'gpu (baseline)':>26} {tref:>8.2f} {1.0:>8.2f} {pref:>8.2f} {'-':>6} {'-':>13}"
+  f"   {tref/_steps*1e3:>6.2f} ms/step")
 
 rows, fail = [], []
 for interval, ring in ((1, 1), (32, 1), (32, 4), (64, 4)):
@@ -105,7 +131,8 @@ for interval, ring in ((1, 1), (32, 1), (32, 4), (64, 4)):
     g2, _, _, _ = run("cpu", interval, ring)
     bit2, mad2 = agree(g, g2)
     tag = f"cpu interval={interval} ring={ring}"
-    P(f"{tag:>26} {el:>8.2f} {el/tref:>7.2f}x {pk:>8.2f} {str(bit):>6} {str(used):>13}")
+    P(f"{tag:>26} {el:>8.2f} {el/tref:>7.2f}x {pk:>8.2f} {str(bit):>6} {str(used):>13}"
+      f"   {el/_steps*1e3:>6.2f} ms/step")
     if not bit:
         fail.append(f"{tag}: not bit-exact vs gpu, max|d|={mad:.3e}")
     if not bit2:

--- a/test/dd_session_bench.py
+++ b/test/dd_session_bench.py
@@ -1,0 +1,124 @@
+"""DD boundary staging: correctness gates + a (storage x interval x ring) wall-clock matrix.
+
+Run with: torchrun --standalone --nproc-per-node=2 dd_session_bench.py
+Whichever tree PYTHONPATH points at is the tree under test.
+
+**Gates (fail one and the timings do not count)**
+  A  every staged config's gradient must be BIT-EXACT against storage='gpu'
+  B  two runs of the same cpu config must be bit-exact against each other -- a
+     single comparison can pass by luck, two cannot. (Staging reuses someone
+     else's ring machinery with shifted addressing, and that class of change has
+     produced races visible only on the second run: silent under initcheck and
+     unchanged under CUDA_LAUNCH_BLOCKING.)
+  C  session.used must be True for staged configs, otherwise the call site fell
+     back to the per-call path and the timings mean nothing.
+
+**Why sweep interval/ring**: one non-overlapped PCIe round trip per step is the
+root of storage='cpu' being slow. PR #77 let DD inherit those two knobs, but the
+synchronize at the end of forward and the per-step teardown of the copy stream
+were still there; the persistent session is what removes them. Running the same
+matrix on both trees is what separates "the knobs took effect" from "the
+barriers were removed".
+"""
+import json
+import os
+import sys
+import time
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+from sweep.equations import Acoustic3D
+from sweep.parallel import MeshTopology, ModelParallel
+from sweep.propagator.torch import PropTorch
+
+dist.init_process_group("nccl")
+rank, world = dist.get_rank(), dist.get_world_size()
+li = int(os.environ.get("LOCAL_RANK", rank)) % max(1, torch.cuda.device_count())
+torch.cuda.set_device(li)
+dev = torch.device(f"cuda:{li}")
+
+PY, PX = int(os.environ.get("MESH_PY", 2)), int(os.environ.get("MESH_PX", world // 2))
+assert PY * PX == world, (PY, PX, world)
+# Keep nt large: the staging cost scales with the step count, and 140 steps
+# is too few to show a trend.
+dh, dt, nt, abcn, order = 10.0, 0.001, int(os.environ.get("NT", 1200)), 12, 8
+nz, ny, nx = 48, int(os.environ.get("MESH_NY", 96)), 48 * PX
+shape = (nz, ny, nx)
+
+zramp = np.linspace(0, 1, nz, dtype=np.float32)
+vp_true = (2000.0 + 700.0 * np.linspace(0, 1, int(np.prod(shape)), dtype=np.float32)
+           ).reshape(shape)
+vp_init = np.broadcast_to(2000.0 + 700.0 * zramp.reshape(nz, 1, 1),
+                          shape).astype(np.float32).copy()
+t = np.arange(nt) * dt
+a = np.pi * 12.0 * (t - 0.06)
+wav = ((1 - 2 * a ** 2) * np.exp(-a ** 2) * 1e3).astype(np.float32)
+src = np.array([[[nx // 2, ny // 2, 1]]], np.int32)
+gx, gy = np.meshgrid(np.arange(2, nx, 4), np.arange(2, ny, 4), indexing="xy")
+rec = np.stack([gx.ravel(), gy.ravel(), np.ones(gx.size, np.int32)], -1)[None].astype(np.int32)
+
+
+def run(storage, interval=1, ring=1):
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    cfg = {"enabled": True, "storage": storage, "storage_dtype": "fp32",
+           "transfer_interval": interval, "ring_buffers": ring}
+    prop = PropTorch(Acoustic3D(spatial_order=order, device=dev), backend="torch",
+                     impl="c", shape=shape, dh=dh, dt=dt, nt=nt, abcn=abcn,
+                     source_type=["h1"], receiver_type=["h1"], dev=dev,
+                     boundary_saving_config=cfg)
+    ddp = ModelParallel(prop, MeshTopology(py=PY, px=PX, shot_groups=1,
+                                           world_size=world, rank=rank))
+    obs = ddp(wav, src, rec, models=[vp_true]).detach().clone()
+    vp_g = torch.tensor(vp_init, device=dev, requires_grad=True)
+    torch.cuda.synchronize(); dist.barrier(); t0 = time.perf_counter()
+    (0.5 * (ddp(wav, src, rec, models=[vp_g]) - obs).pow(2).sum()).backward()
+    torch.cuda.synchronize(); dist.barrier(); el = time.perf_counter() - t0
+    sess = getattr(getattr(ddp, "_bsession", None), "used", None)
+    return (vp_g.grad.detach().clone(), torch.cuda.max_memory_allocated() / 1e9,
+            el, sess)
+
+
+def agree(ga, gb):
+    """All-rank verdict: if any tile is not bit-exact, the gate fails."""
+    bit = torch.tensor([1.0 if torch.equal(ga, gb) else 0.0], device=dev)
+    mad = torch.tensor([float((ga - gb).abs().max())], device=dev)
+    dist.all_reduce(bit, op=dist.ReduceOp.MIN)
+    dist.all_reduce(mad, op=dist.ReduceOp.MAX)
+    return bool(bit.item()), float(mad.item())
+
+
+P = (lambda *a: print(*a, flush=True)) if rank == 0 else (lambda *a: None)
+P(f"tree = {os.path.dirname(os.path.dirname(__import__('sweep').__file__))}")
+P(f"mesh {PY}x{PX}  shape {shape}  nt {nt}  world {world}")
+
+gref, pref, tref, _ = run("gpu")
+P(f"\n{'config':>26} {'sec':>8} {'vs gpu':>8} {'peak GB':>8} {'bitex':>6} {'session.used':>13}")
+P(f"{'gpu (baseline)':>26} {tref:>8.2f} {1.0:>8.2f} {pref:>8.2f} {'-':>6} {'-':>13}")
+
+rows, fail = [], []
+for interval, ring in ((1, 1), (32, 1), (32, 4), (64, 4)):
+    g, pk, el, used = run("cpu", interval, ring)
+    bit, mad = agree(gref, g)
+    g2, _, _, _ = run("cpu", interval, ring)
+    bit2, mad2 = agree(g, g2)
+    tag = f"cpu interval={interval} ring={ring}"
+    P(f"{tag:>26} {el:>8.2f} {el/tref:>7.2f}x {pk:>8.2f} {str(bit):>6} {str(used):>13}")
+    if not bit:
+        fail.append(f"{tag}: not bit-exact vs gpu, max|d|={mad:.3e}")
+    if not bit2:
+        fail.append(f"{tag}: two runs differ, max|d|={mad2:.3e}")
+    rows.append(dict(interval=interval, ring=ring, sec=el, ratio=el / tref,
+                     peak_gb=pk, bitexact=bit, repeat_bitexact=bit2, used=used))
+
+if rank == 0:
+    json.dump(dict(baseline_sec=tref, baseline_peak=pref, rows=rows),
+              open(os.environ.get("OUT", "/tmp/dd_session_bench.json"), "w"), indent=1)
+    P("\n=== gates ===")
+    for f in fail:
+        P("  FAIL " + f)
+    P("  all bit-exact" if not fail else f"  {len(fail)} gate(s) failed")
+dist.barrier()
+sys.exit(1 if fail else 0)


### PR DESCRIPTION
Stacked on #80 (`fix/bs-backward-last-two`) — review/merge that first. Base is that
branch, so this diff is only the two commits below; GitHub retargets it to `dev`
when #80 merges.

Two commits.

**`feat(dd): persistent boundary staging session`** — under DD every time step is
a separate call into the extension, so the copy stream and the ring events were
built and torn down per step. A transfer could never stay in flight and
`transfer_interval` / `ring_buffers` overlapped nothing. They now live in a
Python-owned session.

**`perf(dd): non-blocking copy stream, multi-slot backward staging`** —
`cudaStreamCreate` makes a *blocking* stream, implicitly synchronised against the
legacy default stream that PyTorch computes on, so every staged copy serialised
against all compute. Plus: per-slot backward ring (the old `gpu_start=0` packed
every chunk into slot 0, which made `ring_buffers` a no-op on the backward path),
prefetch at chunk end, and an explicit write-after-read guard that the blocking
stream used to provide implicitly.

### Gates
Bit-exact gradients vs `storage=gpu` on 2 ranks for interval/ring 1/1, 32/1,
32/4, 64/4, and bit-exact across two runs of the same config (a single
comparison can pass by luck). `session.used == True` on every staged config, so
the timings are not measuring a silent fallback to the per-call path.
`dd_offload_check` A-D still pass. Harness: `test/dd_session_bench.py`.

### Honest performance status
`ddbench` shows 2.32x -> 1.98x (interval=1) and 1.89x -> 1.64x (32/4) for the
session, and a further -18% for the stream/multi-slot commit.

**On production this bought nothing.** The same band went 1760.3 -> 1851.2
s/iteration with loss and `peak_gb` bit-identical. At that time the backward was
~10x too slow (the bug fixed in #80) and the forward these changes help was
2.5% of the iteration, so the ceiling was small. After that fix the split is
fwd 32% / bwd 58%, and this branch has **not** been re-measured in that regime.

Merging it is a correctness/plumbing argument — two real CUDA usage errors, the
knobs now do what they claim — not a proven production speedup.

