### PR TITLE
fix(boundary): disk-staged backward restored the wrong chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,21 @@ and this project adheres to
   support Material grid-card layouts.
 
 ### Fixed
+- **Disk-staged boundary saving reconstructed a wrong gradient.**  Since the
+  persistent staging session / non-blocking copy stream (PR #81), every
+  `storage='disk'` gradient was wrong: max|disk-gpu|/scale 0.2-0.5 for acoustic
+  2-D/3-D and 0.8-5.0 for nvar>1 3-D (Elastic3D, DASMu3D); cpu staging with
+  `ring_buffers >= 2` was off by 1.4-2.4x on the same equations.  Three defects in
+  `boundary/runtime.cuh`: (1) `prefetch_next_backward_chunk_if_needed` issued
+  the next chunk early on `ring_buffers >= 2`, but the synchronous disk path is
+  pinned to slot 0 whatever `ring_buffers` says (and defaults to 3 / 2), so the
+  early H2D overwrote the chunk still being restored -- the predicate is now the
+  slot assignment; (2) the synchronous-disk enqueue never got the
+  `cudaStreamWaitEvent(compute_ready_)` write-after-read fence the host-staging
+  branch has; (3) the two nvar>1 restore readers kept the slot-0 override for
+  cpu staging with `ring_buffers >= 2`.  Regression test
+  `test/test_boundary_disk_staging_slot.py`: disk (default knobs and short
+  chunks) and cpu ring 2 must be bit-exact against gpu-direct.
 - **CPML aux writes on a domain-decomposition cut tile.**  With the strip
   allocation, the per-axis PML compute band reaches columns on a cut face that
   carry no slab storage; the unclamped index produced a negative offset and the

--- a/src/sweep/csrc/cuda/common/boundary/runtime.cuh
+++ b/src/sweep/csrc/cuda/common/boundary/runtime.cuh
@@ -921,7 +921,14 @@ public:
                 int chunk_start = it - 1 - buf_idx;
                 int slot_start = backward_slot_for_chunk(chunk_start) * transfer_interval_;
                 int gpu_idx = slot_start + buf_idx;
-                if (!boundary_disk_async_read_)
+                // Only the SYNCHRONOUS DISK path is pinned to slot 0 (see
+                // backward_slot_for_chunk); host staging rotates slots and must
+                // read the one the prefetch wrote.  76505cc narrowed this guard
+                // in backward_restore_ptrs but missed the two nvar>1 readers,
+                // which made cpu staging with ring_buffers>=2 read slot 0 while
+                // the H2D landed in slot k.  Latent only because
+                // cpu_ring_buffers defaults to 1.
+                if (boundary_on_disk_ && !boundary_disk_async_read_)
                     gpu_idx = buf_idx;
 
                 ptr.dtype = boundary_dtype_from_tensor(saver_->top_gpu);
@@ -1006,7 +1013,9 @@ public:
             int chunk_start = it - 1 - buf_idx;
             int slot_start = backward_slot_for_chunk(chunk_start) * transfer_interval_;
             time_idx = slot_start + buf_idx;
-            if (!boundary_disk_async_read_)
+            // See backward_restore_ptrs_field (2-D): only synchronous disk is
+            // slot-0 pinned.
+            if (boundary_on_disk_ && !boundary_disk_async_read_)
                 time_idx = buf_idx;
         }
         int64_t flat_idx = static_cast<int64_t>(time_idx) * saver_->nvar + field_idx;
@@ -1296,19 +1305,6 @@ public:
 
         int buf_idx = (it - 1) % transfer_interval_;
         int cur_start = it - 1 - buf_idx;
-        // ring>=2: issue the next chunk on entry to the current one -- the same
-        // point as wait_before_backward_restore -- so the copy overlaps this
-        // chunk's transfer_interval steps of compute. ring==1 has a single slot
-        // where issuing early would overwrite data still being read, so it keeps
-        // the original "compute, then issue" (no overlap, but correct).
-        const bool early = (ring_buffers_ >= 2);
-        if (early) {
-            if (buf_idx != backward_chunk_len(cur_start) - 1)
-                return;
-        } else {
-            if (buf_idx != 0)
-                return;
-        }
 
         int chunk_id = (it - 1) / transfer_interval_;
         int next_chunk = chunk_id - 1;
@@ -1316,6 +1312,33 @@ public:
             return;
 
         int next_start = next_chunk * transfer_interval_;
+
+        // Issue the next chunk on ENTRY to the current one -- the same point as
+        // wait_before_backward_restore -- so the copy overlaps this chunk's
+        // transfer_interval steps of compute.  That is only safe when the next
+        // chunk lands in a DIFFERENT ring slot; when it reuses this slot the
+        // early H2D would overwrite boundary data the current chunk's restore
+        // is still reading, so fall back to "compute, then issue" (no overlap,
+        // but correct).
+        //
+        // The predicate must be the slot assignment itself, not ring_buffers_.
+        // backward_slot_for_chunk() pins the SYNCHRONOUS disk path to slot 0
+        // whatever ring_buffers_ says, and that path defaults to
+        // disk_ring_buffers_2d = 3 / _3d = 2 (options.py) -- so keying off
+        // ring_buffers_ >= 2 turned early issue on for a single-slot path whose
+        // prefetch_backward_chunk() has no compute_ready_ write-after-read guard
+        // (only the host-staging branch got one).  Every bs_disk gate case and
+        // the three disk cases in test_boundary_storage_dtype_validation.py
+        // reconstructed a wrong gradient as a result.
+        const bool early =
+            backward_slot_for_chunk(cur_start) != backward_slot_for_chunk(next_start);
+        if (early) {
+            if (buf_idx != backward_chunk_len(cur_start) - 1)
+                return;
+        } else {
+            if (buf_idx != 0)
+                return;
+        }
         int remain = nt - next_start;
         int next_len = remain < transfer_interval_ ? remain : transfer_interval_;
         prefetch_backward_chunk(next_start, next_len,
@@ -1448,8 +1471,10 @@ private:
                 // it to finish before clobbering it — otherwise the host races
                 // ahead of the (possibly backlogged) copy stream and the
                 // in-flight H2D picks up this chunk's freshly-read bytes,
-                // scrambling the restored boundary for nvar>1.  (ring_buffers
-                // is 1 on this path, so the staging buffer is reused verbatim.)
+                // scrambling the restored boundary for nvar>1.  This path is
+                // pinned to a single slot by backward_slot_for_chunk(), so the
+                // staging buffer is reused verbatim -- note that ring_buffers_
+                // itself is NOT 1 here (disk defaults are 3 in 2-D, 2 in 3-D).
                 cudaStreamSynchronize(copy_stream_);
                 auto read_start = Clock::now();
                 if (dim_ == 2)
@@ -1461,6 +1486,16 @@ private:
                     cudaEventRecord(backward_copy_start_[slot], copy_stream_);
                     cudaEventRecord(backward_h2d_start_[slot], copy_stream_);
                 }
+                // Write-after-read, the same fence the host-staging branch
+                // below carries.  copy_stream_ is NON-BLOCKING since 76505cc, so
+                // it is no longer implicitly ordered behind the default stream
+                // PyTorch computes on: without this, the H2D can start
+                // overwriting slot 0 while the current chunk's last restore
+                // kernels are still reading it.  nvar>1 3-D lost that race
+                // deterministically (elastic3d / das_mu3d bs_disk); nvar=1 won it
+                // by having a smaller H2D, which is exactly how the earlier
+                // CPU-staging race in this function presented too.
+                cudaStreamWaitEvent(copy_stream_, compute_ready_[slot], 0);
                 auto enqueue_start = Clock::now();
                 saver_->load_cpu_to_gpu(0, len, copy_stream_);
                 add_backward_h2d_enqueue_time(elapsed_seconds(enqueue_start, Clock::now()));

--- a/test/test_boundary_disk_staging_slot.py
+++ b/test/test_boundary_disk_staging_slot.py
@@ -1,0 +1,167 @@
+"""Staged (disk / cpu) boundary saving must reconstruct the SAME gradient as
+gpu-direct -- bit-for-bit, on the synchronous paths.
+
+Regression test for the PR #81 staging defect (848a100 + 76505cc):
+
+1. ``prefetch_next_backward_chunk_if_needed`` issued the next chunk's H2D early
+   whenever ``ring_buffers >= 2``, but ``backward_slot_for_chunk`` pins the
+   synchronous DISK path to slot 0 regardless of ``ring_buffers`` -- and that
+   path DEFAULTS to ring 3 (2-D) / 2 (3-D).  The early copy overwrote the slot
+   the current chunk was still restoring from.  On the unfixed tree this file
+   sees max|disk-gpu|/scale = 0.18 / 0.22 (Acoustic 2-D / 3-D, default knobs),
+   0.22 / 0.52 with short chunks, and 0.8-5.0 on Elastic3D / DASMu3D.
+2. ``copy_stream`` became non-blocking in 76505cc, but the synchronous-disk
+   enqueue in ``prefetch_backward_chunk`` never got the matching
+   ``cudaStreamWaitEvent(compute_ready_[slot])`` write-after-read fence.
+   nvar>1 3-D (elastic3d, das_mu3d) lost that race deterministically:
+   the multi-field H2D is large enough to still be landing while the
+   restore kernels read, and #1 alone does not explain the 1.2-5.0x errors.
+3. The two nvar>1 restore readers kept the slot-0 override for ALL non-async
+   staging, so cpu staging with ``ring_buffers >= 2`` read slot 0 while the
+   prefetch landed in slot k.  Latent on defaults (cpu ring = 1); with ring 2
+   the unfixed tree is off by 1.4-2.4x on Elastic3D / DASMu3D.
+
+Why bit-exact and not a tolerance: the compiled path is reproducible on one
+GPU (run twice, identical bits), and gpu-direct / cpu-staged / sync-disk-staged
+all execute the same restore kernels on the same numbers -- only WHERE the
+boundary bytes waited differs.  A tolerance would have hidden #1 behind
+"chunking noise"; it is corruption, and the assertion says so.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+
+def _binding_ready():
+    if not torch.cuda.is_available():
+        return False
+    try:
+        from sweep import is_torch_binding_available
+        return bool(is_torch_binding_available())
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _binding_ready(), reason="CUDA + compiled sweep._C required")
+
+DEV = "cuda"
+
+
+def _models_2d(nz, nx, elastic):
+    vp = np.full((nz, nx), 2000.0, dtype=np.float32)
+    vp[nz // 2:, :] += 300.0
+    if not elastic:
+        return [vp]
+    return [vp, (vp / 1.73).astype(np.float32), np.full((nz, nx), 1900.0, np.float32)]
+
+
+def _models_3d(nz, ny, nx, elastic):
+    vp = np.full((nz, ny, nx), 2000.0, dtype=np.float32)
+    vp[nz // 2:, :, :] += 300.0
+    if not elastic:
+        return [vp]
+    return [vp, (vp / 1.73).astype(np.float32), np.full((nz, ny, nx), 1900.0, np.float32)]
+
+
+def _gradients(eqname, storage, disk_dir, *, transfer_interval=None, ring_buffers=None):
+    """Gradients w.r.t. every model of one propagation, with the boundary held
+    in ``storage``.  ``None`` knobs mean "whatever the resolver picks", which is
+    exactly what a user who only writes ``storage='disk'`` gets."""
+    import sweep.equations as E
+    from sweep.propagator.options import BoundaryOptions, CUDAOptions, MemoryOptions
+    from sweep.propagator.torch import PropTorch
+
+    cls = getattr(E, eqname)
+    elastic = eqname.startswith(("Elastic", "DASMu"))
+    nt, dt = 100, 0.0015
+    if eqname.endswith("3D"):
+        nz, ny, nx = 24, 20, 24
+        shape = (nz, ny, nx)
+        models = _models_3d(nz, ny, nx, elastic)
+        src = np.array([[nx // 2, ny // 2 + 3, nz // 4]], dtype=np.int32)
+        rx, ry = np.meshgrid(np.arange(2, nx - 2, 6), np.arange(2, ny - 2, 6))
+        rx, ry = rx.ravel(), ry.ravel()
+        rec = np.stack([rx, ry, np.full(rx.size, 2)], -1).astype(np.int32)[None]
+        dh = (10.0, 10.0, 10.0)
+    else:
+        nz, nx = 40, 48
+        shape = (nz, nx)
+        models = _models_2d(nz, nx, elastic)
+        src = np.array([[nx // 2, nz // 4]], dtype=np.int32)
+        rx = np.arange(2, nx - 2, 4, dtype=np.int32)
+        rec = np.stack([rx, np.full(rx.size, 2, dtype=np.int32)], -1)[None]
+        dh = (10.0, 10.0)
+    wav = torch.zeros(nt, device=DEV)
+    wav[5] = 1.0
+
+    kw = dict(storage=storage)
+    if storage != "gpu":
+        if transfer_interval is not None:
+            kw["transfer_interval"] = transfer_interval
+        if ring_buffers is not None:
+            kw["ring_buffers"] = ring_buffers
+    if storage == "disk":
+        # the saver creates its files INSIDE disk_dir but does not create the
+        # directory itself (tier B's build_cuda_options mkdirs it too)
+        disk_dir.mkdir(parents=True, exist_ok=True)
+        kw["disk_dir"] = str(disk_dir)
+    co = CUDAOptions(memory=MemoryOptions(strategy="boundary", boundary=BoundaryOptions(**kw)))
+    eq = cls(spatial_order=4, device=DEV, backend="torch")
+    # no pml_type: let each equation pick its own (acoustic -> cpmlr, the
+    # staggered family -> cpmls; forcing cpmlr on Elastic3D segfaults in the
+    # forward on every tree, which is a test bug, not the defect under test)
+    prop = PropTorch(eq, backend="torch", impl="c", cuda_options=co, shape=shape, dev=DEV,
+                     dh=dh, dt=dt, abcn=15, nt=nt, B=1, allow_growth=True)
+    ms = [torch.tensor(m, device=DEV, requires_grad=True) for m in models]
+    prop(wav, src.copy(), rec.copy(), models=ms).pow(2).mean().backward()
+    return [m.grad.detach().clone() for m in ms]
+
+
+def _assert_bit_exact(ref, got, label):
+    for i, (a, b) in enumerate(zip(ref, got)):
+        assert torch.isfinite(b).all(), f"{label}: grad{i} not finite"
+        if torch.equal(a, b):
+            continue
+        scale = a.abs().max().item() + 1e-30
+        rel = (a.double() - b.double()).abs().max().item() / scale
+        pytest.fail(f"{label}: grad{i} differs from gpu-direct, max|d|/scale={rel:.2e} "
+                    f"(same kernels, same numbers -- this is a staging slot/race bug, not noise)")
+
+
+# (equation, why it is here)
+_EQS = [
+    ("Acoustic",   "2-D, nvar=1: the ring>=2 early-issue overwrite (#1) alone"),
+    ("Acoustic3D", "3-D, nvar=1: #1 on the 3-D disk path"),
+    ("Elastic3D",  "3-D, nvar>1: #1 plus the non-blocking-stream race (#2)"),
+    ("DASMu3D",    "3-D, nvar>1, more fields: the other #2 survivor"),
+]
+
+
+@pytest.mark.parametrize("eqname", [e for e, _ in _EQS], ids=[e for e, _ in _EQS])
+def test_disk_default_knobs_matches_gpu(eqname, tmp_path):
+    """The config a user actually gets from ``storage='disk'`` alone: sync read,
+    transfer_interval 32, ring 3 (2-D) / 2 (3-D)."""
+    ref = _gradients(eqname, "gpu", tmp_path)
+    got = _gradients(eqname, "disk", tmp_path / "disk")
+    _assert_bit_exact(ref, got, f"{eqname} disk(defaults)")
+
+
+@pytest.mark.parametrize("eqname", [e for e, _ in _EQS], ids=[e for e, _ in _EQS])
+def test_disk_short_chunks_matches_gpu(eqname, tmp_path):
+    """Short chunks so the reverse walk crosses many chunk boundaries (25 with
+    nt=100), i.e. the early-issue / slot logic fires ~25 times per gradient."""
+    ref = _gradients(eqname, "gpu", tmp_path)
+    got = _gradients(eqname, "disk", tmp_path / "disk", transfer_interval=4, ring_buffers=2)
+    _assert_bit_exact(ref, got, f"{eqname} disk(ti=4,ring=2)")
+
+
+@pytest.mark.parametrize("eqname", ["Elastic3D", "DASMu3D"])
+def test_cpu_ring2_nvar_gt1_matches_gpu(eqname, tmp_path):
+    """Defect #3: host staging with ring_buffers>=2 on an nvar>1 equation -- the
+    two multi-field restore readers must read the slot the prefetch wrote,
+    not slot 0.  Latent on the default (cpu ring = 1), so ask for ring 2."""
+    ref = _gradients(eqname, "gpu", tmp_path)
+    got = _gradients(eqname, "cpu", tmp_path, transfer_interval=4, ring_buffers=2)
+    _assert_bit_exact(ref, got, f"{eqname} cpu(ti=4,ring=2)")


### PR DESCRIPTION
## What

Since PR #81 (persistent boundary-staging session + non-blocking copy stream), every `storage='disk'` boundary-saving gradient has been wrong, and cpu staging with `ring_buffers >= 2` is wrong on nvar>1 equations. No error is raised; the numbers are silently off.

Measured on the unfixed `dev` (max|disk−gpu| / scale, each case in its own process):

| case | Acoustic | Acoustic3D | Elastic3D | DASMu3D |
|---|---|---|---|---|
| disk, default knobs (sync read, interval 32, ring 3/2) | 0.18 | 0.22 | 1.22 | 0.77 |
| disk, interval 4 / ring 2 | 0.22 | 0.52 | 5.02 | 3.31 |
| cpu, interval 4 / ring 2 | – | – | 2.36 | 1.40 |

`test/test_boundary_storage_dtype_validation.py`'s three disk cases are red on `dev` today (0.13 / 0.13 / 0.67). The two docs notebooks that use disk staging run without any error on `dev`: `07_memory_strategies` prints disk ‖g‖₂ off by 1 % (L2 hides a 20 % pointwise error), and `19_fwi_boundary_dtype`'s disk FWI runs **diverge** (final RMSE 433–470 vs 304 stored, worse than the 357 starting model).

## Why

Three defects in `boundary/runtime.cuh`:

1. `prefetch_next_backward_chunk_if_needed` issued the next chunk's H2D early whenever `ring_buffers >= 2`, but `backward_slot_for_chunk` pins the synchronous disk path to slot 0 regardless of `ring_buffers` — and that path defaults to ring 3 (2-D) / 2 (3-D). The early copy overwrote the slot the current chunk was still restoring from. The predicate is now the slot assignment itself.
2. `copy_stream` became non-blocking in 76505cc, but the synchronous-disk enqueue in `prefetch_backward_chunk` never got the matching `cudaStreamWaitEvent(compute_ready_[slot])` write-after-read fence the host-staging branch has.
3. The two nvar>1 restore readers kept the slot-0 override for all non-async staging, so cpu staging with `ring_buffers >= 2` read slot 0 while the prefetch landed in slot k.

## Test

`test/test_boundary_disk_staging_slot.py` — 10 cases: disk (default knobs and short chunks) × {Acoustic, Acoustic3D, Elastic3D, DASMu3D} and cpu ring 2 × {Elastic3D, DASMu3D}, each required to be **bit-exact** against gpu-direct (same kernels, same numbers; only where the boundary bytes wait differs, so a tolerance would hide defect 1 as "chunking noise"). All 10 fail on `dev`, all pass with the fix; together with `test_boundary_storage_dtype_validation.py`: 15 passed.

Cherry-picked from `refactor/driver-template` (eeb42fd5), applied to `dev` without conflicts (`runtime.cuh` was byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
